### PR TITLE
Adding a lock mechanism on cache rebuild

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "phpdocumentor/reflection-docblock": "^4.3",
         "phpdocumentor/type-resolver": "^0.4",
         "psr/http-message": "^1",
-        "ecodev/graphql-upload": "^4.0"
+        "ecodev/graphql-upload": "^4.0",
+        "symfony/lock": "^3 || ^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.1",


### PR DESCRIPTION
When a cache expires, it needs to be recomputed. If the website is under heavy load, the recompute will be started by many processes at once and will slow down the server.
Adding a lock allows us to perform this recompute only once.