### PR TITLE
Configure globTtl in SchemaFactory

### DIFF
--- a/docs/other_frameworks.md
+++ b/docs/other_frameworks.md
@@ -59,6 +59,14 @@ $factory->setNamingStrategy(new NamingStrategy());
 $factory->addTypeMapper($typeMapper);
 // Add custom options to the Webonyx underlying Schema.
 $factory->setSchemaConfig($schemaConfig);
+// Configures the time-to-live for the GraphQLite cache. Defaults to 2 seconds in dev mode.
+$factory->setGlobTtl(2);
+// Enables prod-mode (cache settings optimized for best performance).
+// This is a shortcut for `$schemaFactory->setGlobTtl(null)`
+$factory->prodMode();
+// Enables dev-mode (this is the default mode: cache settings optimized for best developer experience).
+// This is a shortcut for `$schemaFactory->setGlobTtl(2)`
+$factory->devMode();
 ```
 
 ## Minimal example

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -52,7 +52,9 @@ class SchemaFactoryTest extends TestCase
                 ->setNamingStrategy(new NamingStrategy())
                 ->addTypeMapper(new CompositeTypeMapper())
                 ->addRootTypeMapper(new CompositeRootTypeMapper([]))
-                ->setSchemaConfig(new SchemaConfig());
+                ->setSchemaConfig(new SchemaConfig())
+                ->devMode()
+                ->prodMode();
 
         $schema = $factory->createSchema();
 


### PR DESCRIPTION
This PR adds the ability to configure the TTL of the "glob" caches from the SchemaFactory.
It also adds a "prodMode()" and a "devMode()" method to SchemaFactory to help setting this cache to sensible values.