### PR TITLE
Adding the ability to inject ResolveInfo into method arguments

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -10,8 +10,9 @@ sidebar_label: Internals
 The core of GraphQLite is its ability to map PHP types to GraphQL types. This mapping is performed by a series of
 "type mappers".
 
-GraphQLite contains 3 categories of type mappers:
+GraphQLite contains 4 categories of type mappers:
 
+- **Parameter mappers**
 - **Root type mappers**
 - **Recursive (class) type mappers**
 - **(class) type mappers**
@@ -99,3 +100,26 @@ This is the role of the "recursive type mapper".
 Imagine that class "B" extends class "A" and class "A" maps to GraphQL type "AType".
 
 Since "B" *is a* "A", the "recursive type mapper" role is to make sure that "B" will also map to GraphQL type "AType". 
+
+## Parameter mappers
+
+"Parameter mappers" are used to decide what argument should be injected into a parameter.
+
+Let's have a look at a simple query:
+
+```php
+/**
+ * @Query
+ * @return Product[]
+ */
+public function products(ResolveInfo $info): array
+```
+
+As you may know, [the `ResolveInfo` object injected in this query comes from Webonyx/GraphQL-PHP library](query_plan.md).
+GraphQLite knows that is must inject a `ResolveInfo` instance because it comes with a `ResolveInfoParameterMapper` class
+that implements the [`ParameterMapperInterface`](https://github.com/thecodingmachine/graphqlite/blob/master/src/Mappers/Parameters/ParameterMapperInterface.php)).
+
+You can register your own parameter mappers using the `SchemaFactory::addParameterMapper()` method.
+
+<div class="alert alert-info">Use a parameter mapper if you want to inject an argument in a method and if this argument
+is not a GraphQL input type</div>

--- a/docs/query_plan.md
+++ b/docs/query_plan.md
@@ -1,0 +1,68 @@
+---
+id: query-plan
+title: Query plan
+sidebar_label: Query plan
+---
+
+## The problem
+
+GraphQL naive implementations often suffer from the "N+1" problem.
+
+Let's have a look at the following query:
+
+```graphql
+{
+    products {
+        name
+        manufacturer {
+            name
+        }
+    }
+}
+```
+
+A naive implementation will do this:
+
+- 1 query to fetch the list of products
+- 1 query per product to fetch the manufacturer
+
+Assuming we have "N" products, we will make "N+1" queries.
+
+There are several ways to fix this problem. Assuming you are using a relational database, one solution is to try to look 
+ahead and perform only one query with a JOIN between "products" and "manufacturers".
+
+But how do I know if I should make the JOIN between "products" and "manufacturers" or not? I need to know ahead
+of time.
+
+With GraphQLite, you can answer this question by tapping into the `ResolveInfo` object.
+
+## Fetching the query plan
+
+```php
+use GraphQL\Type\Definition\ResolveInfo;
+
+class ProductsController
+{
+    /**
+     * @Query
+     * @return Product[]
+     */
+    public function products(ResolveInfo $info): array
+    {
+        if (isset($info->getFieldSelection()['manufacturer']) {
+            // Let's perform a request with a JOIN on manufacturer
+        } else {
+            // Let's perform a request without a JOIN on manufacturer
+        }
+        // ...
+    }
+}
+```
+
+`ResolveInfo` is a class provided by Webonyx/GraphQL-PHP (the low-level GraphQL library used by GraphQLite).
+It contains info about the query and what fields are requested. Using `ResolveInfo::getFieldSelection` you can analyze the query 
+and decide whether you should perform additional "JOINS" in your query or not.
+
+<div class="alert alert-info">As of the writing of this documentation, the <code>ResolveInfo</code> class is useful but somewhat limited.
+The <a href="https://github.com/webonyx/graphql-php/pull/436">next version of Webonyx/GraphQL-PHP will add a "query plan"</a>
+that allows a deeper analysis of the query.</div>

--- a/docs/type_mapping.md
+++ b/docs/type_mapping.md
@@ -104,7 +104,7 @@ public function getId(): string
 
 Using the `outputType` attribute of the `@Field` annotation, you can force the output type to `ID`.
 
-You can learn more about forcing output types in the [custom output types section](custom_output_types.md).
+You can learn more about forcing output types in the [custom types section](custom_types.md).
 
 ### ID class
 

--- a/src/Mappers/Parameters/CompositeParameterMapper.php
+++ b/src/Mappers/Parameters/CompositeParameterMapper.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
+
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\NamedType;
+use GraphQL\Type\Definition\OutputType;
+use function is_array;
+use function iterator_to_array;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use ReflectionMethod;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+
+class CompositeParameterMapper implements ParameterMapperInterface
+{
+    /**
+     * @var ParameterMapperInterface[]
+     */
+    private $parameterMappers;
+
+    /**
+     * @param ParameterMapperInterface[] $parameterMappers
+     */
+    public function __construct(iterable $parameterMappers)
+    {
+        $this->parameterMappers = is_array($parameterMappers) ? $parameterMappers : iterator_to_array($parameterMappers);
+    }
+
+    /**
+     * @param array<string, DocBlock\Tags\Param> $paramTags
+     */
+    public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, array $paramTags): ?ParameterInterface
+    {
+        foreach ($this->parameterMappers as $parameterMapper) {
+            $parameterObj = $parameterMapper->mapParameter($parameter, $docBlock, $paramTags);
+            if ($parameterObj !== null) {
+                return $parameterObj;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Mappers/Parameters/ParameterMapperInterface.php
+++ b/src/Mappers/Parameters/ParameterMapperInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
+
+
+use phpDocumentor\Reflection\DocBlock;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+
+interface ParameterMapperInterface
+{
+    /**
+     * @param array<string, DocBlock\Tags\Param> $paramTags
+     */
+    public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, array $paramTags): ?ParameterInterface;
+}

--- a/src/Mappers/Parameters/ResolveInfoParameterMapper.php
+++ b/src/Mappers/Parameters/ResolveInfoParameterMapper.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
+
+
+use GraphQL\Type\Definition\ResolveInfo;
+use phpDocumentor\Reflection\DocBlock;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+use TheCodingMachine\GraphQLite\Parameters\ResolveInfoParameter;
+
+class ResolveInfoParameterMapper implements ParameterMapperInterface
+{
+    public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, array $paramTags): ?ParameterInterface
+    {
+        $type = $parameter->getType();
+        if ($type!== null && $type->getName() === ResolveInfo::class) {
+            return new ResolveInfoParameter();
+        }
+        return null;
+    }
+}

--- a/src/Mappers/Parameters/TypeMapper.php
+++ b/src/Mappers/Parameters/TypeMapper.php
@@ -1,0 +1,395 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
+
+
+use function array_filter;
+use function count;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Iterator;
+use IteratorAggregate;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tags\Return_;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\TypeResolver as PhpDocumentorTypeResolver;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Iterable_;
+use phpDocumentor\Reflection\Types\Mixed_;
+use phpDocumentor\Reflection\Types\Null_;
+use phpDocumentor\Reflection\Types\Nullable;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\Self_;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\InvalidDocBlockException;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+use TheCodingMachine\GraphQLite\TypeMappingException;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
+use TheCodingMachine\GraphQLite\Types\UnionType;
+
+class TypeMapper implements ParameterMapperInterface
+{
+    /**
+     * @var PhpDocumentorTypeResolver
+     */
+    private $typeResolver;
+    /**
+     * @var RecursiveTypeMapperInterface
+     */
+    private $recursiveTypeMapper;
+    /**
+     * @var ArgumentResolver
+     */
+    private $argumentResolver;
+    /**
+     * @var RootTypeMapperInterface
+     */
+    private $rootTypeMapper;
+
+    public function __construct(RecursiveTypeMapperInterface $typeMapper,
+                                ArgumentResolver $argumentResolver,
+                                RootTypeMapperInterface $rootTypeMapper)
+    {
+        $this->recursiveTypeMapper = $typeMapper;
+        $this->argumentResolver = $argumentResolver;
+        $this->rootTypeMapper = $rootTypeMapper;
+        $this->typeResolver = new PhpDocumentorTypeResolver();
+    }
+
+    /**
+     * @return GraphQLType&OutputType
+     */
+    public function mapReturnType(ReflectionMethod $refMethod, DocBlock $docBlockObj): GraphQLType
+    {
+        $returnType = $refMethod->getReturnType();
+        if ($returnType !== null) {
+            $phpdocType = $this->typeResolver->resolve((string) $returnType);
+            $phpdocType = $this->resolveSelf($phpdocType, $refMethod->getDeclaringClass());
+        } else {
+            $phpdocType = new Mixed_();
+        }
+
+        $docBlockReturnType = $this->getDocBlocReturnType($docBlockObj, $refMethod);
+
+        try {
+            /** @var GraphQLType&OutputType $type */
+            $type = $this->mapType($phpdocType, $docBlockReturnType, $returnType ? $returnType->allowsNull() : false, false, $refMethod, $docBlockObj);
+        } catch (TypeMappingException $e) {
+            throw TypeMappingException::wrapWithReturnInfo($e, $refMethod);
+        } catch (CannotMapTypeExceptionInterface $e) {
+            throw CannotMapTypeException::wrapWithReturnInfo($e, $refMethod);
+        }
+        return $type;
+    }
+
+    private function getDocBlocReturnType(DocBlock $docBlock, \ReflectionMethod $refMethod): ?Type
+    {
+        /** @var Return_[] $returnTypeTags */
+        $returnTypeTags = $docBlock->getTagsByName('return');
+        if (count($returnTypeTags) > 1) {
+            throw InvalidDocBlockException::tooManyReturnTags($refMethod);
+        }
+        $docBlockReturnType = null;
+        if (isset($returnTypeTags[0])) {
+            $docBlockReturnType = $returnTypeTags[0]->getType();
+        }
+        return $docBlockReturnType;
+    }
+
+    /**
+     * @param array<string, DocBlock\Tags\Param> $paramTags
+     */
+    public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, array $paramTags): ParameterInterface
+    {
+        $parameterType = $parameter->getType();
+        $allowsNull = $parameterType === null ? true : $parameterType->allowsNull();
+
+        $type = (string) $parameterType;
+        if ($type === '') {
+            $phpdocType = new Mixed_();
+            $allowsNull = false;
+            //throw MissingTypeHintException::missingTypeHint($parameter);
+        } else {
+            $phpdocType = $this->typeResolver->resolve($type);
+            $phpdocType = $this->resolveSelf($phpdocType, $parameter->getDeclaringClass());
+        }
+
+        $docBlockType = $paramTags[$parameter->getName()] ?? null;
+
+        try {
+            $type = $this->mapType($phpdocType, $docBlockType, $allowsNull || $parameter->isDefaultValueAvailable(), true, $parameter->getDeclaringFunction(), $docBlock, $parameter->getName());
+        } catch (TypeMappingException $e) {
+            throw TypeMappingException::wrapWithParamInfo($e, $parameter);
+        } catch (CannotMapTypeExceptionInterface $e) {
+            throw CannotMapTypeException::wrapWithParamInfo($e, $parameter);
+        }
+
+        $hasDefaultValue = false;
+        $defaultValue = null;
+        if ($parameter->allowsNull()) {
+            $hasDefaultValue = true;
+        }
+        if ($parameter->isDefaultValueAvailable()) {
+            $hasDefaultValue = true;
+            $defaultValue = $parameter->getDefaultValue();
+        }
+
+        return new InputTypeParameter($parameter->getName(), $type, $hasDefaultValue, $defaultValue, $this->argumentResolver);
+    }
+
+    private function mapType(Type $type, ?Type $docBlockType, bool $isNullable, bool $mapToInputType, ReflectionMethod $refMethod, DocBlock $docBlockObj, string $argumentName = null): GraphQLType
+    {
+        $graphQlType = null;
+
+        if ($type instanceof Array_ || $type instanceof Iterable_ || $type instanceof Mixed_) {
+            $graphQlType = $this->mapDocBlockType($type, $docBlockType, $isNullable, $mapToInputType, $refMethod, $docBlockObj, $argumentName);
+        } else {
+            try {
+                $graphQlType = $this->toGraphQlType($type, null, $mapToInputType, $refMethod, $docBlockObj, $argumentName);
+                if (!$isNullable) {
+                    $graphQlType = GraphQLType::nonNull($graphQlType);
+                }
+            } catch (TypeMappingException | CannotMapTypeExceptionInterface $e) {
+                // Is the type iterable? If yes, let's analyze the docblock
+                // TODO: it would be better not to go through an exception for this.
+                if ($type instanceof Object_) {
+                    $fqcn = (string) $type->getFqsen();
+                    $refClass = new ReflectionClass($fqcn);
+                    // Note : $refClass->isIterable() is only accessible in PHP 7.2
+                    if ($refClass->implementsInterface(Iterator::class) || $refClass->implementsInterface(IteratorAggregate::class)) {
+                        $graphQlType = $this->mapIteratorDocBlockType($type, $docBlockType, $isNullable, $refMethod, $docBlockObj, $argumentName);
+                    } else {
+                        throw $e;
+                    }
+                } else {
+                    throw $e;
+                }
+            }
+        }
+
+        return $graphQlType;
+    }
+
+    private function mapDocBlockType(Type $type, ?Type $docBlockType, bool $isNullable, bool $mapToInputType, ReflectionMethod $refMethod, DocBlock $docBlockObj, string $argumentName = null): GraphQLType
+    {
+        if ($docBlockType === null) {
+            throw TypeMappingException::createFromType($type);
+        }
+        if (!$isNullable) {
+            // Let's check a "null" value in the docblock
+            $isNullable = $this->isNullable($docBlockType);
+        }
+
+        $filteredDocBlockTypes = $this->typesWithoutNullable($docBlockType);
+        if (empty($filteredDocBlockTypes)) {
+            throw TypeMappingException::createFromType($type);
+        }
+
+        $unionTypes = [];
+        $lastException = null;
+        foreach ($filteredDocBlockTypes as $singleDocBlockType) {
+            try {
+                $unionTypes[] = $this->toGraphQlType($this->dropNullableType($singleDocBlockType), null, $mapToInputType, $refMethod, $docBlockObj, $argumentName);
+            } catch (TypeMappingException | CannotMapTypeExceptionInterface $e) {
+                // We have several types. It is ok not to be able to match one.
+                $lastException = $e;
+            }
+        }
+
+        if (empty($unionTypes) && $lastException !== null) {
+            throw $lastException;
+        }
+
+        if (count($unionTypes) === 1) {
+            $graphQlType = $unionTypes[0];
+        } else {
+            $graphQlType = new UnionType($unionTypes, $this->recursiveTypeMapper);
+        }
+
+        /* elseif (count($filteredDocBlockTypes) === 1) {
+            $graphQlType = $this->toGraphQlType($filteredDocBlockTypes[0], $mapToInputType);
+        } else {
+            throw new GraphQLException('Union types are not supported (yet)');
+            //$graphQlTypes = array_map([$this, 'toGraphQlType'], $filteredDocBlockTypes);
+            //$$graphQlType = new UnionType($graphQlTypes);
+        }*/
+
+        if (!$isNullable) {
+            $graphQlType = GraphQLType::nonNull($graphQlType);
+        }
+        return $graphQlType;
+    }
+
+    /**
+     * Maps a type where the main PHP type is an iterator
+     */
+    private function mapIteratorDocBlockType(Type $type, ?Type $docBlockType, bool $isNullable, ReflectionMethod $refMethod, DocBlock $docBlockObj, string $argumentName = null): GraphQLType
+    {
+        if ($docBlockType === null) {
+            throw TypeMappingException::createFromType($type);
+        }
+        if (!$isNullable) {
+            // Let's check a "null" value in the docblock
+            $isNullable = $this->isNullable($docBlockType);
+        }
+
+        $filteredDocBlockTypes = $this->typesWithoutNullable($docBlockType);
+        if (empty($filteredDocBlockTypes)) {
+            throw TypeMappingException::createFromType($type);
+        }
+
+        $unionTypes = [];
+        $lastException = null;
+        foreach ($filteredDocBlockTypes as $singleDocBlockType) {
+            try {
+                $singleDocBlockType = $this->getTypeInArray($singleDocBlockType);
+                if ($singleDocBlockType !== null) {
+                    $subGraphQlType = $this->toGraphQlType($singleDocBlockType, null, false, $refMethod, $docBlockObj);
+                } else {
+                    $subGraphQlType = null;
+                }
+
+                $unionTypes[] = $this->toGraphQlType($type, $subGraphQlType, false, $refMethod, $docBlockObj);
+
+                // TODO: add here a scan of the $type variable and do stuff if it is iterable.
+                // TODO: remove the iterator type if specified in the docblock (@return Iterator|User[])
+                // TODO: check there is at least one array (User[])
+            } catch (TypeMappingException | CannotMapTypeExceptionInterface $e) {
+                // We have several types. It is ok not to be able to match one.
+                $lastException = $e;
+            }
+        }
+
+        if (empty($unionTypes) && $lastException !== null) {
+            // We have an issue, let's try without the subType
+            return $this->mapDocBlockType($type, $docBlockType, $isNullable, false, $refMethod, $docBlockObj);
+        }
+
+        if (count($unionTypes) === 1) {
+            $graphQlType = $unionTypes[0];
+        } else {
+            $graphQlType = new UnionType($unionTypes, $this->recursiveTypeMapper);
+        }
+
+        if (!$isNullable) {
+            $graphQlType = GraphQLType::nonNull($graphQlType);
+        }
+        return $graphQlType;
+    }
+
+    /**
+     * Casts a Type to a GraphQL type.
+     * Does not deal with nullable.
+     *
+     * @param Type $type
+     * @param GraphQLType|null $subType
+     * @param bool $mapToInputType
+     * @return GraphQLType (InputType&GraphQLType)|(OutputType&GraphQLType)
+     * @throws CannotMapTypeExceptionInterface
+     */
+    private function toGraphQlType(Type $type, ?GraphQLType $subType, bool $mapToInputType, ReflectionMethod $refMethod, DocBlock $docBlockObj, string $argumentName = null): GraphQLType
+    {
+        if ($mapToInputType === true) {
+            $mappedType = $this->rootTypeMapper->toGraphQLInputType($type, $subType, $argumentName, $refMethod, $docBlockObj);
+        } else {
+            $mappedType = $this->rootTypeMapper->toGraphQLOutputType($type, $subType, $refMethod, $docBlockObj);
+        }
+        if ($mappedType === null) {
+            throw TypeMappingException::createFromType($type);
+        }
+        return $mappedType;
+    }
+
+    /**
+     * Removes "null" from the type (if it is compound). Return an array of types (not a Compound type).
+     *
+     * @param Type $docBlockTypeHint
+     * @return array
+     */
+    private function typesWithoutNullable(Type $docBlockTypeHint): array
+    {
+        if ($docBlockTypeHint instanceof Compound) {
+            $docBlockTypeHints = \iterator_to_array($docBlockTypeHint);
+        } else {
+            $docBlockTypeHints = [$docBlockTypeHint];
+        }
+        return array_filter($docBlockTypeHints, function ($item) {
+            return !$item instanceof Null_;
+        });
+    }
+
+    /**
+     * Drops "Nullable" types and return the core type.
+     *
+     * @param Type $typeHint
+     * @return Type
+     */
+    private function dropNullableType(Type $typeHint): Type
+    {
+        if ($typeHint instanceof Nullable) {
+            return $typeHint->getActualType();
+        }
+        return $typeHint;
+    }
+
+    /**
+     * Resolves a list type.
+     *
+     * @param Type $typeHint
+     * @return Type|null
+     */
+    private function getTypeInArray(Type $typeHint): ?Type
+    {
+        $typeHint = $this->dropNullableType($typeHint);
+
+        if (!$typeHint instanceof Array_) {
+            return null;
+        }
+
+        return $this->dropNullableType($typeHint->getValueType());
+    }
+
+    /**
+     * @param Type $docBlockTypeHint
+     * @return bool
+     */
+    private function isNullable(Type $docBlockTypeHint): bool
+    {
+        if ($docBlockTypeHint instanceof Null_) {
+            return true;
+        }
+        if ($docBlockTypeHint instanceof Compound) {
+            foreach ($docBlockTypeHint as $type) {
+                if ($type instanceof Null_) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolves "self" types into the class type.
+     *
+     * @param Type $type
+     * @return Type
+     */
+    private function resolveSelf(Type $type, ReflectionClass $reflectionClass): Type
+    {
+        if ($type instanceof Self_) {
+            return new Object_(new Fqsen('\\'.$reflectionClass->getName()));
+        }
+        return $type;
+    }
+}

--- a/src/Parameters/ResolveInfoParameter.php
+++ b/src/Parameters/ResolveInfoParameter.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A parameter type-hinted to ResolveInfo
+ */
+class ResolveInfoParameter implements ParameterInterface
+{
+    /**
+     * @param object $source
+     * @param array<string, mixed> $args
+     * @param mixed $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public function resolve($source, $args, $context, ResolveInfo $info)
+    {
+        return $info;
+    }
+}

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -22,6 +22,7 @@ use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
@@ -230,7 +231,7 @@ class SchemaFactory
         $argumentResolver = new ArgumentResolver($hydrator);
 
         $parameterMappers = $this->parameterMappers;
-        // TODO: add ResolveInfo parameter mapper when ready.
+        $parameterMappers[] = new ResolveInfoParameterMapper();
         $compositeParameterMapper = new CompositeParameterMapper($parameterMappers);
 
         $fieldsBuilder = new FieldsBuilder(

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -20,6 +20,8 @@ use TheCodingMachine\GraphQLite\Hydrators\FactoryHydrator;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
@@ -57,6 +59,10 @@ class SchemaFactory
      * @var TypeMapperInterface[]
      */
     private $typeMappers = [];
+    /**
+     * @var ParameterMapperInterface[]
+     */
+    private $parameterMappers = [];
     private $doctrineAnnotationReader;
     /**
      * @var HydratorInterface|null
@@ -86,10 +92,6 @@ class SchemaFactory
      * @var SchemaConfig
      */
     private $schemaConfig;
-    /**
-     * @var LockFactory
-     */
-    private $lockFactory;
 
     public function __construct(CacheInterface $cache, ContainerInterface $container)
     {
@@ -227,9 +229,14 @@ class SchemaFactory
 
         $argumentResolver = new ArgumentResolver($hydrator);
 
+        $parameterMappers = $this->parameterMappers;
+        // TODO: add ResolveInfo parameter mapper when ready.
+        $compositeParameterMapper = new CompositeParameterMapper($parameterMappers);
+
         $fieldsBuilder = new FieldsBuilder(
             $annotationReader, $recursiveTypeMapper, $argumentResolver, $authenticationService,
-            $authorizationService, $typeResolver, $cachedDocBlockFactory, $namingStrategy, $compositeRootTypeMapper
+            $authorizationService, $typeResolver, $cachedDocBlockFactory, $namingStrategy, $compositeRootTypeMapper,
+            $compositeParameterMapper
         );
 
 

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -27,6 +27,7 @@ use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
@@ -284,7 +285,7 @@ abstract class AbstractQueryProviderTest extends TestCase
                 new BaseTypeMapper($this->getTypeMapper())
             ]),
             new CompositeParameterMapper([
-
+                new ResolveInfoParameterMapper()
             ])
         );
     }

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -26,6 +26,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory;
 use TheCodingMachine\GraphQLite\Hydrators\HydratorInterface;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
@@ -281,6 +282,9 @@ abstract class AbstractQueryProviderTest extends TestCase
             new CompositeRootTypeMapper([
                 new MyCLabsEnumTypeMapper(),
                 new BaseTypeMapper($this->getTypeMapper())
+            ]),
+            new CompositeParameterMapper([
+
             ])
         );
     }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -29,6 +29,7 @@ use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithIterableReturnType;
 use TheCodingMachine\GraphQLite\Fixtures\TestDoubleReturnTag;
 use TheCodingMachine\GraphQLite\Fixtures\TestFieldBadOutputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
+use TheCodingMachine\GraphQLite\Fixtures\TestResolveInfo;
 use TheCodingMachine\GraphQLite\Fixtures\TestSelfType;
 use TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType2;
@@ -44,6 +45,7 @@ use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
@@ -273,7 +275,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new CachedDocBlockFactory(new ArrayCache()),
             new NamingStrategy(),
             new BaseTypeMapper($this->getTypeMapper()),
-            new CompositeParameterMapper([])
+            new CompositeParameterMapper([ new ResolveInfoParameterMapper() ])
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -300,7 +302,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new CachedDocBlockFactory(new ArrayCache()),
             new NamingStrategy(),
             new BaseTypeMapper($this->getTypeMapper()),
-            new CompositeParameterMapper([])
+            new CompositeParameterMapper([ new ResolveInfoParameterMapper() ])
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -359,7 +361,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new CachedDocBlockFactory(new ArrayCache()),
             new NamingStrategy(),
             new BaseTypeMapper($this->getTypeMapper()),
-            new CompositeParameterMapper([])
+            new CompositeParameterMapper([ new ResolveInfoParameterMapper() ])
         );
         $fields = $queryProvider->getFields(new TestTypeWithSourceFieldInterface(), true);
         $this->assertCount(1, $fields);

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -43,6 +43,7 @@ use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
@@ -271,7 +272,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
             new NamingStrategy(),
-            new BaseTypeMapper($this->getTypeMapper())
+            new BaseTypeMapper($this->getTypeMapper()),
+            new CompositeParameterMapper([])
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -297,7 +299,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
             new NamingStrategy(),
-            new BaseTypeMapper($this->getTypeMapper())
+            new BaseTypeMapper($this->getTypeMapper()),
+            new CompositeParameterMapper([])
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -355,7 +358,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             $this->getTypeResolver(),
             new CachedDocBlockFactory(new ArrayCache()),
             new NamingStrategy(),
-            new BaseTypeMapper($this->getTypeMapper())
+            new BaseTypeMapper($this->getTypeMapper()),
+            new CompositeParameterMapper([])
         );
         $fields = $queryProvider->getFields(new TestTypeWithSourceFieldInterface(), true);
         $this->assertCount(1, $fields);

--- a/tests/Fixtures/Integration/Controllers/FilterController.php
+++ b/tests/Fixtures/Integration/Controllers/FilterController.php
@@ -4,9 +4,9 @@
 namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Controllers;
 
 
+use GraphQL\Type\Definition\ResolveInfo;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Filter;
-use function var_export;
 
 class FilterController
 {
@@ -17,5 +17,14 @@ class FilterController
     public function echoFilters(Filter $filter): array
     {
         return $filter->getValues();
+    }
+
+    /**
+     * @Query()
+     * @return string
+     */
+    public function echoResolveInfo(ResolveInfo $info): string
+    {
+        return $info->fieldName;
     }
 }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -23,6 +23,7 @@ use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
@@ -190,7 +191,7 @@ class EndToEndTest extends TestCase
             },
             ParameterMapperInterface::class => function(ContainerInterface $container) {
                 return new CompositeParameterMapper([
-
+                    new ResolveInfoParameterMapper()
                 ]);
             }
         ]);
@@ -522,4 +523,26 @@ class EndToEndTest extends TestCase
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
 
+    public function testEndToEndResolveInfo()
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            echoResolveInfo
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'echoResolveInfo' => 'echoResolveInfo'
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
 }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -21,6 +21,8 @@ use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
@@ -72,7 +74,8 @@ class EndToEndTest extends TestCase
                     $container->get(TypeResolver::class),
                     $container->get(CachedDocBlockFactory::class),
                     $container->get(NamingStrategyInterface::class),
-                    $container->get(RootTypeMapperInterface::class)
+                    $container->get(RootTypeMapperInterface::class),
+                    $container->get(ParameterMapperInterface::class)
                 );
             },
             ArgumentResolver::class => function(ContainerInterface $container) {
@@ -183,6 +186,11 @@ class EndToEndTest extends TestCase
                 return new CompositeRootTypeMapper([
                     new MyCLabsEnumTypeMapper(),
                     new BaseTypeMapper($container->get(RecursiveTypeMapperInterface::class))
+                ]);
+            },
+            ParameterMapperInterface::class => function(ContainerInterface $container) {
+                return new CompositeParameterMapper([
+
                 ]);
             }
         ]);

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,6 +3,7 @@
     "Introduction": ["features"],
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
     "Usage": ["queries", "mutations", "type_mapping", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance"],
+    "Performance": ["query-plan"],
     "Advanced": ["file-uploads", "pagination", "custom-types", "internals", "troubleshooting", "migrating"],
     "Reference": ["annotations_reference"]
   }


### PR DESCRIPTION
This PR adds the ability to inject a parameter type-hinted to ResolveInfo in any query/mutation/field method.
Using the `ResolveInfo` class, one can analyse the query and perform
requests in database accordingly in order to avoid the N+1 problem.

Closes #46.