### PR TITLE
Error when there are no types declared

### DIFF
--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -283,6 +283,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
     private function getClassTree(): array
     {
         if ($this->mappedClasses === null) {
+            $this->mappedClasses = [];
             $supportedClasses = array_flip($this->typeMapper->getSupportedClasses());
             foreach ($supportedClasses as $supportedClass => $foo) {
                 $this->getMappedClass($supportedClass, $supportedClasses);

--- a/src/Mappers/Root/MyCLabsEnumTypeMapper.php
+++ b/src/Mappers/Root/MyCLabsEnumTypeMapper.php
@@ -13,7 +13,7 @@ use phpDocumentor\Reflection\Types\Object_;
 use ReflectionMethod;
 
 /**
- * Maps an class extending MyClabs enums to a GraphQL type
+ * Maps an class extending MyCLabs enums to a GraphQL type
  */
 class MyCLabsEnumTypeMapper implements RootTypeMapperInterface
 {

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -179,4 +179,15 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
         $this->expectExceptionMessage("The type 'Foobar' is created by 2 different classes: 'TheCodingMachine\GraphQLite\Fixtures\Interfaces\ClassB' and 'TheCodingMachine\GraphQLite\Fixtures\Interfaces\ClassA'");
         $recursiveTypeMapper->getOutputTypes();
     }
+
+    /**
+     * Tests that the RecursiveTypeMapper behaves correctly if there are no types to map.
+     */
+    public function testMapNoTypes()
+    {
+        $recursiveTypeMapper = new RecursiveTypeMapper(new CompositeTypeMapper([]), new NamingStrategy(), new ArrayCache(), $this->getTypeRegistry());
+
+        $this->expectException(CannotMapTypeException::class);
+        $recursiveTypeMapper->mapNameToType('Foo');
+    }
 }


### PR DESCRIPTION
When there are no types declared, errors can arise.
See unit test in commit.