### PR TITLE
Adding support for complex GraphQL types in "outputType" parameter

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -524,11 +524,6 @@ class FieldsBuilder
         return $args;
     }
 
-    /**
-     * @param Type $type
-     * @param Type|null $docBlockType
-     * @return GraphQLType
-     */
     private function mapType(Type $type, ?Type $docBlockType, bool $isNullable, bool $mapToInputType): GraphQLType
     {
         $graphQlType = null;

--- a/src/Types/TypeResolver.php
+++ b/src/Types/TypeResolver.php
@@ -3,8 +3,13 @@
 
 namespace TheCodingMachine\GraphQLite\Types;
 
+use GraphQL\Error\Error;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Definition\WrappingType;
 use GraphQL\Type\Schema;
+use GraphQL\Utils\AST;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
@@ -36,12 +41,27 @@ class TypeResolver
         if ($this->schema === null) {
             throw new RuntimeException('You must register a schema first before resolving types.');
         }
-        
-        $type = $this->schema->getType($typeName);
+
+        try {
+            $parsedOutputType = Parser::parseType($typeName);
+            $type = AST::typeFromAST($this->schema, $parsedOutputType);
+        } catch (Error $e) {
+            throw CannotMapTypeException::createForParseError($e);
+        }
+
         if ($type === null) {
             throw CannotMapTypeException::createForName($typeName);
         }
 
+        return $type;
+    }
+
+    public function mapNameToOutputType(string $typeName): OutputType
+    {
+        $type = $this->mapNameToType($typeName);
+        if (!$type instanceof OutputType || ($type instanceof WrappingType && !$type->getWrappedType() instanceof OutputType)) {
+            throw CannotMapTypeException::mustBeOutputType($typeName);
+        }
         return $type;
     }
 }

--- a/tests/AggregateControllerQueryProviderTest.php
+++ b/tests/AggregateControllerQueryProviderTest.php
@@ -43,7 +43,7 @@ class AggregateControllerQueryProviderTest extends AbstractQueryProviderTest
         $aggregateQueryProvider = new AggregateControllerQueryProvider([ 'controller' ], $this->getControllerQueryProviderFactory(), $this->getTypeMapper(), $container);
 
         $queries = $aggregateQueryProvider->getQueries();
-        $this->assertCount(6, $queries);
+        $this->assertCount(7, $queries);
 
         $mutations = $aggregateQueryProvider->getMutations();
         $this->assertCount(1, $mutations);

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -55,7 +55,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queries = $queryProvider->getQueries($controller);
 
-        $this->assertCount(6, $queries);
+        $this->assertCount(7, $queries);
         $usersQuery = $queries[0];
         $this->assertSame('test', $usersQuery->name);
 
@@ -146,10 +146,27 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queries = $queryProvider->getQueries($controller);
 
-        $this->assertCount(6, $queries);
+        $this->assertCount(7, $queries);
         $fixedQuery = $queries[1];
 
         $this->assertInstanceOf(IDType::class, $fixedQuery->getType());
+    }
+
+    public function testQueryProviderWithComplexFixedReturnType()
+    {
+        $controller = new TestController();
+
+        $queryProvider = $this->buildFieldsBuilder();
+
+        $queries = $queryProvider->getQueries($controller);
+
+        $this->assertCount(7, $queries);
+        $fixedQuery = $queries[6];
+
+        $this->assertInstanceOf(NonNull::class, $fixedQuery->getType());
+        $this->assertInstanceOf(ListOfType::class, $fixedQuery->getType()->getWrappedType());
+        $this->assertInstanceOf(NonNull::class, $fixedQuery->getType()->getWrappedType()->getWrappedType());
+        $this->assertInstanceOf(IDType::class, $fixedQuery->getType()->getWrappedType()->getWrappedType()->getWrappedType());
     }
 
     public function testNameFromAnnotation()
@@ -312,7 +329,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queries = $queryProvider->getQueries($controller);
 
-        $this->assertCount(6, $queries);
+        $this->assertCount(7, $queries);
         $iterableQuery = $queries[3];
 
         $this->assertInstanceOf(NonNull::class, $iterableQuery->getType());
@@ -328,7 +345,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queries = $queryProvider->getQueries(new TestController());
 
-        $this->assertCount(6, $queries);
+        $this->assertCount(7, $queries);
         $iterableQuery = $queries[4];
 
         $this->assertInstanceOf(NonNull::class, $iterableQuery->getType());
@@ -353,7 +370,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queries = $queryProvider->getQueries($controller);
 
-        $this->assertCount(6, $queries);
+        $this->assertCount(7, $queries);
         $unionQuery = $queries[5];
 
         $this->assertInstanceOf(NonNull::class, $unionQuery->getType());

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -24,8 +24,11 @@ use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithInvalidInputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithInvalidReturnType;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithIterableParam;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithIterableReturnType;
+use TheCodingMachine\GraphQLite\Fixtures\TestFieldBadOutputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Fixtures\TestSelfType;
+use TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType;
+use TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType2;
 use TheCodingMachine\GraphQLite\Fixtures\TestType;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeId;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeMissingAnnotation;
@@ -36,6 +39,7 @@ use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithSourceFieldInterface;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
@@ -487,5 +491,29 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertNull($result);
 
         $this->assertInstanceOf(StringType::class, $fields['test']->getType());
+    }
+
+    public function testSourceFieldBadOutputTypeException()
+    {
+        $queryProvider = $this->buildFieldsBuilder();
+        $this->expectException(CannotMapTypeExceptionInterface::class);
+        $this->expectExceptionMessage('For @SourceField "test" declared in "TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType", cannot find GraphQL type "[NotExists]". Check your TypeMapper configuration.');
+        $queryProvider->getFields(new TestSourceFieldBadOutputType(), true);
+    }
+
+    public function testSourceFieldBadOutputType2Exception()
+    {
+        $queryProvider = $this->buildFieldsBuilder();
+        $this->expectException(CannotMapTypeExceptionInterface::class);
+        $this->expectExceptionMessage('For @SourceField "test" declared in "TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType2", Syntax Error: Expected ], found <EOF>');
+        $queryProvider->getFields(new TestSourceFieldBadOutputType2(), true);
+    }
+
+    public function testBadOutputTypeException()
+    {
+        $queryProvider = $this->buildFieldsBuilder();
+        $this->expectException(CannotMapTypeExceptionInterface::class);
+        $this->expectExceptionMessage('For return type of TheCodingMachine\GraphQLite\Fixtures\TestFieldBadOutputType::test, cannot find GraphQL type "[NotExists]". Check your TypeMapper configuration.');
+        $queryProvider->getFields(new TestFieldBadOutputType(), true);
     }
 }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -107,4 +107,12 @@ class TestController
     {
         return new TestObject2('foo');
     }
+
+    /**
+     * @Query(outputType="[ID!]!")
+     */
+    public function testFixComplexReturnType(): array
+    {
+        return ['42'];
+    }
 }

--- a/tests/Fixtures/TestFieldBadOutputType.php
+++ b/tests/Fixtures/TestFieldBadOutputType.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ */
+class TestFieldBadOutputType
+{
+    /**
+     * @Field(outputType="[NotExists]")
+     */
+    public function test(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/TestSourceFieldBadOutputType.php
+++ b/tests/Fixtures/TestSourceFieldBadOutputType.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ * @SourceField(name="test", outputType="[NotExists]")
+ */
+class TestSourceFieldBadOutputType
+{
+}

--- a/tests/Fixtures/TestSourceFieldBadOutputType2.php
+++ b/tests/Fixtures/TestSourceFieldBadOutputType2.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ * @SourceField(name="test", outputType="[BadFormat")
+ */
+class TestSourceFieldBadOutputType2
+{
+}

--- a/tests/GlobControllerQueryProviderTest.php
+++ b/tests/GlobControllerQueryProviderTest.php
@@ -37,7 +37,7 @@ class GlobControllerQueryProviderTest extends AbstractQueryProviderTest
         $globControllerQueryProvider = new GlobControllerQueryProvider('TheCodingMachine\\GraphQLite\\Fixtures', $this->getControllerQueryProviderFactory(), $this->getTypeMapper(), $container, $this->getLockFactory(), new NullCache(), null, false);
 
         $queries = $globControllerQueryProvider->getQueries();
-        $this->assertCount(6, $queries);
+        $this->assertCount(7, $queries);
 
         $mutations = $globControllerQueryProvider->getMutations();
         $this->assertCount(1, $mutations);


### PR DESCRIPTION
Currently, the "outputType" parameter of the Field/Query/Mutation annotations only supports Scalar or ObjectType.
We should instead support all possible types in the GraphQL syntax.

For instance:

```
@Field(outputType="[User!]!")
```

This first commit contains a failing test showcasing the issue.