### PR TITLE
Adding the ability to type-hint in docblocks only.

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -508,10 +508,13 @@ class FieldsBuilder
 
             $type = (string) $parameterType;
             if ($type === '') {
-                throw MissingTypeHintException::missingTypeHint($parameter);
+                $phpdocType = new Mixed_();
+                $allowsNull = false;
+                //throw MissingTypeHintException::missingTypeHint($parameter);
+            } else {
+                $phpdocType = $typeResolver->resolve($type);
+                $phpdocType = $this->resolveSelf($phpdocType, $parameter->getDeclaringClass());
             }
-            $phpdocType = $typeResolver->resolve($type);
-            $phpdocType = $this->resolveSelf($phpdocType, $parameter->getDeclaringClass());
 
             $docBlockType = $docBlockTypes[$parameter->getName()] ?? null;
 

--- a/src/MissingTypeHintException.php
+++ b/src/MissingTypeHintException.php
@@ -6,11 +6,6 @@ use \ReflectionParameter;
 
 class MissingTypeHintException extends GraphQLException
 {
-    public static function missingTypeHint(ReflectionParameter $parameter): self
-    {
-        return new self(sprintf('Parameter "%s" of method "%s::%s" is missing a type-hint', $parameter->getName(), $parameter->getDeclaringClass()->getName(), $parameter->getDeclaringFunction()->getName()));
-    }
-
     public static function missingReturnType(ReflectionMethod $method): self
     {
         return new self(sprintf('Factory "%s::%s" must have a return type.', $method->getDeclaringClass()->getName(), $method->getName()));


### PR DESCRIPTION
Until now, it was compulsory to type-hint methods in PHP (and not docblocks) when it was possible to do so.
This PR allows type-hinting in DocBlocks only (could be useful for a legacy code base accessed via @SourceField and also for type-mappers that can decide what to do later in the process... before an exception is triggered!)