### PR TITLE
Refactoring duplicated code into an "ArgumentResolver"

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -19,6 +19,7 @@ use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\CustomTypesRegistry;
 use TheCodingMachine\GraphQLite\Types\ID;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
@@ -65,9 +66,9 @@ class FieldsBuilder
      */
     private $typeMapper;
     /**
-     * @var HydratorInterface
+     * @var ArgumentResolver
      */
-    private $hydrator;
+    private $argumentResolver;
     /**
      * @var AuthenticationServiceInterface
      */
@@ -90,13 +91,13 @@ class FieldsBuilder
     private $namingStrategy;
 
     public function __construct(AnnotationReader $annotationReader, RecursiveTypeMapperInterface $typeMapper,
-                                HydratorInterface $hydrator, AuthenticationServiceInterface $authenticationService,
+                                ArgumentResolver $argumentResolver, AuthenticationServiceInterface $authenticationService,
                                 AuthorizationServiceInterface $authorizationService, TypeResolver $typeResolver,
                                 CachedDocBlockFactory $cachedDocBlockFactory, NamingStrategyInterface $namingStrategy)
     {
         $this->annotationReader = $annotationReader;
         $this->typeMapper = $typeMapper;
-        $this->hydrator = $hydrator;
+        $this->argumentResolver = $argumentResolver;
         $this->authenticationService = $authenticationService;
         $this->authorizationService = $authorizationService;
         $this->typeResolver = $typeResolver;
@@ -266,13 +267,13 @@ class FieldsBuilder
                     if ($failWithValue === null && $type instanceof NonNull) {
                         $type = $type->getWrappedType();
                     }
-                    $queryList[] = new QueryField($name, $type, $args, $callable, null, $this->hydrator, $docBlockComment, $injectSource);
+                    $queryList[] = new QueryField($name, $type, $args, $callable, null, $this->argumentResolver, $docBlockComment, $injectSource);
                 } else {
                     $callable = [$controller, $methodName];
                     if ($sourceClassName !== null) {
-                        $queryList[] = new QueryField($name, $type, $args, null, $callable[1], $this->hydrator, $docBlockComment, $injectSource);
+                        $queryList[] = new QueryField($name, $type, $args, null, $callable[1], $this->argumentResolver, $docBlockComment, $injectSource);
                     } else {
-                        $queryList[] = new QueryField($name, $type, $args, $callable, null, $this->hydrator, $docBlockComment, $injectSource);
+                        $queryList[] = new QueryField($name, $type, $args, $callable, null, $this->argumentResolver, $docBlockComment, $injectSource);
                     }
                 }
             }
@@ -392,7 +393,7 @@ class FieldsBuilder
             }
 
             if (!$unauthorized) {
-                $queryList[] = new QueryField($sourceField->getName(), $type, $args, null, $methodName, $this->hydrator, $docBlockComment, false);
+                $queryList[] = new QueryField($sourceField->getName(), $type, $args, null, $methodName, $this->argumentResolver, $docBlockComment, false);
             } else {
                 $failWithValue = $sourceField->getFailWith();
                 $callable = function() use ($failWithValue) {
@@ -401,7 +402,7 @@ class FieldsBuilder
                 if ($failWithValue === null && $type instanceof NonNull) {
                     $type = $type->getWrappedType();
                 }
-                $queryList[] = new QueryField($sourceField->getName(), $type, $args, $callable, null, $this->hydrator, $docBlockComment, false);
+                $queryList[] = new QueryField($sourceField->getName(), $type, $args, $callable, null, $this->argumentResolver, $docBlockComment, false);
             }
 
         }

--- a/src/FieldsBuilderFactory.php
+++ b/src/FieldsBuilderFactory.php
@@ -9,6 +9,7 @@ use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 
 class FieldsBuilderFactory
@@ -65,7 +66,7 @@ class FieldsBuilderFactory
         return new FieldsBuilder(
             $this->annotationReader,
             $typeMapper,
-            $this->hydrator,
+            new ArgumentResolver($this->hydrator),
             $this->authenticationService,
             $this->authorizationService,
             $this->typeResolver,

--- a/src/Hydrators/HydratorInterface.php
+++ b/src/Hydrators/HydratorInterface.php
@@ -11,7 +11,7 @@ use GraphQL\Type\Definition\InputObjectType;
 interface HydratorInterface
 {
     /**
-     * Whether this hydrate can hydrate the passed data.
+     * Whether this hydrator can hydrate the passed data.
      *
      * @param mixed[] $data
      * @param InputObjectType $type

--- a/src/InputTypeGenerator.php
+++ b/src/InputTypeGenerator.php
@@ -15,6 +15,7 @@ use ReflectionType;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\ResolvableInputObjectType;
 
 /**
@@ -31,9 +32,9 @@ class InputTypeGenerator
      */
     private $cache = [];
     /**
-     * @var HydratorInterface
+     * @var ArgumentResolver
      */
-    private $hydrator;
+    private $argumentResolver;
     /**
      * @var InputTypeUtils
      */
@@ -41,11 +42,11 @@ class InputTypeGenerator
 
     public function __construct(InputTypeUtils $inputTypeUtils,
                                 FieldsBuilderFactory $fieldsBuilderFactory,
-                                HydratorInterface $hydrator)
+                                ArgumentResolver $argumentResolver)
     {
         $this->inputTypeUtils = $inputTypeUtils;
         $this->fieldsBuilderFactory = $fieldsBuilderFactory;
-        $this->hydrator = $hydrator;
+        $this->argumentResolver = $argumentResolver;
     }
 
     /**
@@ -68,7 +69,7 @@ class InputTypeGenerator
 
         if (!isset($this->cache[$inputName])) {
             // TODO: add comment argument.
-            $this->cache[$inputName] = new ResolvableInputObjectType($inputName, $this->fieldsBuilderFactory, $recursiveTypeMapper, $object, $methodName, $this->hydrator, null);
+            $this->cache[$inputName] = new ResolvableInputObjectType($inputName, $this->fieldsBuilderFactory, $recursiveTypeMapper, $object, $methodName, $this->argumentResolver, null);
         }
 
         return $this->cache[$inputName];

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\IDType;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\LeafType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\OutputType;
@@ -16,11 +17,14 @@ use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
 use function is_array;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\DateTimeType;
 use TheCodingMachine\GraphQLite\Types\ID;
 
 /**
  * A GraphQL field that maps to a PHP method automatically.
+ *
+ * @internal
  */
 class QueryField extends FieldDefinition
 {
@@ -31,12 +35,12 @@ class QueryField extends FieldDefinition
      * @param array[] $arguments Indexed by argument name, value: ['type'=>InputType, 'defaultValue'=>val].
      * @param callable|null $resolve The method to execute
      * @param string|null $targetMethodOnSource The name of the method to execute on the source object. Mutually exclusive with $resolve parameter.
-     * @param HydratorInterface $hydrator
+     * @param ArgumentResolver $argumentResolver
      * @param null|string $comment
      * @param bool $injectSource Whether to inject the source object (for Fields), or null for Query and Mutations
      * @param array $additionalConfig
      */
-    public function __construct(string $name, OutputType $type, array $arguments, ?callable $resolve, ?string $targetMethodOnSource, HydratorInterface $hydrator, ?string $comment, bool $injectSource, array $additionalConfig = [])
+    public function __construct(string $name, OutputType $type, array $arguments, ?callable $resolve, ?string $targetMethodOnSource, ArgumentResolver $argumentResolver, ?string $comment, bool $injectSource, array $additionalConfig = [])
     {
         $config = [
             'name' => $name,
@@ -47,7 +51,7 @@ class QueryField extends FieldDefinition
             $config['description'] = $comment;
         }
 
-        $config['resolve'] = function ($source, array $args) use ($resolve, $targetMethodOnSource, $arguments, $injectSource, $hydrator) {
+        $config['resolve'] = function ($source, array $args) use ($resolve, $targetMethodOnSource, $arguments, $injectSource, $argumentResolver) {
             $toPassArgs = [];
             if ($injectSource) {
                 $toPassArgs[] = $source;
@@ -55,7 +59,7 @@ class QueryField extends FieldDefinition
             foreach ($arguments as $name => $arr) {
                 $type = $arr['type'];
                 if (isset($args[$name])) {
-                    $val = $this->castVal($args[$name], $type, $hydrator);
+                    $val = $argumentResolver->resolve($args[$name], $type);
                 } elseif (array_key_exists('defaultValue', $arr)) {
                     $val = $arr['defaultValue'];
                 } else {
@@ -77,42 +81,5 @@ class QueryField extends FieldDefinition
 
         $config += $additionalConfig;
         parent::__construct($config);
-    }
-
-    private function stripNonNullType(Type $type): Type
-    {
-        if ($type instanceof NonNull) {
-            return $this->stripNonNullType($type->getWrappedType());
-        }
-        return $type;
-    }
-
-    /**
-     * Casts a value received from GraphQL into an argument passed to a method.
-     *
-     * @param mixed $val
-     * @param InputType $type
-     * @return mixed
-     */
-    private function castVal($val, InputType $type, HydratorInterface $hydrator)
-    {
-        $type = $this->stripNonNullType($type);
-        if ($type instanceof ListOfType) {
-            if (!is_array($val)) {
-                throw new InvalidArgumentException('Expected GraphQL List but value passed is not an array.');
-            }
-            return array_map(function($item) use ($type, $hydrator) {
-                return $this->castVal($item, $type->getWrappedType(), $hydrator);
-            }, $val);
-        } elseif ($type instanceof DateTimeType) {
-            return new \DateTimeImmutable($val);
-        } elseif ($type instanceof IDType) {
-            return new ID($val);
-        } elseif ($type instanceof InputObjectType) {
-            return $hydrator->hydrate($val, $type);
-        } elseif (!$type instanceof ScalarType) {
-            throw new \RuntimeException('Unexpected type: '.get_class($type));
-        }
-        return $val;
     }
 }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -30,6 +30,7 @@ use TheCodingMachine\GraphQLite\Security\FailAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\FailAuthorizationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 
 /**
@@ -183,6 +184,7 @@ class SchemaFactory
     {
         $annotationReader = new AnnotationReader($this->getDoctrineAnnotationReader(), AnnotationReader::LAX_MODE);
         $hydrator = $this->hydrator ?: new FactoryHydrator();
+        $argumentResolver = new ArgumentResolver($hydrator);
         $authenticationService = $this->authenticationService ?: new FailAuthenticationService();
         $authorizationService = $this->authorizationService ?: new FailAuthorizationService();
         $typeResolver = new TypeResolver();
@@ -202,7 +204,7 @@ class SchemaFactory
 
         $typeGenerator = new TypeGenerator($annotationReader, $fieldsBuilderFactory, $namingStrategy, $typeRegistry, $this->container);
         $inputTypeUtils = new InputTypeUtils($annotationReader, $namingStrategy);
-        $inputTypeGenerator = new InputTypeGenerator($inputTypeUtils, $fieldsBuilderFactory, $hydrator);
+        $inputTypeGenerator = new InputTypeGenerator($inputTypeUtils, $fieldsBuilderFactory, $argumentResolver);
 
         $typeMappers = [];
 

--- a/src/Types/ArgumentResolver.php
+++ b/src/Types/ArgumentResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+use function array_map;
+use function get_class;
+use GraphQL\Type\Definition\IDType;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\LeafType;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\Type;
+use InvalidArgumentException;
+use function is_array;
+use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
+
+/**
+ * Resolves arguments based on input value and InputType
+ */
+class ArgumentResolver
+{
+    /**
+     * @var HydratorInterface
+     */
+    private $hydrator;
+
+    public function __construct(HydratorInterface $hydrator)
+    {
+        $this->hydrator = $hydrator;
+    }
+
+    /**
+     * Casts a value received from GraphQL into an argument passed to a method.
+     *
+     * @param mixed $val
+     * @param InputType $type
+     * @return mixed
+     */
+    public function resolve($val, InputType $type)
+    {
+        $type = $this->stripNonNullType($type);
+        if ($type instanceof ListOfType) {
+            if (!is_array($val)) {
+                throw new InvalidArgumentException('Expected GraphQL List but value passed is not an array.');
+            }
+            return array_map(function($item) use ($type) {
+                return $this->resolve($item, $type->getWrappedType());
+            }, $val);
+        } elseif ($type instanceof IDType) {
+            return new ID($val);
+        } elseif ($type instanceof LeafType) {
+            return $type->parseValue($val);
+        } elseif ($type instanceof InputObjectType) {
+            return $this->hydrator->hydrate($val, $type);
+        } else {
+            throw new \RuntimeException('Unexpected type: '.get_class($type));
+        }
+    }
+
+    private function stripNonNullType(Type $type): Type
+    {
+        if ($type instanceof NonNull) {
+            return $this->stripNonNullType($type->getWrappedType());
+        }
+        return $type;
+    }
+}

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -6,10 +6,10 @@ namespace TheCodingMachine\GraphQLite\Types;
 
 use DateTime;
 use DateTimeImmutable;
+use Exception;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\StringValueNode;
-use GraphQL\Language\AST\ValueNode;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\Utils;
 
@@ -75,6 +75,7 @@ class DateTimeType extends ScalarType
             return $valueNode->value;
         }
 
-        return null;
+        // Intentionally without message, as all information already in wrapped Exception
+        throw new Exception();
     }
 }

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -53,7 +53,10 @@ class DateTimeType extends ScalarType
      */
     public function parseValue($value): ?DateTimeImmutable
     {
-        return DateTimeImmutable::createFromFormat(DateTime::ATOM, $value) ?: null;
+        if ($value === null) {
+            return null;
+        }
+        return new DateTimeImmutable($value);
     }
 
     /**

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -33,6 +33,7 @@ use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableInputObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
@@ -42,9 +43,9 @@ abstract class AbstractQueryProviderTest extends TestCase
     private $testObjectType;
     private $testObjectType2;
     private $inputTestObjectType;
-    private $inputTestObjectType2;
     private $typeMapper;
     private $hydrator;
+    private $argumentResolver;
     private $registry;
     private $typeGenerator;
     private $inputTypeGenerator;
@@ -229,6 +230,14 @@ abstract class AbstractQueryProviderTest extends TestCase
         return $this->hydrator;
     }
 
+    protected function getArgumentResolver(): ArgumentResolver
+    {
+        if ($this->argumentResolver === null) {
+            $this->argumentResolver = new ArgumentResolver($this->getHydrator());
+        }
+        return $this->argumentResolver;
+    }
+
     protected function getRegistry()
     {
         if ($this->registry === null) {
@@ -259,7 +268,7 @@ abstract class AbstractQueryProviderTest extends TestCase
         return new FieldsBuilder(
             $this->getAnnotationReader(),
             $this->getTypeMapper(),
-            $this->getHydrator(),
+            $this->getArgumentResolver(),
             new VoidAuthenticationService(),
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
@@ -279,7 +288,7 @@ abstract class AbstractQueryProviderTest extends TestCase
     protected function getInputTypeGenerator(): InputTypeGenerator
     {
         if ($this->inputTypeGenerator === null) {
-            $this->inputTypeGenerator = new InputTypeGenerator($this->getInputTypeUtils(), $this->getControllerQueryProviderFactory(), $this->getHydrator());
+            $this->inputTypeGenerator = new InputTypeGenerator($this->getInputTypeUtils(), $this->getControllerQueryProviderFactory(), $this->getArgumentResolver());
         }
         return $this->inputTypeGenerator;
     }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -203,7 +203,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $queryProvider = new FieldsBuilder(
             $this->getAnnotationReader(),
             $this->getTypeMapper(),
-            $this->getHydrator(),
+            $this->getArgumentResolver(),
             new class implements AuthenticationServiceInterface {
                 public function isLogged(): bool
                 {
@@ -228,7 +228,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $queryProvider = new FieldsBuilder(
             $this->getAnnotationReader(),
             $this->getTypeMapper(),
-            $this->getHydrator(),
+            $this->getArgumentResolver(),
             new VoidAuthenticationService(),
             new class implements AuthorizationServiceInterface {
                 public function isAllowed(string $right): bool
@@ -290,7 +290,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $queryProvider = new FieldsBuilder(
             $this->getAnnotationReader(),
             $this->getTypeMapper(),
-            $this->getHydrator(),
+            $this->getArgumentResolver(),
             new VoidAuthenticationService(),
             new VoidAuthorizationService(),
             $this->getTypeResolver(),

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -46,6 +46,7 @@ use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQLite\TypeGenerator;
 use TheCodingMachine\GraphQLite\TypeRegistry;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use function var_dump;
 use function var_export;
@@ -148,7 +149,7 @@ class EndToEndTest extends TestCase
                 return new InputTypeGenerator(
                     $container->get(InputTypeUtils::class),
                     $container->get(FieldsBuilderFactory::class),
-                    $container->get(HydratorInterface::class)
+                    $container->get(ArgumentResolver::class)
                 );
             },
             InputTypeUtils::class => function(ContainerInterface $container) {
@@ -162,6 +163,9 @@ class EndToEndTest extends TestCase
             },
             HydratorInterface::class => function(ContainerInterface $container) {
                 return new FactoryHydrator();
+            },
+            ArgumentResolver::class => function(ContainerInterface $container) {
+                return new ArgumentResolver($container->get(HydratorInterface::class));
             },
             NamingStrategyInterface::class => function() {
                 return new NamingStrategy();

--- a/tests/Types/DateTimeTypeTest.php
+++ b/tests/Types/DateTimeTypeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+use DateTimeImmutable;
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\StringValueNode;
+use PHPUnit\Framework\TestCase;
+
+class DateTimeTypeTest extends TestCase
+{
+
+    public function testSerialize(): void
+    {
+        $dateTimeType = DateTimeType::getInstance();
+
+        $this->assertSame('2019-05-05T10:10:10+00:00', $dateTimeType->serialize(new DateTimeImmutable('2019-05-05T10:10:10+00:00')));
+
+        $this->expectException(InvariantViolation::class);
+        $dateTimeType->serialize('foo');
+    }
+
+    public function testParseLiteral(): void
+    {
+        $dateTimeType = DateTimeType::getInstance();
+
+        $this->assertSame('2019-05-05T10:10:10+00:00', $dateTimeType->parseLiteral(new StringValueNode(['value' => '2019-05-05T10:10:10+00:00'])));
+
+        $this->expectException(Exception::class);
+        $dateTimeType->parseLiteral(null);
+
+    }
+
+    public function testParseValue(): void
+    {
+        $dateTimeType = DateTimeType::getInstance();
+
+
+        $this->assertNull($dateTimeType->parseValue(null));
+    }
+}

--- a/tests/Types/ResolvableInputObjectTypeTest.php
+++ b/tests/Types/ResolvableInputObjectTypeTest.php
@@ -19,7 +19,7 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
             $this->getTypeMapper(),
             new TestFactory(),
             'myFactory',
-            $this->getHydrator(),
+            $this->getArgumentResolver(),
             'my comment');
 
         $this->assertSame('InputObject', $inputType->name);
@@ -48,7 +48,7 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
             $this->getTypeMapper(),
             new TestFactory(),
             'myListFactory',
-            $this->getHydrator(),
+            $this->getArgumentResolver(),
             null);
 
         $obj = $inputType->resolve(['date' => '2018-12-25', 'stringList' =>


### PR DESCRIPTION
The ArgumentResolver role is similar to the HydratorInterface except it can actually hydrate any type (not only input types) but also lists and scalars.

The code was previously duplicated between input type objects and queryfield args.