### PR TITLE
Working on fields order in inheritance

### DIFF
--- a/src/Types/TypeAnnotatedObjectType.php
+++ b/src/Types/TypeAnnotatedObjectType.php
@@ -43,8 +43,11 @@ class TypeAnnotatedObjectType extends MutableObjectType
                     $fields = $fieldProvider->getSelfFields($className);
                 }
                 if ($parentType !== null) {
-                    // Note: with +=, the keys already present are not overloaded
-                    $fields += $parentType->getFields();
+                    $finalFields = $parentType->getFields();
+                    foreach ($fields as $name => $field) {
+                        $finalFields[$name] = $field;
+                    }
+                    return $finalFields;
                 }
                 return $fields;
             },


### PR DESCRIPTION
When using some UIs like GraphiQL, field order can be relevant for the end user.
This PR changes field order so that fields from the most parent class are displayed before fields from child classes.