### PR TITLE
Adding a "root" type mapper

### DIFF
--- a/src/Mappers/Root/BaseTypeMapper.php
+++ b/src/Mappers/Root/BaseTypeMapper.php
@@ -1,0 +1,111 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use function ltrim;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Boolean;
+use phpDocumentor\Reflection\Types\Float_;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\String_;
+use Psr\Http\Message\UploadedFileInterface;
+use ReflectionMethod;
+use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Types\CustomTypesRegistry;
+use TheCodingMachine\GraphQLite\Types\DateTimeType;
+use TheCodingMachine\GraphQLite\Types\ID;
+
+/**
+ * Casts base GraphQL types (scalar, lists, DateTime, ID, UploadedFileInterface.
+ * Does not deal with nullable types => assumes nullable types have been handled BEFORE.
+ * Does not deal with union types => assumes union types have been handled BEFORE.
+ */
+class BaseTypeMapper implements RootTypeMapperInterface
+{
+    /**
+     * @var RecursiveTypeMapperInterface
+     */
+    private $recursiveTypeMapper;
+
+    public function __construct(RecursiveTypeMapperInterface $recursiveTypeMapper)
+    {
+        $this->recursiveTypeMapper = $recursiveTypeMapper;
+    }
+
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType
+    {
+        $mappedType = $this->mapBaseType($type);
+        if ($mappedType !== null) {
+            return $mappedType;
+        }
+        if ($type instanceof Array_) {
+            return GraphQLType::listOf(GraphQLType::nonNull($this->toGraphQLOutputType($type->getValueType(), $subType, $refMethod, $docBlockObj)));
+        }
+        if ($type instanceof Object_) {
+            $className = ltrim($type->getFqsen(), '\\');
+            return $this->recursiveTypeMapper->mapClassToInterfaceOrType($className, $subType);
+        }
+        return null;
+    }
+
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType
+    {
+        $mappedType = $this->mapBaseType($type);
+        if ($mappedType !== null) {
+            return $mappedType;
+        }
+        if ($type instanceof Array_) {
+            return GraphQLType::listOf(GraphQLType::nonNull($this->toGraphQLInputType($type->getValueType(), $subType, $argumentName, $refMethod, $docBlockObj)));
+        }
+        if ($type instanceof Object_) {
+            $className = ltrim($type->getFqsen(), '\\');
+            return $this->recursiveTypeMapper->mapClassToInputType($className);
+        }
+        return null;
+    }
+
+    /**
+     * Casts a Type to a GraphQL type.
+     * Does not deal with nullable.
+     *
+     * @param Type $type
+     * @return \GraphQL\Type\Definition\BooleanType|\GraphQL\Type\Definition\FloatType|\GraphQL\Type\Definition\IDType|\GraphQL\Type\Definition\IntType|\GraphQL\Type\Definition\StringType|\GraphQL\Upload\UploadType|DateTimeType|null
+     */
+    private function mapBaseType(Type $type)
+    {
+        if ($type instanceof Integer) {
+            return GraphQLType::int();
+        } elseif ($type instanceof String_) {
+            return GraphQLType::string();
+        } elseif ($type instanceof Boolean) {
+            return GraphQLType::boolean();
+        } elseif ($type instanceof Float_) {
+            return GraphQLType::float();
+        } elseif ($type instanceof Object_) {
+            $fqcn = (string) $type->getFqsen();
+            switch ($fqcn) {
+                case '\\DateTimeImmutable':
+                case '\\DateTimeInterface':
+                    return DateTimeType::getInstance();
+                case '\\'.UploadedFileInterface::class:
+                    return CustomTypesRegistry::getUploadType();
+                case '\\DateTime':
+                    throw new GraphQLException('Type-hinting a parameter against DateTime is not allowed. Please use the DateTimeImmutable type instead.');
+                case '\\'.ID::class:
+                    return GraphQLType::id();
+                default:
+                    return null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Mappers/Root/CompositeRootTypeMapper.php
+++ b/src/Mappers/Root/CompositeRootTypeMapper.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use function is_array;
+use function iterator_to_array;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use ReflectionMethod;
+
+class CompositeRootTypeMapper implements RootTypeMapperInterface
+{
+    /**
+     * @var RootTypeMapperInterface[]
+     */
+    private $rootTypeMappers;
+
+    /**
+     * @param RootTypeMapperInterface[] $rootTypeMappers
+     */
+    public function __construct(iterable $rootTypeMappers)
+    {
+        $this->rootTypeMappers = is_array($rootTypeMappers) ? $rootTypeMappers : iterator_to_array($rootTypeMappers);
+    }
+
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType
+    {
+        foreach ($this->rootTypeMappers as $rootTypeMapper) {
+            $mappedType = $rootTypeMapper->toGraphQLOutputType($type, $subType, $refMethod, $docBlockObj);
+            if ($mappedType !== null) {
+                return $mappedType;
+            }
+        }
+        return null;
+    }
+
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType
+    {
+        foreach ($this->rootTypeMappers as $rootTypeMapper) {
+            $mappedType = $rootTypeMapper->toGraphQLInputType($type, $subType, $argumentName, $refMethod, $docBlockObj);
+            if ($mappedType !== null) {
+                return $mappedType;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Mappers/Root/RootTypeMapperInterface.php
+++ b/src/Mappers/Root/RootTypeMapperInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use ReflectionMethod;
+
+
+/**
+ * Maps a method return type or argument to a GraphQL Type.
+ *
+ * Unlike TypeMapperInterface that maps a class to a GraphQL object, RootTypeMapperInterface has access to
+ * the "context" (i.e. the function signature, the annotations...). Also, it can map to any types (not only objects,
+ * but also scalar types...)
+ *
+ * We call it "RootTypeMapper" because it is the first type mapper to be called. It will call the recursive type
+ * mappers which will in turn, call the "type mappers".
+ */
+interface RootTypeMapperInterface
+{
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType;
+
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType;
+}

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -27,6 +27,8 @@ use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
@@ -273,7 +275,10 @@ abstract class AbstractQueryProviderTest extends TestCase
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new CompositeRootTypeMapper([
+                new BaseTypeMapper($this->getTypeMapper())
+            ])
         );
     }
 

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -40,6 +40,8 @@ use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
@@ -234,7 +236,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new BaseTypeMapper($this->getTypeMapper())
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -259,7 +262,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             },
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new BaseTypeMapper($this->getTypeMapper())
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -316,7 +320,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new BaseTypeMapper($this->getTypeMapper())
         );
         $fields = $queryProvider->getFields(new TestTypeWithSourceFieldInterface(), true);
         $this->assertCount(1, $fields);

--- a/tests/Mappers/Root/BaseTypeMapperTest.php
+++ b/tests/Mappers/Root/BaseTypeMapperTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Nullable;
+use phpDocumentor\Reflection\Types\Object_;
+use ReflectionMethod;
+use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\GraphQLException;
+
+class BaseTypeMapperTest extends AbstractQueryProviderTest
+{
+
+    public function testNullableToGraphQLInputType()
+    {
+        $baseTypeMapper = new BaseTypeMapper($this->getTypeMapper());
+
+        $mappedType = $baseTypeMapper->toGraphQLInputType(new Nullable(new Object_(new Fqsen('\\Exception'))), null, 'foo', new ReflectionMethod(BaseTypeMapper::class, '__construct'), new DocBlock());
+        $this->assertNull($mappedType);
+    }
+
+    public function testToGraphQLOutputTypeException()
+    {
+        $baseTypeMapper = new BaseTypeMapper($this->getTypeMapper());
+
+        $this->expectException(GraphQLException::class);
+        $this->expectExceptionMessage('Type-hinting a parameter against DateTime is not allowed. Please use the DateTimeImmutable type instead.');
+        $baseTypeMapper->toGraphQLInputType(new Object_(new Fqsen('\\DateTime')), null, 'foo', new ReflectionMethod(BaseTypeMapper::class, '__construct'), new DocBlock());
+    }
+}

--- a/tests/Mappers/Root/CompositeRootTypeMapperTest.php
+++ b/tests/Mappers/Root/CompositeRootTypeMapperTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Integer;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class CompositeRootTypeMapperTest extends TestCase
+{
+    private function getNullTypeMapper(): RootTypeMapperInterface
+    {
+        return new class() implements RootTypeMapperInterface {
+            public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType
+            {
+                return null;
+            }
+
+            public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType
+            {
+                return null;
+            }
+        };
+    }
+
+    public function testToGraphQLInputType()
+    {
+        $typeMapper = new CompositeRootTypeMapper([$this->getNullTypeMapper()]);
+        $this->assertNull($typeMapper->toGraphQLOutputType(new Integer(), null, new ReflectionMethod(CompositeRootTypeMapper::class, '__construct'), new DocBlock()));
+    }
+
+    public function testToGraphQLOutputType()
+    {
+        $typeMapper = new CompositeRootTypeMapper([$this->getNullTypeMapper()]);
+        $this->assertNull($typeMapper->toGraphQLInputType(new Integer(), null, 'foo', new ReflectionMethod(CompositeRootTypeMapper::class, '__construct'), new DocBlock()));
+    }
+}


### PR DESCRIPTION
Adding a new RootTypeMapperInterface that can be used to map any return or any parameter to a GraphQL output / input type.

Unless the TypeMapperInterface, the RootTypeMapperInterface can map any input/output type (not only objects).
It also has access to the method signature / annotation, etc... and not only the type.