### PR TITLE
Adding support for myclabs/php-enum mapping 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "mouf/picotainer": "^1.1",
         "phpstan/phpstan": "^0.11",
         "beberlei/porpaginas": "^1.2",
-        "myclabs/php-enum": "^1.7"
+        "myclabs/php-enum": "^1.6.6"
     },
     "suggest": {
         "beberlei/porpaginas": "If you want automatic pagination in your GraphQL types"
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "3.1.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "symfony/cache": "^4.1.4",
         "mouf/picotainer": "^1.1",
         "phpstan/phpstan": "^0.11",
-        "beberlei/porpaginas": "^1.2"
+        "beberlei/porpaginas": "^1.2",
+        "myclabs/php-enum": "^1.7"
     },
     "suggest": {
         "beberlei/porpaginas": "If you want automatic pagination in your GraphQL types"

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,101 @@
+---
+id: internals
+title: Internals
+sidebar_label: Internals
+---
+<script src="https://unpkg.com/mermaid@8.0.0/dist/mermaid.min.js"></script>
+
+## Mapping types
+
+The core of GraphQLite is its ability to map PHP types to GraphQL types. This mapping is performed by a series of
+"type mappers".
+
+GraphQLite contains 3 categories of type mappers:
+
+- **Root type mappers**
+- **Recursive (class) type mappers**
+- **(class) type mappers**
+
+
+<script>
+mermaid.initialize({
+  theme: 'forest',
+  // themeCSS: '.node rect { fill: red; }',
+  logLevel: 3,
+  flowchart: { curve: 'linear' },
+  gantt: { axisFormat: '%m/%d/%Y' },
+  sequence: { actorMargin: 50 },
+});
+</script>
+<div class="mermaid">
+  graph TD
+  classDef custom fill:#cfc,stroke:#7a7,stroke-width:2px,stroke-dasharray: 5, 5;
+  subgraph RootTypeMapperInterface
+    YourCustomRootTypeMapper-->MyCLabsEnumTypeMapper
+    MyCLabsEnumTypeMapper-->BaseTypeMapper
+  end
+  subgraph RecursiveTypeMapperInterface
+    BaseTypeMapper-->RecursiveTypeMapper
+  end
+  subgraph TypeMapperInterface
+    RecursiveTypeMapper-->YourCustomTypeMapper
+    YourCustomTypeMapper-->PorpaginasTypeMapper
+    PorpaginasTypeMapper-->GlobTypeMapper
+  end
+  class YourCustomRootTypeMapper,YourCustomTypeMapper custom;
+
+</div>
+
+## Root type mappers
+
+(Classes implementing the [`RootTypeMapperInterface`](https://github.com/thecodingmachine/graphqlite/blob/master/src/Mappers/Root/RootTypeMapperInterface.php))
+
+These type mappers are the first type mappers called.
+
+They are responsible for:
+ 
+ - mapping scalar types (for instance mapping the "int" PHP type to GraphQL Integer type)
+ - mapping list types (mapping a PHP array to a GraphQL list)
+ - mapping enums
+
+Root type mappers have access to the *context* of a type: they can access the PHP DocBlock and read annotations.
+If you want to write a custom type mapper that needs access to annotations, it needs to be a "root type mapper".
+
+GraphQLite provide 3 default implementations:
+
+ - `CompositeRootTypeMapper`: a type mapper that delegates mapping to other type mappers using the Composite Design Pattern.
+ - `MyCLabsEnumTypeMapper`: maps MyCLabs/enum types to GraphQL enum types
+ - `BaseTypeMapper`: maps scalar types and lists. Passes the control to the "recursive type mappers" if an object is encountered.
+
+## Class type mappers
+
+(Classes implementing the [`TypeMapperInterface`](https://github.com/thecodingmachine/graphqlite/blob/master/src/Mappers/TypeMapperInterface.php))
+
+Class type mappers are mapping PHP classes to GraphQL object types.
+
+GraphQLite provide 3 default implementations:
+
+ - `CompositeTypeMapper`: a type mapper that delegates mapping to other type mappers using the Composite Design Pattern.
+ - `GlobTypeMapper`: scans classes in a directory for the `@Type` or `@ExtendType` annotation and maps those to GraphQL types
+ - `PorpaginasTypeMapper`: maps and class implementing the Porpaginas `Result` interface to a [special paginated type](pagination.md).
+
+### Registering a type mapper in Symfony
+
+If you are using the GraphQLite Symfony bundle, you can register a type mapper by tagging the service with the "graphql.type_mapper" tag.
+
+### Registering a type mapper using the SchemaFactory
+
+If you are using the `SchemaFactory` to bootstrap GraphQLite, you can register a type mapper using the `SchemaFactory::addTypeMapper` method.
+
+## Recursive type mappers
+
+(Classes implementing the [`RecursiveTypeMapperInterface`](https://github.com/thecodingmachine/graphqlite/blob/master/src/Mappers/RecursiveTypeMapperInterface.php))
+
+There is only one implementation of the `RecursiveTypeMapperInterface`: the `RecursiveTypeMapper`.
+
+Standard "class type mappers" are mapping a given PHP class to a GraphQL type. But they do not handle class hierarchies.
+This is the role of the "recursive type mapper".
+
+Imagine that class "B" extends class "A" and class "A" maps to GraphQL type "AType".
+
+Since "B" *is a* "A", the "recursive type mapper" role is to make sure that "B" will also map to GraphQL type "AType". 

--- a/docs/type_mapping.md
+++ b/docs/type_mapping.md
@@ -173,3 +173,48 @@ public function companyOrContact(int $id)
 }
 ```
 
+## Enum types
+
+<small>Available in GraphQLite 3.1+</small>
+
+PHP has no native support for enum types. Hopefully, there are a number of PHP libraries that emulate enums in PHP.
+The most commonly used library is [myclabs/php-enum](https://github.com/myclabs/php-enum) and GraphQLite comes with
+native support for it.
+
+You will first need to install [myclabs/php-enum](https://github.com/myclabs/php-enum):
+
+```bash
+$ composer require myclabs/php-enum
+```
+
+Now, any class extending the `MyCLabs\Enum\Enum` class will be mapped to a GraphQL enum:
+
+```php
+use MyCLabs\Enum\Enum;
+
+class StatusEnum extends Enum
+{
+    private const ON = 'on';
+    private const OFF = 'off';
+    private const PENDING = 'pending';
+}
+```
+
+```php
+/**
+ * @Query
+ * @return User[]
+ */
+public function users(StatusEnum $status): array
+{
+    if ($status === StatusEum::ON()) {
+        // ...
+    }
+    // ...
+}
+```
+
+<div class="alert alert-info">There are many enumeration library in PHP and you might be using another library.
+If you want to add support for your own library, this is not extremely difficult to do. You need to register a custom
+"RootTypeMapper" with GraphQLite. You can learn more about <em>type mappers</em> in the <a href="internals.md">"internals" documentation</a>
+and <a href="https://github.com/thecodingmachine/graphqlite/blob/master/src/Mappers/Root/MyCLabsEnumTypeMapper.php">copy/paste and adapt the root type mapper used for myclabs/php-enum</a>.</div>

--- a/src/FieldsBuilderFactory.php
+++ b/src/FieldsBuilderFactory.php
@@ -8,6 +8,7 @@ use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\MyCLabsEnumTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
@@ -76,6 +77,7 @@ class FieldsBuilderFactory
     public function buildFieldsBuilder(RecursiveTypeMapperInterface $typeMapper): FieldsBuilder
     {
         $rootTypeMappers = $this->rootTypeMappers;
+        $rootTypeMappers[] = new MyCLabsEnumTypeMapper();
         $rootTypeMappers[] = new BaseTypeMapper($typeMapper);
         return new FieldsBuilder(
             $this->annotationReader,

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -4,6 +4,7 @@
 namespace TheCodingMachine\GraphQLite\Mappers;
 
 
+use GraphQL\Error\Error;
 use GraphQL\Error\SyntaxError;
 use GraphQL\Type\Definition\ObjectType;
 use ReflectionClass;
@@ -28,7 +29,7 @@ class CannotMapTypeException extends \Exception implements CannotMapTypeExceptio
         return new self('cannot find GraphQL type "'.$name.'". Check your TypeMapper configuration.');
     }
 
-    public static function createForParseError(SyntaxError $error): self
+    public static function createForParseError(Error $error): self
     {
         return new self($error->getMessage(), $error->getCode(), $error);
     }

--- a/src/Mappers/Root/BaseTypeMapper.php
+++ b/src/Mappers/Root/BaseTypeMapper.php
@@ -1,0 +1,111 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use function ltrim;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Boolean;
+use phpDocumentor\Reflection\Types\Float_;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\String_;
+use Psr\Http\Message\UploadedFileInterface;
+use ReflectionMethod;
+use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Types\CustomTypesRegistry;
+use TheCodingMachine\GraphQLite\Types\DateTimeType;
+use TheCodingMachine\GraphQLite\Types\ID;
+
+/**
+ * Casts base GraphQL types (scalar, lists, DateTime, ID, UploadedFileInterface.
+ * Does not deal with nullable types => assumes nullable types have been handled BEFORE.
+ * Does not deal with union types => assumes union types have been handled BEFORE.
+ */
+class BaseTypeMapper implements RootTypeMapperInterface
+{
+    /**
+     * @var RecursiveTypeMapperInterface
+     */
+    private $recursiveTypeMapper;
+
+    public function __construct(RecursiveTypeMapperInterface $recursiveTypeMapper)
+    {
+        $this->recursiveTypeMapper = $recursiveTypeMapper;
+    }
+
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType
+    {
+        $mappedType = $this->mapBaseType($type);
+        if ($mappedType !== null) {
+            return $mappedType;
+        }
+        if ($type instanceof Array_) {
+            return GraphQLType::listOf(GraphQLType::nonNull($this->toGraphQLOutputType($type->getValueType(), $subType, $refMethod, $docBlockObj)));
+        }
+        if ($type instanceof Object_) {
+            $className = ltrim($type->getFqsen(), '\\');
+            return $this->recursiveTypeMapper->mapClassToInterfaceOrType($className, $subType);
+        }
+        return null;
+    }
+
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType
+    {
+        $mappedType = $this->mapBaseType($type);
+        if ($mappedType !== null) {
+            return $mappedType;
+        }
+        if ($type instanceof Array_) {
+            return GraphQLType::listOf(GraphQLType::nonNull($this->toGraphQLInputType($type->getValueType(), $subType, $argumentName, $refMethod, $docBlockObj)));
+        }
+        if ($type instanceof Object_) {
+            $className = ltrim($type->getFqsen(), '\\');
+            return $this->recursiveTypeMapper->mapClassToInputType($className);
+        }
+        return null;
+    }
+
+    /**
+     * Casts a Type to a GraphQL type.
+     * Does not deal with nullable.
+     *
+     * @param Type $type
+     * @return \GraphQL\Type\Definition\BooleanType|\GraphQL\Type\Definition\FloatType|\GraphQL\Type\Definition\IDType|\GraphQL\Type\Definition\IntType|\GraphQL\Type\Definition\StringType|\GraphQL\Upload\UploadType|DateTimeType|null
+     */
+    private function mapBaseType(Type $type)
+    {
+        if ($type instanceof Integer) {
+            return GraphQLType::int();
+        } elseif ($type instanceof String_) {
+            return GraphQLType::string();
+        } elseif ($type instanceof Boolean) {
+            return GraphQLType::boolean();
+        } elseif ($type instanceof Float_) {
+            return GraphQLType::float();
+        } elseif ($type instanceof Object_) {
+            $fqcn = (string) $type->getFqsen();
+            switch ($fqcn) {
+                case '\\DateTimeImmutable':
+                case '\\DateTimeInterface':
+                    return DateTimeType::getInstance();
+                case '\\'.UploadedFileInterface::class:
+                    return CustomTypesRegistry::getUploadType();
+                case '\\DateTime':
+                    throw new GraphQLException('Type-hinting a parameter against DateTime is not allowed. Please use the DateTimeImmutable type instead.');
+                case '\\'.ID::class:
+                    return GraphQLType::id();
+                default:
+                    return null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Mappers/Root/CompositeRootTypeMapper.php
+++ b/src/Mappers/Root/CompositeRootTypeMapper.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use function is_array;
+use function iterator_to_array;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use ReflectionMethod;
+
+class CompositeRootTypeMapper implements RootTypeMapperInterface
+{
+    /**
+     * @var RootTypeMapperInterface[]
+     */
+    private $rootTypeMappers;
+
+    /**
+     * @param RootTypeMapperInterface[] $rootTypeMappers
+     */
+    public function __construct(iterable $rootTypeMappers)
+    {
+        $this->rootTypeMappers = is_array($rootTypeMappers) ? $rootTypeMappers : iterator_to_array($rootTypeMappers);
+    }
+
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType
+    {
+        foreach ($this->rootTypeMappers as $rootTypeMapper) {
+            $mappedType = $rootTypeMapper->toGraphQLOutputType($type, $subType, $refMethod, $docBlockObj);
+            if ($mappedType !== null) {
+                return $mappedType;
+            }
+        }
+        return null;
+    }
+
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType
+    {
+        foreach ($this->rootTypeMappers as $rootTypeMapper) {
+            $mappedType = $rootTypeMapper->toGraphQLInputType($type, $subType, $argumentName, $refMethod, $docBlockObj);
+            if ($mappedType !== null) {
+                return $mappedType;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Mappers/Root/RootTypeMapperInterface.php
+++ b/src/Mappers/Root/RootTypeMapperInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use ReflectionMethod;
+
+
+/**
+ * Maps a method return type or argument to a GraphQL Type.
+ *
+ * Unlike TypeMapperInterface that maps a class to a GraphQL object, RootTypeMapperInterface has access to
+ * the "context" (i.e. the function signature, the annotations...). Also, it can map to any types (not only objects,
+ * but also scalar types...)
+ *
+ * We call it "RootTypeMapper" because it is the first type mapper to be called. It will call the recursive type
+ * mappers which will in turn, call the "type mappers".
+ */
+interface RootTypeMapperInterface
+{
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType;
+
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType;
+}

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -22,6 +22,7 @@ use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
@@ -45,6 +46,10 @@ class SchemaFactory
      * @var QueryProviderInterface[]
      */
     private $queryProviders = [];
+    /**
+     * @var RootTypeMapperInterface[]
+     */
+    private $rootTypeMappers = [];
     /**
      * @var TypeMapperInterface[]
      */
@@ -113,6 +118,15 @@ class SchemaFactory
     public function addQueryProvider(QueryProviderInterface $queryProvider): self
     {
         $this->queryProviders[] = $queryProvider;
+        return $this;
+    }
+
+    /**
+     * Registers a root type mapper.
+     */
+    public function addRootTypeMapper(RootTypeMapperInterface $rootTypeMapper): self
+    {
+        $this->rootTypeMappers[] = $rootTypeMapper;
         return $this;
     }
 
@@ -200,7 +214,7 @@ class SchemaFactory
         $lockFactory = new LockFactory($lockStore);
 
         $fieldsBuilderFactory = new FieldsBuilderFactory($annotationReader, $hydrator, $authenticationService,
-            $authorizationService, $typeResolver, $cachedDocBlockFactory, $namingStrategy);
+            $authorizationService, $typeResolver, $cachedDocBlockFactory, $namingStrategy, $this->rootTypeMappers);
 
         $typeGenerator = new TypeGenerator($annotationReader, $fieldsBuilderFactory, $namingStrategy, $typeRegistry, $this->container);
         $inputTypeUtils = new InputTypeUtils($annotationReader, $namingStrategy);

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -27,6 +27,8 @@ use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
@@ -273,7 +275,10 @@ abstract class AbstractQueryProviderTest extends TestCase
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new CompositeRootTypeMapper([
+                new BaseTypeMapper($this->getTypeMapper())
+            ])
         );
     }
 

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -29,6 +29,7 @@ use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\MyCLabsEnumTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
@@ -277,6 +278,7 @@ abstract class AbstractQueryProviderTest extends TestCase
             new CachedDocBlockFactory(new ArrayCache()),
             new NamingStrategy(),
             new CompositeRootTypeMapper([
+                new MyCLabsEnumTypeMapper(),
                 new BaseTypeMapper($this->getTypeMapper())
             ])
         );

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -40,6 +40,8 @@ use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
@@ -234,7 +236,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new BaseTypeMapper($this->getTypeMapper())
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -259,7 +262,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             },
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new BaseTypeMapper($this->getTypeMapper())
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -316,7 +320,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new VoidAuthorizationService(),
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
-            new NamingStrategy()
+            new NamingStrategy(),
+            new BaseTypeMapper($this->getTypeMapper())
         );
         $fields = $queryProvider->getFields(new TestTypeWithSourceFieldInterface(), true);
         $this->assertCount(1, $fields);

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -4,6 +4,7 @@ namespace TheCodingMachine\GraphQLite;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use GraphQL\Type\Definition\BooleanType;
+use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FloatType;
 use GraphQL\Type\Definition\IDType;
 use GraphQL\Type\Definition\InputObjectType;
@@ -65,7 +66,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $usersQuery = $queries[0];
         $this->assertSame('test', $usersQuery->name);
 
-        $this->assertCount(9, $usersQuery->args);
+        $this->assertCount(10, $usersQuery->args);
         $this->assertSame('int', $usersQuery->args[0]->name);
         $this->assertInstanceOf(NonNull::class, $usersQuery->args[0]->getType());
         $this->assertInstanceOf(IntType::class, $usersQuery->args[0]->getType()->getWrappedType());
@@ -80,6 +81,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertInstanceOf(DateTimeType::class, $usersQuery->args[5]->getType());
         $this->assertInstanceOf(StringType::class, $usersQuery->args[6]->getType());
         $this->assertInstanceOf(IDType::class, $usersQuery->args[8]->getType());
+        $this->assertInstanceOf(EnumType::class, $usersQuery->args[9]->getType());
         $this->assertSame('TestObjectInput', $usersQuery->args[1]->getType()->getWrappedType()->getWrappedType()->getWrappedType()->name);
 
         $context = ['int' => 42, 'string' => 'foo', 'list' => [
@@ -90,19 +92,20 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             'float' => 4.2,
             'dateTimeImmutable' => '2017-01-01 01:01:01',
             'dateTime' => '2017-01-01 01:01:01',
-            'id' => 42
+            'id' => 42,
+            'enum' => 'on'
         ];
 
         $resolve = $usersQuery->resolveFn;
         $result = $resolve('foo', $context);
 
         $this->assertInstanceOf(TestObject::class, $result);
-        $this->assertSame('foo424212true4.22017010101010120170101010101default42', $result->getTest());
+        $this->assertSame('foo424212true4.22017010101010120170101010101default42on', $result->getTest());
 
         unset($context['string']); // Testing null default value
         $result = $resolve('foo', $context);
 
-        $this->assertSame('424212true4.22017010101010120170101010101default42', $result->getTest());
+        $this->assertSame('424212true4.22017010101010120170101010101default42on', $result->getTest());
     }
 
     public function testMutations()

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -23,9 +23,10 @@ class TestController
      * @param string $withDefault
      * @param null|string $string
      * @param ID|null $id
+     * @param TestEnum $enum
      * @return TestObject
      */
-    public function test(int $int, array $list, ?bool $boolean, ?float $float, ?\DateTimeImmutable $dateTimeImmutable, ?\DateTimeInterface $dateTime, string $withDefault = 'default', ?string $string = null, ID $id = null): TestObject
+    public function test(int $int, array $list, ?bool $boolean, ?float $float, ?\DateTimeImmutable $dateTimeImmutable, ?\DateTimeInterface $dateTime, string $withDefault = 'default', ?string $string = null, ID $id = null, TestEnum $enum = null): TestObject
     {
         $str = '';
         foreach ($list as $test) {
@@ -34,7 +35,7 @@ class TestController
             }
             $str .= $test->getTest();
         }
-        return new TestObject($string.$int.$str.($boolean?'true':'false').$float.$dateTimeImmutable->format('YmdHis').$dateTime->format('YmdHis').$withDefault.($id !== null ? $id->val() : ''));
+        return new TestObject($string.$int.$str.($boolean?'true':'false').$float.$dateTimeImmutable->format('YmdHis').$dateTime->format('YmdHis').$withDefault.($id !== null ? $id->val() : '').$enum->getValue());
     }
 
     /**

--- a/tests/Fixtures/TestEnum.php
+++ b/tests/Fixtures/TestEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @method static TestEnum ON()
+ * @method static TestEnum OFF()
+ */
+class TestEnum extends Enum
+{
+    private const ON = 'on';
+    private const OFF = 'off';
+}

--- a/tests/Mappers/Root/BaseTypeMapperTest.php
+++ b/tests/Mappers/Root/BaseTypeMapperTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Nullable;
+use phpDocumentor\Reflection\Types\Object_;
+use ReflectionMethod;
+use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\GraphQLException;
+
+class BaseTypeMapperTest extends AbstractQueryProviderTest
+{
+
+    public function testNullableToGraphQLInputType()
+    {
+        $baseTypeMapper = new BaseTypeMapper($this->getTypeMapper());
+
+        $mappedType = $baseTypeMapper->toGraphQLInputType(new Nullable(new Object_(new Fqsen('\\Exception'))), null, 'foo', new ReflectionMethod(BaseTypeMapper::class, '__construct'), new DocBlock());
+        $this->assertNull($mappedType);
+    }
+
+    public function testToGraphQLOutputTypeException()
+    {
+        $baseTypeMapper = new BaseTypeMapper($this->getTypeMapper());
+
+        $this->expectException(GraphQLException::class);
+        $this->expectExceptionMessage('Type-hinting a parameter against DateTime is not allowed. Please use the DateTimeImmutable type instead.');
+        $baseTypeMapper->toGraphQLInputType(new Object_(new Fqsen('\\DateTime')), null, 'foo', new ReflectionMethod(BaseTypeMapper::class, '__construct'), new DocBlock());
+    }
+}

--- a/tests/Mappers/Root/CompositeRootTypeMapperTest.php
+++ b/tests/Mappers/Root/CompositeRootTypeMapperTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Integer;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class CompositeRootTypeMapperTest extends TestCase
+{
+    private function getNullTypeMapper(): RootTypeMapperInterface
+    {
+        return new class() implements RootTypeMapperInterface {
+            public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType
+            {
+                return null;
+            }
+
+            public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType
+            {
+                return null;
+            }
+        };
+    }
+
+    public function testToGraphQLInputType()
+    {
+        $typeMapper = new CompositeRootTypeMapper([$this->getNullTypeMapper()]);
+        $this->assertNull($typeMapper->toGraphQLOutputType(new Integer(), null, new ReflectionMethod(CompositeRootTypeMapper::class, '__construct'), new DocBlock()));
+    }
+
+    public function testToGraphQLOutputType()
+    {
+        $typeMapper = new CompositeRootTypeMapper([$this->getNullTypeMapper()]);
+        $this->assertNull($typeMapper->toGraphQLInputType(new Integer(), null, 'foo', new ReflectionMethod(CompositeRootTypeMapper::class, '__construct'), new DocBlock()));
+    }
+}

--- a/tests/Mappers/Root/MyCLabsEnumTypeMapper.php
+++ b/tests/Mappers/Root/MyCLabsEnumTypeMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use GraphQL\Type\Definition\EnumType;
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\OutputType;
+use MyCLabs\Enum\Enum;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Object_;
+use ReflectionMethod;
+
+/**
+ * Maps an class extending MyClabs enums to a GraphQL type
+ */
+class MyCLabsEnumTypeMapper implements RootTypeMapperInterface
+{
+
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?OutputType
+    {
+        return $this->map($type);
+    }
+
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, ReflectionMethod $refMethod, DocBlock $docBlockObj): ?InputType
+    {
+        return $this->map($type);
+    }
+
+    private function map(Type $type): ?EnumType
+    {
+        if ($type instanceof Object_ && is_a((string) $type->getFqsen(), Enum::class, true)) {
+            $enumClass = (string) $type->getFqsen();
+            $consts = $enumClass::toArray();
+            $constInstances = [];
+            foreach ($consts as $key => $value) {
+                $constInstances[$value] = ['value' => $enumClass::$key()];
+            }
+            return new EnumType([
+                'name' => $type->getFqsen()->getName(),
+                'description' => 'One of the films in the Star Wars Trilogy',
+                'values' => $constInstances
+            ]);
+        }
+        return null;
+    }
+}

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -11,6 +11,7 @@ use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Hydrators\FactoryHydrator;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 
@@ -50,6 +51,7 @@ class SchemaFactoryTest extends TestCase
                 ->setAuthorizationService(new VoidAuthorizationService())
                 ->setNamingStrategy(new NamingStrategy())
                 ->addTypeMapper(new CompositeTypeMapper([]))
+                ->addRootTypeMapper(new CompositeRootTypeMapper([]))
                 ->setSchemaConfig(new SchemaConfig());
 
         $schema = $factory->createSchema();

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,7 +3,7 @@
     "Introduction": ["features"],
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
     "Usage": ["queries", "mutations", "type_mapping", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance"],
-    "Advanced": ["file-uploads", "pagination", "custom-output-types", "troubleshooting"],
+    "Advanced": ["file-uploads", "pagination", "custom-output-types", "internals", "troubleshooting"],
     "Reference": ["annotations_reference"]
   }
 }


### PR DESCRIPTION
GraphQLite cannot map yet classes to Enum types.
This PR adds support for mapping classes extending Myclabs's Enum class to GraphQL enums.

The first commit is a failing test

This PR closes #43 