### PR TITLE
Optimization: we are not recreating fields in child class that are part of parent class

### DIFF
--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -148,7 +148,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
      * @param string $className
      * @return string|null
      */
-    private function findClosestMatchingParent(string $className): ?string
+    public function findClosestMatchingParent(string $className): ?string
     {
         do {
             if ($this->typeMapper->canMapClassToType($className)) {

--- a/src/Mappers/RecursiveTypeMapperInterface.php
+++ b/src/Mappers/RecursiveTypeMapperInterface.php
@@ -94,4 +94,12 @@ interface RecursiveTypeMapperInterface
      * @return Type&(InputType|OutputType)
      */
     public function mapNameToType(string $typeName): Type;
+
+    /**
+     * Returns the closest parent that can be mapped, or null if nothing can be matched.
+     *
+     * @param string $className
+     * @return string|null
+     */
+    public function findClosestMatchingParent(string $className): ?string;
 }

--- a/src/Types/TypeAnnotatedObjectType.php
+++ b/src/Types/TypeAnnotatedObjectType.php
@@ -43,6 +43,7 @@ class TypeAnnotatedObjectType extends MutableObjectType
                     $fields = $fieldProvider->getSelfFields($className);
                 }
                 if ($parentType !== null) {
+                    // Note: with +=, the keys already present are not overloaded
                     $fields += $parentType->getFields();
                 }
                 return $fields;

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -114,7 +114,7 @@ class Contact
     }
 
     /**
-     * Here, we are testing overriding the field in the extend class.
+     * This getter will be overridden in the extend class.
      *
      * @Field()
      * @return string

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -6,6 +6,7 @@ namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
 
 use DateTimeInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 
 /**
@@ -33,6 +34,10 @@ class Contact
      * @var DateTimeInterface
      */
     private $birthDate;
+    /**
+     * @var string
+     */
+    private $company;
 
     public function __construct(string $name)
     {
@@ -106,5 +111,24 @@ class Contact
     public function setBirthDate(DateTimeInterface $birthDate): void
     {
         $this->birthDate = $birthDate;
+    }
+
+    /**
+     * Here, we are testing overriding the field in the extend class.
+     *
+     * @Field()
+     * @return string
+     */
+    public function getCompany(): string
+    {
+        return $this->company;
+    }
+
+    /**
+     * @param string $company
+     */
+    public function setCompany(string $company): void
+    {
+        $this->company = $company;
     }
 }

--- a/tests/Fixtures/Integration/Types/ExtendedContactType.php
+++ b/tests/Fixtures/Integration/Types/ExtendedContactType.php
@@ -22,4 +22,15 @@ class ExtendedContactType
     {
         return strtoupper($contact->getName());
     }
+
+    /**
+     * Here, we are testing overriding the field in the extend class.
+     *
+     * @Field()
+     * @return string
+     */
+    public function company(Contact $contact): string
+    {
+        return $contact->getName().' Ltd';
+    }
 }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -195,6 +195,7 @@ class EndToEndTest extends TestCase
         query {
             contacts {
                 name
+                company
                 uppercaseName
                 ... on User {
                     email
@@ -212,10 +213,12 @@ class EndToEndTest extends TestCase
             'contacts' => [
                 [
                     'name' => 'Joe',
+                    'company' => 'Joe Ltd',
                     'uppercaseName' => 'JOE'
                 ],
                 [
                     'name' => 'Bill',
+                    'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
                     'email' => 'bill@example.com'
                 ]
@@ -233,10 +236,12 @@ class EndToEndTest extends TestCase
             'contacts' => [
                 [
                     'name' => 'Joe',
+                    'company' => 'Joe Ltd',
                     'uppercaseName' => 'JOE'
                 ],
                 [
                     'name' => 'Bill',
+                    'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
                     'email' => 'bill@example.com'
                 ]


### PR DESCRIPTION
The FieldsBuilder is not stopping analyzing annotations if the annotations are part of a parent type.