### PR TITLE
 Switching to an object-oriented Parameter resolver 

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -22,6 +22,8 @@ use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\CustomTypesRegistry;
@@ -208,7 +210,8 @@ class FieldsBuilder
 
         $args = $this->mapParameters($parameters, $docBlockObj, $refMethod);
 
-        return $args;
+        // TODO: move this out of "QueryField"
+        return QueryField::getInputTypeArgs($args);
     }
 
     /**
@@ -286,12 +289,12 @@ class FieldsBuilder
 
                 if ($unauthorized) {
                     $failWithValue = $failWith->getValue();
-                    $queryList[] = QueryField::alwaysReturn($name, $type, $args, $failWithValue, $this->argumentResolver, $docBlockComment);
+                    $queryList[] = QueryField::alwaysReturn($name, $type, $args, $failWithValue, $docBlockComment);
                 } else {
                     if ($sourceClassName !== null) {
-                        $queryList[] = QueryField::selfField($name, $type, $args, $methodName, $this->argumentResolver, $docBlockComment);
+                        $queryList[] = QueryField::selfField($name, $type, $args, $methodName, $docBlockComment);
                     } else {
-                        $queryList[] = QueryField::externalField($name, $type, $args, [$controller, $methodName], $this->argumentResolver, $docBlockComment, $injectSource);
+                        $queryList[] = QueryField::externalField($name, $type, $args, [$controller, $methodName], $docBlockComment, $injectSource);
                     }
                 }
             }
@@ -415,10 +418,10 @@ class FieldsBuilder
             }
 
             if (!$unauthorized) {
-                $queryList[] = QueryField::selfField($sourceField->getName(), $type, $args, $methodName, $this->argumentResolver, $docBlockComment);
+                $queryList[] = QueryField::selfField($sourceField->getName(), $type, $args, $methodName, $docBlockComment);
             } else {
                 $failWithValue = $sourceField->getFailWith();
-                $queryList[] = QueryField::alwaysReturn($sourceField->getName(), $type, $args, $failWithValue, $this->argumentResolver, $docBlockComment);
+                $queryList[] = QueryField::alwaysReturn($sourceField->getName(), $type, $args, $failWithValue, $docBlockComment);
             }
         }
         return $queryList;
@@ -470,7 +473,7 @@ class FieldsBuilder
      * Note: there is a bug in $refMethod->allowsNull that forces us to use $standardRefMethod->allowsNull instead.
      *
      * @param \ReflectionParameter[] $refParameters
-     * @return array[] An array of ['type'=>Type, 'defaultValue'=>val]
+     * @return array<string, ParameterInterface>
      * @throws MissingTypeHintException
      */
     private function mapParameters(array $refParameters, DocBlock $docBlock, ReflectionMethod $refMethod): array
@@ -505,23 +508,24 @@ class FieldsBuilder
             $docBlockType = $docBlockTypes[$parameter->getName()] ?? null;
 
             try {
-                $arr = [
-                    'type' => $this->mapType($phpdocType, $docBlockType, $allowsNull || $parameter->isDefaultValueAvailable(), true, $refMethod, $docBlock, $parameter->getName()),
-                ];
+                $type = $this->mapType($phpdocType, $docBlockType, $allowsNull || $parameter->isDefaultValueAvailable(), true, $refMethod, $docBlock, $parameter->getName());
             } catch (TypeMappingException $e) {
                 throw TypeMappingException::wrapWithParamInfo($e, $parameter);
             } catch (CannotMapTypeExceptionInterface $e) {
                 throw CannotMapTypeException::wrapWithParamInfo($e, $parameter);
             }
 
+            $hasDefaultValue = false;
+            $defaultValue = null;
             if ($parameter->allowsNull()) {
-                $arr['defaultValue'] = null;
+                $hasDefaultValue = true;
             }
             if ($parameter->isDefaultValueAvailable()) {
-                $arr['defaultValue'] = $parameter->getDefaultValue();
+                $hasDefaultValue = true;
+                $defaultValue = $parameter->getDefaultValue();
             }
 
-            $args[$parameter->getName()] = $arr;
+            $args[$parameter->getName()] = new InputTypeParameter($parameter->getName(), $type, $hasDefaultValue, $defaultValue, $this->argumentResolver);
         }
 
         return $args;

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -199,19 +199,16 @@ class FieldsBuilder
 
     /**
      * @param ReflectionMethod $refMethod A method annotated with a Factory annotation.
-     * @return array<string, array<int, mixed>> Returns an array of fields as accepted by the InputObjectType constructor.
+     * @return array<string, ParameterInterface> Returns an array of parameters.
      */
-    public function getInputFields(ReflectionMethod $refMethod): array
+    public function getParameters(ReflectionMethod $refMethod): array
     {
         $docBlockObj = $this->cachedDocBlockFactory->getDocBlock($refMethod);
         //$docBlockComment = $docBlockObj->getSummary()."\n".$docBlockObj->getDescription()->render();
 
         $parameters = $refMethod->getParameters();
 
-        $args = $this->mapParameters($parameters, $docBlockObj, $refMethod);
-
-        // TODO: move this out of "QueryField"
-        return QueryField::getInputTypeArgs($args);
+        return $this->mapParameters($parameters, $docBlockObj, $refMethod);
     }
 
     /**

--- a/src/Hydrators/FactoryHydrator.php
+++ b/src/Hydrators/FactoryHydrator.php
@@ -4,8 +4,10 @@
 namespace TheCodingMachine\GraphQLite\Hydrators;
 
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
 use TheCodingMachine\GraphQLite\GraphQLException;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
+use TheCodingMachine\GraphQLite\Types\ResolvableInputInterface;
 use TheCodingMachine\GraphQLite\Types\ResolvableInputObjectType;
 
 /**
@@ -22,10 +24,10 @@ class FactoryHydrator implements HydratorInterface
      * @return object
      * @throws CannotHydrateException
      */
-    public function hydrate(array $data, InputObjectType $type)
+    public function hydrate($source, array $data, $context, ResolveInfo $resolveInfo, InputObjectType $type)
     {
-        if ($type instanceof ResolvableInputObjectType) {
-            return $type->resolve($data);
+        if ($type instanceof ResolvableInputInterface) {
+            return $type->resolve($source, $data, $context, $resolveInfo);
         }
         throw CannotHydrateException::createForInputType($type->name);
     }
@@ -39,6 +41,6 @@ class FactoryHydrator implements HydratorInterface
      */
     public function canHydrate(array $data, InputObjectType $type): bool
     {
-        return $type instanceof ResolvableInputObjectType;
+        return $type instanceof ResolvableInputInterface;
     }
 }

--- a/src/Hydrators/HydratorInterface.php
+++ b/src/Hydrators/HydratorInterface.php
@@ -4,6 +4,7 @@
 namespace TheCodingMachine\GraphQLite\Hydrators;
 
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * Hydrates an object given an array and a GraphQL type.
@@ -27,5 +28,5 @@ interface HydratorInterface
      * @return object
      * @throws CannotHydrateException
      */
-    public function hydrate(array $data, InputObjectType $type);
+    public function hydrate($source, array $data, $context, ResolveInfo $resolveInfo, InputObjectType $type);
 }

--- a/src/InputTypeUtils.php
+++ b/src/InputTypeUtils.php
@@ -87,7 +87,6 @@ class InputTypeUtils
         return $type;
     }
 
-
     /**
      * Maps an array of ParameterInterface to an array of field descriptors as accepted by Webonyx.
      *

--- a/src/InputTypeUtils.php
+++ b/src/InputTypeUtils.php
@@ -3,12 +3,17 @@
 
 namespace TheCodingMachine\GraphQLite;
 
+use function array_filter;
+use function array_map;
+use GraphQL\Type\Definition\InputType;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\Self_;
 use ReflectionClass;
 use ReflectionMethod;
+use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 
 class InputTypeUtils
 {
@@ -80,5 +85,26 @@ class InputTypeUtils
             return new Object_(new Fqsen('\\'.$reflectionClass->getName()));
         }
         return $type;
+    }
+
+
+    /**
+     * Maps an array of ParameterInterface to an array of field descriptors as accepted by Webonyx.
+     *
+     * @param ParameterInterface[] $args
+     * @return array<string, array<string, mixed|InputType>>
+     */
+    public static function getInputTypeArgs(array $args): array
+    {
+        $inputTypeArgs = array_filter($args, static function(ParameterInterface $parameter) { return $parameter instanceof InputTypeParameter; });
+        return array_map(static function(InputTypeParameter $parameter) {
+            $desc = [
+                'type' => $parameter->getType()
+            ];
+            if ($parameter->hasDefaultValue()) {
+                $desc['defaultValue'] = $parameter->getDefaultValue();
+            }
+            return $desc;
+        }, $inputTypeArgs);
     }
 }

--- a/src/Parameters/InputTypeParameter.php
+++ b/src/Parameters/InputTypeParameter.php
@@ -60,14 +60,14 @@ class InputTypeParameter implements ParameterInterface
     public function resolve($source, $args, $context, ResolveInfo $info)
     {
         if (isset($args[$this->name])) {
-            return $this->argumentResolver->resolve($args[$this->name], $this->type);
+            return $this->argumentResolver->resolve($source, $args[$this->name], $context, $info, $this->type);
         }
 
         if ($this->doesHaveDefaultValue) {
             return $this->defaultValue;
         }
 
-        throw new GraphQLException("Expected argument '{$this->name}' was not provided.");
+        throw MissingArgumentException::create($this->name);
     }
 
     /**

--- a/src/Parameters/InputTypeParameter.php
+++ b/src/Parameters/InputTypeParameter.php
@@ -26,7 +26,7 @@ class InputTypeParameter implements ParameterInterface
     /**
      * @var bool
      */
-    private $hasDefaultValue;
+    private $doesHaveDefaultValue;
     private $defaultValue;
     /**
      * @var ArgumentResolver
@@ -45,7 +45,7 @@ class InputTypeParameter implements ParameterInterface
     {
         $this->name = $name;
         $this->type = $type;
-        $this->hasDefaultValue = $hasDefaultValue;
+        $this->doesHaveDefaultValue = $hasDefaultValue;
         $this->defaultValue = $defaultValue;
         $this->argumentResolver = $argumentResolver;
     }
@@ -63,7 +63,7 @@ class InputTypeParameter implements ParameterInterface
             return $this->argumentResolver->resolve($args[$this->name], $this->type);
         }
 
-        if ($this->hasDefaultValue) {
+        if ($this->doesHaveDefaultValue) {
             return $this->defaultValue;
         }
 
@@ -76,5 +76,21 @@ class InputTypeParameter implements ParameterInterface
     public function getType(): InputType
     {
         return $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasDefaultValue(): bool
+    {
+        return $this->doesHaveDefaultValue;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
     }
 }

--- a/src/Parameters/InputTypeParameter.php
+++ b/src/Parameters/InputTypeParameter.php
@@ -1,0 +1,80 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+
+use function array_key_exists;
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\ResolveInfo;
+use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
+
+/**
+ * Typically the first parameter of "external" fields that will be filled with the Source object.
+ */
+class InputTypeParameter implements ParameterInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var InputType
+     */
+    private $type;
+    /**
+     * @var bool
+     */
+    private $hasDefaultValue;
+    private $defaultValue;
+    /**
+     * @var ArgumentResolver
+     */
+    private $argumentResolver;
+
+    /**
+     * InputTypeParameter constructor.
+     * @param string $name
+     * @param InputType $type
+     * @param bool $hasDefaultValue
+     * @param mixed $defaultValue
+     * @param ArgumentResolver $argumentResolver
+     */
+    public function __construct(string $name, InputType $type, bool $hasDefaultValue, $defaultValue, ArgumentResolver $argumentResolver)
+    {
+        $this->name = $name;
+        $this->type = $type;
+        $this->hasDefaultValue = $hasDefaultValue;
+        $this->defaultValue = $defaultValue;
+        $this->argumentResolver = $argumentResolver;
+    }
+
+    /**
+     * @param object $source
+     * @param array<string, mixed> $args
+     * @param mixed $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public function resolve($source, $args, $context, ResolveInfo $info)
+    {
+        if (isset($args[$this->name])) {
+            return $this->argumentResolver->resolve($args[$this->name], $this->type);
+        }
+
+        if ($this->hasDefaultValue) {
+            return $this->defaultValue;
+        }
+
+        throw new GraphQLException("Expected argument '{$this->name}' was not provided.");
+    }
+
+    /**
+     * @return InputType
+     */
+    public function getType(): InputType
+    {
+        return $this->type;
+    }
+}

--- a/src/Parameters/MissingArgumentException.php
+++ b/src/Parameters/MissingArgumentException.php
@@ -5,15 +5,9 @@ namespace TheCodingMachine\GraphQLite\Parameters;
 
 
 use function get_class;
-use GraphQL\Error\Error;
-use GraphQL\Error\SyntaxError;
-use GraphQL\Type\Definition\ObjectType;
 use function is_array;
 use function is_string;
-use ReflectionClass;
-use ReflectionMethod;
 use function sprintf;
-use TheCodingMachine\GraphQLite\Annotations\SourceField;
 
 class MissingArgumentException extends \BadMethodCallException
 {

--- a/src/Parameters/MissingArgumentException.php
+++ b/src/Parameters/MissingArgumentException.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+
+use GraphQL\Error\Error;
+use GraphQL\Error\SyntaxError;
+use GraphQL\Type\Definition\ObjectType;
+use ReflectionClass;
+use ReflectionMethod;
+use function sprintf;
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+
+class MissingArgumentException extends \BadMethodCallException
+{
+    public static function create(string $argumentName): self
+    {
+        return new self("Expected argument '$argumentName' was not provided");
+    }
+
+    public static function wrapWithFactoryContext(self $previous, string $inputType, string $factoryClass, string $factoryMethod): self
+    {
+        $message = sprintf('%s in GraphQL input type \'%s\' used in factory \'%s::%s()\'',
+            $previous->getMessage(),
+            $inputType,
+            $factoryClass,
+            $factoryMethod
+            );
+
+        return new self($message, 0, $previous);
+    }
+
+    public static function wrapWithFieldContext(self $previous, string $name, string $factoryClass, string $factoryMethod): self
+    {
+        $message = sprintf('%s in GraphQL query/mutation/field \'%s\' used in method \'%s::%s()\'',
+            $previous->getMessage(),
+            $name,
+            $factoryClass,
+            $factoryMethod
+        );
+
+        return new self($message, 0, $previous);
+    }
+}

--- a/src/Parameters/MissingArgumentException.php
+++ b/src/Parameters/MissingArgumentException.php
@@ -4,9 +4,12 @@
 namespace TheCodingMachine\GraphQLite\Parameters;
 
 
+use function get_class;
 use GraphQL\Error\Error;
 use GraphQL\Error\SyntaxError;
 use GraphQL\Type\Definition\ObjectType;
+use function is_array;
+use function is_string;
 use ReflectionClass;
 use ReflectionMethod;
 use function sprintf;
@@ -19,27 +22,38 @@ class MissingArgumentException extends \BadMethodCallException
         return new self("Expected argument '$argumentName' was not provided");
     }
 
-    public static function wrapWithFactoryContext(self $previous, string $inputType, string $factoryClass, string $factoryMethod): self
+    public static function wrapWithFactoryContext(self $previous, string $inputType, callable $callable): self
     {
-        $message = sprintf('%s in GraphQL input type \'%s\' used in factory \'%s::%s()\'',
+        $message = sprintf('%s in GraphQL input type \'%s\' used in factory \'%s\'',
             $previous->getMessage(),
             $inputType,
-            $factoryClass,
-            $factoryMethod
+            self::toMethod($callable)
             );
 
         return new self($message, 0, $previous);
     }
 
-    public static function wrapWithFieldContext(self $previous, string $name, string $factoryClass, string $factoryMethod): self
+    public static function wrapWithFieldContext(self $previous, string $name, callable $callable): self
     {
-        $message = sprintf('%s in GraphQL query/mutation/field \'%s\' used in method \'%s::%s()\'',
+        $message = sprintf('%s in GraphQL query/mutation/field \'%s\' used in method \'%s\'',
             $previous->getMessage(),
             $name,
-            $factoryClass,
-            $factoryMethod
+            self::toMethod($callable)
         );
 
         return new self($message, 0, $previous);
+    }
+
+    private static function toMethod(callable $callable): string
+    {
+        if (!is_array($callable)) {
+            return '';
+        }
+        if (is_string($callable[0])) {
+            $factoryName = $callable[0];
+        } else {
+            $factoryName = get_class($callable[0]);
+        }
+        return $factoryName.'::'.$callable[1].'()';
     }
 }

--- a/src/Parameters/ParameterInterface.php
+++ b/src/Parameters/ParameterInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Instances of ParameterInterface represent a single PHP parameter in a Query/Mutation/Field.
+ */
+interface ParameterInterface
+{
+    /**
+     * @param object $source
+     * @param array<string, mixed> $args
+     * @param mixed $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public function resolve($source, $args, $context, ResolveInfo $info);
+}

--- a/src/Parameters/SourceParameter.php
+++ b/src/Parameters/SourceParameter.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Typically the first parameter of "external" fields that will be filled with the Source object.
+ */
+class SourceParameter implements ParameterInterface
+{
+    /**
+     * @param object $source
+     * @param array<string, mixed> $args
+     * @param mixed $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public function resolve($source, $args, $context, ResolveInfo $info)
+    {
+        return $source;
+    }
+}

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -64,12 +64,7 @@ class QueryField extends FieldDefinition
                 try {
                     return $parameter->resolve($source, $args, $context, $info);
                 } catch (MissingArgumentException $e) {
-                    if (is_string($resolve[0])) {
-                        $factoryName = $resolve[0];
-                    } else {
-                        $factoryName = get_class($resolve[0]);
-                    }
-                    throw MissingArgumentException::wrapWithFieldContext($e, $this->name, $factoryName, $resolve[1]);
+                    throw MissingArgumentException::wrapWithFieldContext($e, $this->name, $resolve);
                 }
             }, $arguments));
 

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -3,6 +3,10 @@
 
 namespace TheCodingMachine\GraphQLite;
 
+use function array_filter;
+use function array_map;
+use function array_unshift;
+use function array_values;
 use function get_class;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\IDType;
@@ -12,11 +16,15 @@ use GraphQL\Type\Definition\LeafType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
 use function is_array;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
+use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+use TheCodingMachine\GraphQLite\Parameters\SourceParameter;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\DateTimeType;
 use TheCodingMachine\GraphQLite\Types\ID;
@@ -32,7 +40,7 @@ class QueryField extends FieldDefinition
      * QueryField constructor.
      * @param string $name
      * @param OutputType&Type $type
-     * @param array[] $arguments Indexed by argument name, value: ['type'=>InputType, 'defaultValue'=>val].
+     * @param array<string, ParameterInterface> $arguments Indexed by argument name.
      * @param callable|null $resolve The method to execute
      * @param string|null $targetMethodOnSource The name of the method to execute on the source object. Mutually exclusive with $resolve parameter.
      * @param ArgumentResolver $argumentResolver
@@ -40,34 +48,21 @@ class QueryField extends FieldDefinition
      * @param bool $injectSource Whether to inject the source object (for Fields), or null for Query and Mutations
      * @param array $additionalConfig
      */
-    public function __construct(string $name, OutputType $type, array $arguments, ?callable $resolve, ?string $targetMethodOnSource, ArgumentResolver $argumentResolver, ?string $comment, bool $injectSource, array $additionalConfig = [])
+    public function __construct(string $name, OutputType $type, array $arguments, ?callable $resolve, ?string $targetMethodOnSource, ?string $comment, array $additionalConfig = [])
     {
         $config = [
             'name' => $name,
             'type' => $type,
-            'args' => array_map(function(array $item) { return $item['type']; }, $arguments)
+            'args' => self::getInputTypeArgs($arguments)
         ];
         if ($comment) {
             $config['description'] = $comment;
         }
 
-        $config['resolve'] = function ($source, array $args) use ($resolve, $targetMethodOnSource, $arguments, $injectSource, $argumentResolver) {
-            $toPassArgs = [];
-            if ($injectSource) {
-                $toPassArgs[] = $source;
-            }
-            foreach ($arguments as $name => $arr) {
-                $type = $arr['type'];
-                if (isset($args[$name])) {
-                    $val = $argumentResolver->resolve($args[$name], $type);
-                } elseif (array_key_exists('defaultValue', $arr)) {
-                    $val = $arr['defaultValue'];
-                } else {
-                    throw new GraphQLException("Expected argument '$name' was not provided.");
-                }
-
-                $toPassArgs[] = $val;
-            }
+        $config['resolve'] = function ($source, array $args, $context, ResolveInfo $info) use ($resolve, $targetMethodOnSource, $arguments) {
+            $toPassArgs = array_values(array_map(function(ParameterInterface $parameter) use ($source, $args, $context, $info) {
+                return $parameter->resolve($source, $args, $context, $info);
+            }, $arguments));
 
             if ($resolve !== null) {
                 return $resolve(...$toPassArgs);
@@ -84,10 +79,20 @@ class QueryField extends FieldDefinition
     }
 
     /**
+     * @param ParameterInterface[] $args
+     * @return array<string, InputType>
+     */
+    public static function getInputTypeArgs(array $args): array
+    {
+        $inputTypeArgs = array_filter($args, static function(ParameterInterface $parameter) { return $parameter instanceof InputTypeParameter; });
+        return array_map(static function(InputTypeParameter $parameter) { return $parameter->getType(); }, $inputTypeArgs);
+    }
+
+    /**
      * @param mixed $value A value that will always be returned by this field.
      * @return QueryField
      */
-    public static function alwaysReturn(string $name, OutputType $type, array $arguments, $value, ArgumentResolver $argumentResolver, ?string $comment): self
+    public static function alwaysReturn(string $name, OutputType $type, array $arguments, $value, ?string $comment): self
     {
         if ($value === null && $type instanceof NonNull) {
             $type = $type->getWrappedType();
@@ -95,16 +100,19 @@ class QueryField extends FieldDefinition
         $callable = function() use ($value) {
             return $value;
         };
-        return new self($name, $type, $arguments, $callable, null, $argumentResolver, $comment, false);
+        return new self($name, $type, $arguments, $callable, null, $comment);
     }
 
-    public static function selfField(string $name, OutputType $type, array $arguments, string $targetMethodOnSource, ArgumentResolver $argumentResolver, ?string $comment): self
+    public static function selfField(string $name, OutputType $type, array $arguments, string $targetMethodOnSource, ?string $comment): self
     {
-        return new self($name, $type, $arguments, null, $targetMethodOnSource, $argumentResolver, $comment, false);
+        return new self($name, $type, $arguments, null, $targetMethodOnSource, $comment);
     }
 
-    public static function externalField(string $name, OutputType $type, array $arguments, $callable, ArgumentResolver $argumentResolver, ?string $comment, bool $injectSource): self
+    public static function externalField(string $name, OutputType $type, array $arguments, $callable, ?string $comment, bool $injectSource): self
     {
-        return new self($name, $type, $arguments, $callable, null, $argumentResolver, $comment, $injectSource);
+        if ($injectSource === true) {
+            array_unshift($arguments, new SourceParameter());
+        }
+        return new self($name, $type, $arguments, $callable, null, $comment);
     }
 }

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -80,12 +80,20 @@ class QueryField extends FieldDefinition
 
     /**
      * @param ParameterInterface[] $args
-     * @return array<string, InputType>
+     * @return array<string, array<string, mixed|InputType>>
      */
     public static function getInputTypeArgs(array $args): array
     {
         $inputTypeArgs = array_filter($args, static function(ParameterInterface $parameter) { return $parameter instanceof InputTypeParameter; });
-        return array_map(static function(InputTypeParameter $parameter) { return $parameter->getType(); }, $inputTypeArgs);
+        return array_map(static function(InputTypeParameter $parameter) {
+                $desc = [
+                    'type' => $parameter->getType()
+                ];
+                if ($parameter->hasDefaultValue()) {
+                    $desc['defaultValue'] = $parameter->getDefaultValue();
+                }
+                return $desc;
+            }, $inputTypeArgs);
     }
 
     /**

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -43,9 +43,7 @@ class QueryField extends FieldDefinition
      * @param array<string, ParameterInterface> $arguments Indexed by argument name.
      * @param callable|null $resolve The method to execute
      * @param string|null $targetMethodOnSource The name of the method to execute on the source object. Mutually exclusive with $resolve parameter.
-     * @param ArgumentResolver $argumentResolver
      * @param null|string $comment
-     * @param bool $injectSource Whether to inject the source object (for Fields), or null for Query and Mutations
      * @param array $additionalConfig
      */
     public function __construct(string $name, OutputType $type, array $arguments, ?callable $resolve, ?string $targetMethodOnSource, ?string $comment, array $additionalConfig = [])
@@ -53,7 +51,7 @@ class QueryField extends FieldDefinition
         $config = [
             'name' => $name,
             'type' => $type,
-            'args' => self::getInputTypeArgs($arguments)
+            'args' => InputTypeUtils::getInputTypeArgs($arguments)
         ];
         if ($comment) {
             $config['description'] = $comment;
@@ -76,24 +74,6 @@ class QueryField extends FieldDefinition
 
         $config += $additionalConfig;
         parent::__construct($config);
-    }
-
-    /**
-     * @param ParameterInterface[] $args
-     * @return array<string, array<string, mixed|InputType>>
-     */
-    public static function getInputTypeArgs(array $args): array
-    {
-        $inputTypeArgs = array_filter($args, static function(ParameterInterface $parameter) { return $parameter instanceof InputTypeParameter; });
-        return array_map(static function(InputTypeParameter $parameter) {
-                $desc = [
-                    'type' => $parameter->getType()
-                ];
-                if ($parameter->hasDefaultValue()) {
-                    $desc['defaultValue'] = $parameter->getDefaultValue();
-                }
-                return $desc;
-            }, $inputTypeArgs);
     }
 
     /**

--- a/src/Types/ResolvableInputInterface.php
+++ b/src/Types/ResolvableInputInterface.php
@@ -3,6 +3,8 @@
 namespace TheCodingMachine\GraphQLite\Types;
 
 
+use GraphQL\Type\Definition\ResolveInfo;
+
 /**
  * A GraphQL input object that can be resolved
  */
@@ -14,5 +16,5 @@ interface ResolvableInputInterface
      * @param array $args
      * @return object
      */
-    public function resolve(array $args);
+    public function resolve($source, array $args, $context, ResolveInfo $resolveInfo);
 }

--- a/src/Types/ResolvableInputObjectType.php
+++ b/src/Types/ResolvableInputObjectType.php
@@ -97,12 +97,7 @@ class ResolvableInputObjectType extends InputObjectType implements ResolvableInp
             try {
                 $toPassArgs[] = $parameter->resolve($source, $args, $context, $resolveInfo);
             } catch (MissingArgumentException $e) {
-                if (is_string($this->resolve[0])) {
-                    $factoryName = $this->resolve[0];
-                } else {
-                    $factoryName = get_class($this->resolve[0]);
-                }
-                throw MissingArgumentException::wrapWithFactoryContext($e, $this->name, $factoryName, $this->resolve[1]);
+                throw MissingArgumentException::wrapWithFactoryContext($e, $this->name, $this->resolve);
             }
         }
 

--- a/src/Types/ResolvableInputObjectType.php
+++ b/src/Types/ResolvableInputObjectType.php
@@ -8,6 +8,8 @@ use GraphQL\Type\Definition\InputObjectType;
 use ReflectionMethod;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
 use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\InputTypeUtils;
+use TheCodingMachine\GraphQLite\QueryField;
 
 /**
  * A GraphQL input object that can be resolved using a factory
@@ -40,7 +42,9 @@ class ResolvableInputObjectType extends InputObjectType implements ResolvableInp
 
         $fields = function() use ($fieldsBuilder, $factory, $methodName) {
             $method = new ReflectionMethod($factory, $methodName);
-            return $fieldsBuilder->getInputFields($method);
+            $args = $fieldsBuilder->getParameters($method);
+
+            return InputTypeUtils::getInputTypeArgs($args);
         };
 
         $config = [

--- a/src/Types/ResolvableInputObjectType.php
+++ b/src/Types/ResolvableInputObjectType.php
@@ -25,7 +25,6 @@ class ResolvableInputObjectType extends InputObjectType implements ResolvableInp
     private $resolve;
 
     /**
-     * QueryField constructor.
      * @param string $name
      * @param FieldsBuilder $fieldsBuilder
      * @param object|string $factory

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type;
 use Mouf\Picotainer\Picotainer;
@@ -219,7 +220,7 @@ abstract class AbstractQueryProviderTest extends TestCase
     {
         if ($this->hydrator === null) {
             $this->hydrator = new class implements HydratorInterface {
-                public function hydrate(array $data, InputObjectType $type)
+                public function hydrate($source, array $data, $context, ResolveInfo $resolveInfo,InputObjectType $type)
                 {
                     return new TestObject($data['test']);
                 }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -11,6 +11,7 @@ use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\IntType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\UnionType;
@@ -98,13 +99,14 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         ];
 
         $resolve = $usersQuery->resolveFn;
-        $result = $resolve('foo', $context);
+        $resolveInfo = $this->createMock(ResolveInfo::class);
+        $result = $resolve('foo', $context, null, $resolveInfo);
 
         $this->assertInstanceOf(TestObject::class, $result);
         $this->assertSame('foo424212true4.22017010101010120170101010101default42on', $result->getTest());
 
         unset($context['string']); // Testing null default value
-        $result = $resolve('foo', $context);
+        $result = $resolve('foo', $context, null, $resolveInfo);
 
         $this->assertSame('424212true4.22017010101010120170101010101default42on', $result->getTest());
     }
@@ -122,7 +124,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertSame('mutation', $mutation->name);
 
         $resolve = $mutation->resolveFn;
-        $result = $resolve('foo', ['testObject' => ['test' => 42]]);
+        $result = $resolve('foo', ['testObject' => ['test' => 42]], null, $this->createMock(ResolveInfo::class));
 
         $this->assertInstanceOf(TestObject::class, $result);
         $this->assertEquals('42', $result->getTest());
@@ -249,7 +251,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertSame('test', $fields['test']->name);
         $resolve = $fields['test']->resolveFn;
         $obj = new TestSelfType();
-        $this->assertEquals('foo', $resolve($obj, []));
+        $this->assertEquals('foo', $resolve($obj, [], null, $this->createMock(ResolveInfo::class)));
     }
 
     public function testLoggedInSourceField()
@@ -500,7 +502,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertSame('testFailWith', $query->name);
 
         $resolve = $query->resolveFn;
-        $result = $resolve('foo', []);
+        $result = $resolve('foo', [], null, $this->createMock(ResolveInfo::class));
 
         $this->assertNull($result);
 
@@ -522,7 +524,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
 
         $resolve = $fields['test']->resolveFn;
-        $result = $resolve('foo', []);
+        $result = $resolve('foo', [], null, $this->createMock(ResolveInfo::class));
 
         $this->assertNull($result);
 

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -45,6 +45,7 @@ use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
+use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
@@ -561,5 +562,25 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->expectException(InvalidDocBlockException::class);
         $this->expectExceptionMessage('Method TheCodingMachine\\GraphQLite\\Fixtures\\TestDoubleReturnTag::test has several @return annotations.');
         $queryProvider->getFields(new TestDoubleReturnTag(), true);
+    }
+
+    public function testMissingArgument()
+    {
+        $controller = new TestController();
+
+        $queryProvider = $this->buildFieldsBuilder();
+
+        $queries = $queryProvider->getQueries($controller);
+
+        $this->assertCount(7, $queries);
+        $usersQuery = $queries[0];
+        $context = [];
+
+        $resolve = $usersQuery->resolveFn;
+        $resolveInfo = $this->createMock(ResolveInfo::class);
+
+        $this->expectException(MissingArgumentException::class);
+        $this->expectExceptionMessage("Expected argument 'int' was not provided in GraphQL query/mutation/field 'test' used in method 'TheCodingMachine\GraphQLite\Fixtures\TestController::test()'");
+        $resolve('foo', $context, null, $resolveInfo);
     }
 }

--- a/tests/Hydrators/FactoryHydratorTest.php
+++ b/tests/Hydrators/FactoryHydratorTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite\Hydrators;
 
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use TheCodingMachine\GraphQLite\Types\ResolvableInputObjectType;
@@ -26,9 +27,9 @@ class FactoryHydratorTest extends TestCase
         $this->assertTrue($factoryHydrator->canHydrate([], $resolvableInputObjectType));
         $this->assertFalse($factoryHydrator->canHydrate([], $badObjectType));
 
-        $this->assertEquals(new stdClass(), $factoryHydrator->hydrate([], $resolvableInputObjectType));
+        $this->assertEquals(new stdClass(), $factoryHydrator->hydrate(null, [], null, $this->createMock(ResolveInfo::class), $resolvableInputObjectType));
 
         $this->expectException(CannotHydrateException::class);
-        $factoryHydrator->hydrate([], $badObjectType);
+        $factoryHydrator->hydrate(null, [], null, $this->createMock(ResolveInfo::class), $badObjectType);
     }
 }

--- a/tests/Parameters/MissingArgumentExceptionTest.php
+++ b/tests/Parameters/MissingArgumentExceptionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+use PHPUnit\Framework\TestCase;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Filter;
+
+class MissingArgumentExceptionTest extends TestCase
+{
+
+    public function testWrapWithFactoryContext()
+    {
+        $e = MissingArgumentException::create('foo');
+        $e2 = MissingArgumentException::wrapWithFactoryContext($e, 'Input', [Filter::class, 'create']);
+
+        $this->assertEquals('Expected argument \'foo\' was not provided in GraphQL input type \'Input\' used in factory \'TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Filter::create()\'', $e2->getMessage());
+
+        $e3 = MissingArgumentException::wrapWithFactoryContext($e, 'Input', function() {});
+
+        $this->assertEquals('Expected argument \'foo\' was not provided in GraphQL input type \'Input\' used in factory \'\'', $e3->getMessage());
+    }
+}

--- a/tests/Types/ResolvableInputObjectTypeTest.php
+++ b/tests/Types/ResolvableInputObjectTypeTest.php
@@ -2,12 +2,14 @@
 
 namespace TheCodingMachine\GraphQLite\Types;
 
+use GraphQL\Type\Definition\ResolveInfo;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
 use TheCodingMachine\GraphQLite\Fixtures\TestObjectWithRecursiveList;
 use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory;
 use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 
 class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
 {
@@ -25,19 +27,21 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
         $this->assertCount(2, $inputType->getFields());
         $this->assertSame('my comment', $inputType->description);
 
-        $obj = $inputType->resolve(['string' => 'foobar', 'bool' => false]);
+        $resolveInfo = $this->createMock(ResolveInfo::class);
+
+        $obj = $inputType->resolve(null, ['string' => 'foobar', 'bool' => false], null, $resolveInfo);
         $this->assertInstanceOf(TestObject::class, $obj);
         $this->assertSame('foobar', $obj->getTest());
         $this->assertSame(false, $obj->isTestBool());
 
-        $obj = $inputType->resolve(['string' => 'foobar']);
+        $obj = $inputType->resolve(null, ['string' => 'foobar'], null, $resolveInfo);
         $this->assertInstanceOf(TestObject::class, $obj);
         $this->assertSame('foobar', $obj->getTest());
         $this->assertSame(true, $obj->isTestBool());
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(MissingArgumentException::class);
         $this->expectExceptionMessage("Expected argument 'string' was not provided in GraphQL input type 'InputObject' used in factory 'TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory::myFactory()'");
-        $inputType->resolve([]);
+        $inputType->resolve(null, [], null, $resolveInfo);
     }
 
     public function testListResolve(): void
@@ -49,14 +53,14 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
             $this->getArgumentResolver(),
             null);
 
-        $obj = $inputType->resolve(['date' => '2018-12-25', 'stringList' =>
+        $obj = $inputType->resolve(null, ['date' => '2018-12-25', 'stringList' =>
             [
                 'foo',
                 'bar'
             ],
             'dateList' => [
                 '2018-12-25'
-            ]]);
+            ]], null, $this->createMock(ResolveInfo::class));
         $this->assertInstanceOf(TestObject2::class, $obj);
         $this->assertSame('2018-12-25-foo-bar-1', $obj->getTest2());
     }


### PR DESCRIPTION
Objects implementing the `ParameterInterface` represent parameters (in methods) that will be filled by GraphQLite.
This paves the way to allowing adding custom parameter handlers in the future.