### PR TITLE
Adding deferred support

### DIFF
--- a/docs/prefetch_method.md
+++ b/docs/prefetch_method.md
@@ -1,0 +1,113 @@
+---
+id: prefetch-method
+title: Prefetching records
+sidebar_label: Prefetching records
+---
+
+## The problem
+
+GraphQL naive implementations often suffer from the "N+1" problem.
+
+Consider a request where a user attached to a post must be returned:
+
+```graphql
+{
+    posts {
+        id
+        user {
+            id
+        }
+    }
+}
+```
+
+A naive implementation will do this:
+
+- 1 query to fetch the list of posts
+- 1 query per post to fetch the user
+
+Assuming we have "N" posts, we will make "N+1" queries.
+
+There are several ways to fix this problem. 
+Assuming you are using a relational database, one solution is to try to look 
+ahead and perform only one query with a JOIN between "posts" and "users".
+This method is described in the ["analyzing the query plan" documentation](query_plan.md).
+
+But this can be difficult to implement. This is also only useful for relational databases. If your data comes from a 
+NoSQL database or from the cache, this will not help.
+
+Instead, GraphQLite offers an easier to implement solution: the ability to fetch all fields from a given type at once.
+
+## The "prefetch" method
+
+```php
+/**
+ * @Type
+ */
+class PostType {
+    /**
+     * @Field(prefetchMethod="prefetchUsers")
+     * @param Post $post
+     * @param mixed $prefetchedUsers
+     * @return User
+     */
+    public function getUser(Post $post, $prefetchedUsers): User
+    {
+        // This method will receive the $prefetchedUsers as second argument. This is the return value of the "prefetchUsers" method below.
+        // Using this prefetched list, it should be easy to map it to the post
+    }
+
+    /**
+     * @param Post[] $posts
+     * @return mixed
+     */
+    public function prefetchUsers(iterable $posts)
+    {
+        // This function is called only once per GraphQL request
+        // with the list of posts. You can fetch the list of users
+        // associated with this posts in a single request,
+        // for instance using a "IN" query in SQL or a multi-fetch
+        // in your cache back-end.
+    }
+}
+```
+
+When the "prefetchMethod" attribute is detected in the "@Field" annotation, the method is called automatically.
+The first argument of the method is an array of instances of the main type.
+The "prefetchMethod" can return absolutely anything (mixed). The return value will be passed as the second parameter of the "@Field" annotated method.
+
+## Input arguments
+
+Field arguments can be set either on the @Field annotated method OR/AND on the prefetchMethod.
+
+For instance:
+
+```php
+/**
+ * @Type
+ */
+class PostType {
+    /**
+     * @Field(prefetchMethod="prefetchComments")
+     * @param Post $post
+     * @param mixed $prefetchedComments
+     * @return Comment[]
+     */
+    public function getComments(Post $post, $prefetchedComments): array
+    {
+        // ...
+    }
+
+    /**
+     * @param Post[] $posts
+     * @return mixed
+     */
+    public function prefetchComments(iterable $posts, bool $hideSpam, int $filterByScore)
+    {
+        // Parameters passed after the first parameter (hideSpam, filterByScore...) are automatically exposed 
+        // as GraphQL arguments for the "comments" field.
+    }
+}
+```
+
+The prefetch method MUST be in the same class as the @Field-annotated method and MUST be public.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,6 @@ parameters:
         - "#PHPDoc tag \\@throws with type Psr\\\\Container\\\\ContainerExceptionInterface is not subtype of Throwable#"
         - "#Property TheCodingMachine\\\\GraphQLite\\\\Types\\\\ResolvableInputObjectType::$resolve \\(array<int, object|string>&callable\\) does not accept array<int,object|string>#"
         - "#Variable \\$failWith might not be defined#"
+        - "#Variable \\$prefetchRefMethod might not be defined.#"
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/Annotations/Field.php
+++ b/src/Annotations/Field.php
@@ -8,9 +8,30 @@ namespace TheCodingMachine\GraphQLite\Annotations;
  * @Annotation
  * @Target({"METHOD"})
  * @Attributes({
+ *   @Attribute("name", type = "string"),
  *   @Attribute("outputType", type = "string"),
+ *   @Attribute("prefetchMethod", type = "string"),
  * })
  */
 class Field extends AbstractRequest
 {
+    /** @var string|null */
+    private $prefetchMethod;
+
+    /**
+     * @param mixed[] $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->prefetchMethod = $attributes['prefetchMethod'] ?? null;
+    }
+
+    /**
+     * Returns the prefetch method name (the method that will be called to fetch many records at once)
+     */
+    public function getPrefetchMethod(): ?string
+    {
+        return $this->prefetchMethod;
+    }
 }

--- a/src/InvalidPrefetchMethodException.php
+++ b/src/InvalidPrefetchMethodException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+
+class InvalidPrefetchMethodException extends GraphQLException
+{
+    public static function methodNotFound(ReflectionMethod $annotationMethod, ReflectionClass $reflectionClass, string $methodName, ReflectionException $previous): self
+    {
+        throw new self('The @Field annotation in ' . $annotationMethod->getDeclaringClass()->getName() . '::' . $annotationMethod->getName() . ' specifies a "prefetch method" that could not be found. Unable to find method ' . $reflectionClass->getName() . '::' . $methodName . '.', 0, $previous);
+    }
+
+    public static function prefetchDataIgnored(ReflectionMethod $annotationMethod, bool $isSecond): self
+    {
+        throw new self('The @Field annotation in ' . $annotationMethod->getDeclaringClass()->getName() . '::' . $annotationMethod->getName() . ' specifies a "prefetch method" but the data from the prefetch method is not gathered. The "' . $annotationMethod->getName() . '" method should accept a ' . ($isSecond?'second':'first') . ' parameter that will contain data returned by the prefetch method.');
+    }
+}

--- a/src/Parameters/PrefetchDataParameter.php
+++ b/src/Parameters/PrefetchDataParameter.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Typically the first parameter of "self" fields or the second parameter of "external" fields that will be filled with the data fetched from the prefetch method.
+ */
+class PrefetchDataParameter implements ParameterInterface
+{
+    /** @var mixed */
+    private $prefetchedData;
+
+    /**
+     * @param array<string, mixed> $args
+     * @param mixed                $context
+     *
+     * @return mixed
+     */
+    public function resolve(?object $source, array $args, $context, ResolveInfo $info)
+    {
+        // Note: data cannot be known at build time.
+        return $this->prefetchedData;
+    }
+
+    /**
+     * @param mixed $prefetchedData
+     */
+    public function setPrefetchedData($prefetchedData): void
+    {
+        $this->prefetchedData = $prefetchedData;
+    }
+}

--- a/src/PrefetchBuffer.php
+++ b/src/PrefetchBuffer.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite;
+
+use function array_key_exists;
+use function md5;
+use function serialize;
+
+/**
+ * A class in charge of holding the fields for a deferred computation.
+ */
+class PrefetchBuffer
+{
+    /** @var array<string, array<int, object>> An array of array of buffered, indexed by hash of arguments. */
+    private $objects = [];
+
+    /** @var array<string, mixed> An array of prefetch method results, indexed by hash of arguments. */
+    private $results = [];
+
+    /**
+     * @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field.
+     */
+    public function register(object $object, array $arguments): void
+    {
+        $this->objects[$this->computeHash($arguments)][] = $object;
+    }
+
+    /**
+     * @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field.
+     */
+    private function computeHash(array $arguments): string
+    {
+        return md5(serialize($arguments));
+    }
+
+    /**
+     * @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field.
+     *
+     * @return array<int, object>
+     */
+    public function getObjectsByArguments(array $arguments): array
+    {
+        return $this->objects[$this->computeHash($arguments)] ?? [];
+    }
+
+    /**
+     * @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field.
+     */
+    public function purge(array $arguments): void
+    {
+        unset($this->objects[$this->computeHash($arguments)]);
+    }
+
+    /**
+     * @param mixed $result
+     * @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field.
+     */
+    public function storeResult($result, array $arguments): void
+    {
+        $this->results[$this->computeHash($arguments)] = $result;
+    }
+
+    /**
+     * @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field.
+     */
+    public function hasResult(array $arguments): bool
+    {
+        return array_key_exists($this->computeHash($arguments), $this->results);
+    }
+
+    /**
+     * @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field.
+     *
+     * @return mixed
+     */
+    public function getResult(array $arguments)
+    {
+        return $this->results[$this->computeHash($arguments)];
+    }
+}

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
+use GraphQL\Deferred;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\OutputType;
@@ -12,6 +13,7 @@ use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+use TheCodingMachine\GraphQLite\Parameters\PrefetchDataParameter;
 use TheCodingMachine\GraphQLite\Parameters\SourceParameter;
 use function array_map;
 use function array_unshift;
@@ -27,7 +29,7 @@ class QueryField extends FieldDefinition
     /**
      * @param OutputType                        &Type                 $type
      * @param array<string, ParameterInterface> $arguments            Indexed by argument name.
-     * @param callable|null                     $resolve              The method to execute
+     * @param (callable&array<int,mixed>)|null  $resolve              The method to execute
      * @param string|null                       $targetMethodOnSource The name of the method to execute on the source object. Mutually exclusive with $resolve parameter.
      * @param array<string, ParameterInterface> $prefetchArgs         Indexed by argument name.
      * @param array<string, mixed>              $additionalConfig
@@ -43,7 +45,7 @@ class QueryField extends FieldDefinition
             $config['description'] = $comment;
         }
 
-        $config['resolve'] = function ($source, array $args, $context, ResolveInfo $info) use ($resolve, $targetMethodOnSource, $arguments) {
+        $resolveFn = function ($source, array $args, $context, ResolveInfo $info) use ($resolve, $targetMethodOnSource, $arguments) {
             $toPassArgs = array_values(array_map(function (ParameterInterface $parameter) use ($source, $args, $context, $info, $resolve) {
                 try {
                     return $parameter->resolve($source, $args, $context, $info);
@@ -62,6 +64,48 @@ class QueryField extends FieldDefinition
             }
             throw new InvalidArgumentException('The QueryField constructor should be passed either a resolve method or a target method on source object.');
         };
+
+        if ($prefetchMethodName === null) {
+            $config['resolve'] = $resolveFn;
+        } else {
+            $prefetchCallable = [$resolve[0], $prefetchMethodName];
+            $prefetchBuffer = new PrefetchBuffer();
+
+            $config['resolve'] = function ($source, array $args, $context, ResolveInfo $info) use ($prefetchBuffer, $arguments, $prefetchArgs, $prefetchCallable, $resolveFn) {
+                $prefetchBuffer->register($source, $args);
+
+                return new Deferred(function () use ($prefetchBuffer, $source, $args, $context, $info, $prefetchArgs, $prefetchCallable, $arguments, $resolveFn) {
+                    if (! $prefetchBuffer->hasResult($args)) {
+                        $sources = $prefetchBuffer->getObjectsByArguments($args);
+
+                        $toPassPrefetchArgs = array_values(array_map(function (ParameterInterface $parameter) use ($source, $args, $context, $info, $prefetchCallable) {
+                            try {
+                                return $parameter->resolve($source, $args, $context, $info);
+                            } catch (MissingArgumentException $e) {
+                                throw MissingArgumentException::wrapWithFieldContext($e, $this->name, $prefetchCallable);
+                            }
+                        }, $prefetchArgs));
+
+                        array_unshift($toPassPrefetchArgs, $sources);
+
+                        $prefetchResult = $prefetchCallable(...$toPassPrefetchArgs);
+                        $prefetchBuffer->storeResult($prefetchResult, $args);
+                    } else {
+                        $prefetchResult = $prefetchBuffer->getResult($args);
+                    }
+
+                    foreach ($arguments as $argument) {
+                        if (! ($argument instanceof PrefetchDataParameter)) {
+                            continue;
+                        }
+
+                        $argument->setPrefetchedData($prefetchResult);
+                    }
+
+                    return $resolveFn($source, $args, $context, $info);
+                });
+            };
+        }
 
         $config += $additionalConfig;
         parent::__construct($config);
@@ -93,6 +137,10 @@ class QueryField extends FieldDefinition
      */
     public static function selfField(string $name, OutputType $type, array $arguments, string $targetMethodOnSource, ?string $comment, ?string $prefetchMethodName, array $prefetchArgs): self
     {
+        if ($prefetchMethodName !== null) {
+            array_unshift($arguments, new PrefetchDataParameter());
+        }
+
         return new self($name, $type, $arguments, null, $targetMethodOnSource, $comment, $prefetchMethodName, $prefetchArgs);
     }
 
@@ -104,6 +152,9 @@ class QueryField extends FieldDefinition
      */
     public static function externalField(string $name, OutputType $type, array $arguments, callable $callable, ?string $comment, bool $injectSource, ?string $prefetchMethodName, array $prefetchArgs): self
     {
+        if ($prefetchMethodName !== null) {
+            array_unshift($arguments, new PrefetchDataParameter());
+        }
         if ($injectSource === true) {
             array_unshift($arguments, new SourceParameter());
         }

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -29,14 +29,15 @@ class QueryField extends FieldDefinition
      * @param array<string, ParameterInterface> $arguments            Indexed by argument name.
      * @param callable|null                     $resolve              The method to execute
      * @param string|null                       $targetMethodOnSource The name of the method to execute on the source object. Mutually exclusive with $resolve parameter.
+     * @param array<string, ParameterInterface> $prefetchArgs         Indexed by argument name.
      * @param array<string, mixed>              $additionalConfig
      */
-    public function __construct(string $name, OutputType $type, array $arguments, ?callable $resolve, ?string $targetMethodOnSource, ?string $comment, array $additionalConfig = [])
+    public function __construct(string $name, OutputType $type, array $arguments, ?callable $resolve, ?string $targetMethodOnSource, ?string $comment, ?string $prefetchMethodName, array $prefetchArgs, array $additionalConfig = [])
     {
         $config = [
             'name' => $name,
             'type' => $type,
-            'args' => InputTypeUtils::getInputTypeArgs($arguments),
+            'args' => InputTypeUtils::getInputTypeArgs($prefetchArgs + $arguments),
         ];
         if ($comment) {
             $config['description'] = $comment;
@@ -81,30 +82,32 @@ class QueryField extends FieldDefinition
             return $value;
         };
 
-        return new self($name, $type, $arguments, $callable, null, $comment);
+        return new self($name, $type, $arguments, $callable, null, $comment, null, []);
     }
 
     /**
      * @param array<string, ParameterInterface> $arguments Indexed by argument name.
+     * @param array<string, ParameterInterface> $prefetchArgs Indexed by argument name.
      *
      * @return QueryField
      */
-    public static function selfField(string $name, OutputType $type, array $arguments, string $targetMethodOnSource, ?string $comment): self
+    public static function selfField(string $name, OutputType $type, array $arguments, string $targetMethodOnSource, ?string $comment, ?string $prefetchMethodName, array $prefetchArgs): self
     {
-        return new self($name, $type, $arguments, null, $targetMethodOnSource, $comment);
+        return new self($name, $type, $arguments, null, $targetMethodOnSource, $comment, $prefetchMethodName, $prefetchArgs);
     }
 
     /**
      * @param array<string, ParameterInterface> $arguments Indexed by argument name.
+     * @param array<string, ParameterInterface> $prefetchArgs Indexed by argument name.
      *
      * @return QueryField
      */
-    public static function externalField(string $name, OutputType $type, array $arguments, callable $callable, ?string $comment, bool $injectSource): self
+    public static function externalField(string $name, OutputType $type, array $arguments, callable $callable, ?string $comment, bool $injectSource, ?string $prefetchMethodName, array $prefetchArgs): self
     {
         if ($injectSource === true) {
             array_unshift($arguments, new SourceParameter());
         }
 
-        return new self($name, $type, $arguments, $callable, null, $comment);
+        return new self($name, $type, $arguments, $callable, null, $comment, $prefetchMethodName, $prefetchArgs);
     }
 }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use GraphQL\Deferred;
 use GraphQL\Type\Definition\BooleanType;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\FloatType;
@@ -648,5 +649,4 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertSame('string', $testField->args[0]->name);
         $this->assertSame('int', $testField->args[1]->name);
     }
-
 }

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -4,6 +4,7 @@
 namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
 
 
+use function array_search;
 use DateTimeInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use TheCodingMachine\GraphQLite\Annotations\Field;
@@ -130,5 +131,19 @@ class Contact
     public function setCompany(string $company): void
     {
         $this->company = $company;
+    }
+
+    /**
+     * @Field(prefetchMethod="prefetchTheContacts")
+     */
+    public function repeatInnerName($data): string
+    {
+        $index = array_search($this, $data, false);
+        return $data[$index]->getName();
+    }
+
+    public function prefetchTheContacts(iterable $contacts)
+    {
+        return $contacts;
     }
 }

--- a/tests/Fixtures/Integration/Types/ContactType.php
+++ b/tests/Fixtures/Integration/Types/ContactType.php
@@ -3,6 +3,7 @@
 
 namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Types;
 
+use function array_search;
 use function strtoupper;
 use TheCodingMachine\GraphQLite\Annotations\ExtendType;
 use TheCodingMachine\GraphQLite\Annotations\Field;
@@ -25,5 +26,19 @@ class ContactType
     public function customField(Contact $contact, string $prefix): string
     {
         return $prefix.' '.strtoupper($contact->getName());
+    }
+
+    /**
+     * @Field(prefetchMethod="prefetchContacts")
+     */
+    public function repeatName(Contact $contact, $data): string
+    {
+        $index = array_search($contact, $data, true);
+        return $data[$index]->getName();
+    }
+
+    public function prefetchContacts(iterable $contacts)
+    {
+        return $contacts;
     }
 }

--- a/tests/Fixtures/Integration/Types/ContactType.php
+++ b/tests/Fixtures/Integration/Types/ContactType.php
@@ -31,14 +31,17 @@ class ContactType
     /**
      * @Field(prefetchMethod="prefetchContacts")
      */
-    public function repeatName(Contact $contact, $data): string
+    public function repeatName(Contact $contact, $data, string $suffix): string
     {
-        $index = array_search($contact, $data, true);
-        return $data[$index]->getName();
+        $index = array_search($contact, $data['contacts'], true);
+        return $data['prefix'].$data['contacts'][$index]->getName().$suffix;
     }
 
-    public function prefetchContacts(iterable $contacts)
+    public function prefetchContacts(iterable $contacts, string $prefix)
     {
-        return $contacts;
+        return [
+            'contacts' => $contacts,
+            'prefix' => $prefix
+        ];
     }
 }

--- a/tests/Fixtures/TestTypeWithInvalidPrefetchMethod.php
+++ b/tests/Fixtures/TestTypeWithInvalidPrefetchMethod.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use Exception;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ */
+class TestTypeWithInvalidPrefetchMethod
+{
+    /**
+     * @Field(prefetchMethod="notExists")
+     */
+    public function test(): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Fixtures/TestTypeWithInvalidPrefetchParameter.php
+++ b/tests/Fixtures/TestTypeWithInvalidPrefetchParameter.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use Exception;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ */
+class TestTypeWithInvalidPrefetchParameter
+{
+    /**
+     * @Field(prefetchMethod="prefetch")
+     */
+    public function test(TestObject $testObject): string
+    {
+        return 'foo';
+    }
+
+    public function prefetch()
+    {
+
+    }
+}

--- a/tests/Fixtures/TestTypeWithPrefetchMethod.php
+++ b/tests/Fixtures/TestTypeWithPrefetchMethod.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use Exception;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(class=TestObject::class)
+ */
+class TestTypeWithPrefetchMethod
+{
+    /**
+     * @Field(prefetchMethod="prefetch")
+     */
+    public function test(TestObject $testObject, $prefetchedData, int $int): string
+    {
+        return $prefetchedData[0].$int;
+    }
+
+    public function prefetch(iterable $testObjects, string $string)
+    {
+        return [$string];
+    }
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -215,7 +215,7 @@ class EndToEndTest extends TestCase
                 name
                 company
                 uppercaseName
-                repeatName
+                repeatName(prefix:"foo", suffix:"bar")
                 ... on User {
                     email
                 }
@@ -234,13 +234,13 @@ class EndToEndTest extends TestCase
                     'name' => 'Joe',
                     'company' => 'Joe Ltd',
                     'uppercaseName' => 'JOE',
-                    'repeatName' => 'Joe',
+                    'repeatName' => 'fooJoebar',
                 ],
                 [
                     'name' => 'Bill',
                     'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
-                    'repeatName' => 'Bill',
+                    'repeatName' => 'fooBillbar',
                     'email' => 'bill@example.com'
                 ]
 
@@ -259,13 +259,13 @@ class EndToEndTest extends TestCase
                     'name' => 'Joe',
                     'company' => 'Joe Ltd',
                     'uppercaseName' => 'JOE',
-                    'repeatName' => 'Joe',
+                    'repeatName' => 'fooJoebar',
                 ],
                 [
                     'name' => 'Bill',
                     'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
-                    'repeatName' => 'Bill',
+                    'repeatName' => 'fooBillbar',
                     'email' => 'bill@example.com'
                 ]
 

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -215,6 +215,7 @@ class EndToEndTest extends TestCase
                 name
                 company
                 uppercaseName
+                repeatName
                 ... on User {
                     email
                 }
@@ -232,12 +233,14 @@ class EndToEndTest extends TestCase
                 [
                     'name' => 'Joe',
                     'company' => 'Joe Ltd',
-                    'uppercaseName' => 'JOE'
+                    'uppercaseName' => 'JOE',
+                    'repeatName' => 'Joe',
                 ],
                 [
                     'name' => 'Bill',
                     'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
+                    'repeatName' => 'Bill',
                     'email' => 'bill@example.com'
                 ]
 
@@ -255,12 +258,14 @@ class EndToEndTest extends TestCase
                 [
                     'name' => 'Joe',
                     'company' => 'Joe Ltd',
-                    'uppercaseName' => 'JOE'
+                    'uppercaseName' => 'JOE',
+                    'repeatName' => 'Joe',
                 ],
                 [
                     'name' => 'Bill',
                     'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
+                    'repeatName' => 'Bill',
                     'email' => 'bill@example.com'
                 ]
 

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -216,6 +216,7 @@ class EndToEndTest extends TestCase
                 company
                 uppercaseName
                 repeatName(prefix:"foo", suffix:"bar")
+                repeatInnerName
                 ... on User {
                     email
                 }
@@ -235,12 +236,14 @@ class EndToEndTest extends TestCase
                     'company' => 'Joe Ltd',
                     'uppercaseName' => 'JOE',
                     'repeatName' => 'fooJoebar',
+                    'repeatInnerName' => 'Joe',
                 ],
                 [
                     'name' => 'Bill',
                     'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
                     'repeatName' => 'fooBillbar',
+                    'repeatInnerName' => 'Bill',
                     'email' => 'bill@example.com'
                 ]
 
@@ -260,12 +263,14 @@ class EndToEndTest extends TestCase
                     'company' => 'Joe Ltd',
                     'uppercaseName' => 'JOE',
                     'repeatName' => 'fooJoebar',
+                    'repeatInnerName' => 'Joe',
                 ],
                 [
                     'name' => 'Bill',
                     'company' => 'Bill Ltd',
                     'uppercaseName' => 'BILL',
                     'repeatName' => 'fooBillbar',
+                    'repeatInnerName' => 'Bill',
                     'email' => 'bill@example.com'
                 ]
 

--- a/tests/PrefetchBufferTest.php
+++ b/tests/PrefetchBufferTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class PrefetchBufferTest extends TestCase
+{
+
+    public function testRegister(): void
+    {
+        $buffer = new PrefetchBuffer();
+
+        $object1 = new stdClass();
+        $object2 = new stdClass();
+        $object3 = new stdClass();
+
+        $buffer->register($object1, ['int'=>42]);
+        $buffer->register($object2, ['int'=>24]);
+        $buffer->register($object3, ['int'=>42]);
+
+        $this->assertSame([$object1, $object3], $buffer->getObjectsByArguments(['int'=>42]));
+        $this->assertSame([$object2], $buffer->getObjectsByArguments(['int'=>24]));
+
+        $buffer->purge(['int'=>42]);
+        $this->assertSame([], $buffer->getObjectsByArguments(['int'=>42]));
+    }
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,7 +3,7 @@
     "Introduction": ["features"],
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
     "Usage": ["queries", "mutations", "type_mapping", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance"],
-    "Performance": ["query-plan"],
+    "Performance": ["query-plan", "prefetch-method"],
     "Advanced": ["file-uploads", "pagination", "custom-types", "extend_input_type", "internals", "troubleshooting", "migrating"],
     "Reference": ["annotations_reference"]
   }


### PR DESCRIPTION
This PR adds support for "prefetch methods" (aka Deferred in Webonyx or DataLoader pattern in GraphQL)
This PR closes #42.

Consider a request where a user attached to a post must be returned.

```graphql
{
    posts {
        id
        user {
            id
        }
    }
}
```

If there are 500 "posts" returned, the "Post::getUser" method will be called 500 times. If each request is performing a call to the database, we are facing a performance issue. We need a way to reduce the number of calls to the database. This is what the "prefetch methods" are designed for.

```php
/**
 * @Type
 */
class PostType {
    /**
     * @Field(prefetchMethod="prefetchUsers")
     * @param Post $post
     * @param mixed $prefetchedUsers
     * @return User
     */
    public function getUser(Post $post, $prefetchedUsers): User
    {
        // This method will receive the $prefetchedUsers as second argument. This is the return value of the "prefetchUsers" method below.
        // Using this prefetched list, it should be easy to map it to the post
    }

    /**
     * @param Post[] $posts
     * @return mixed
     */
    public function prefetchUsers(iterable $posts)
    {
        // This function is called only once per GraphQL request
        // with the list of posts. You can fetch the list of users
        // associated with this posts in a single request,
        // for instance using a "IN" query in SQL or a multi-fetch
        // in your cache back-end.
    }
}
```

When the "prefetchMethod" attribute is detected in the "@Field" annotation, the method is called automatically. The first argument of the method is an iterable over the instances of the main type.
The "prefetchMethod" can return absolutely anything (mixed). The return value will be passed as the second parameter of the "@Field" annotated method.

Important: field arguments can be set either on the @Field annotated method OR/AND on the prefetchMethod.

For instance:

```php
/**
 * @Type
 */
class PostType {
    /**
     * @Field(prefetchMethod="prefetchComments")
     * @param Post $post
     * @param mixed $prefetchedComments
     * @return Comment[]
     */
    public function getComments(Post $post, $prefetchedComments): array
    {
        // ...
    }

    /**
     * @param Post[] $posts
     * @return mixed
     */
    public function prefetchComments(iterable $posts, bool $hideSpam, int $filterByScore)
    {
        // Parameters passed after the first parameter (hideSpam, filterByScore...) are automatically exposed as GraphQL arguments for the "comments" field.
    }
}
```

The prefetch method MUST be in the same class as the @Field-annotated method and MUST be public.

Note: the "prefetchMethod" argument CANNOT be applied on @Query and @Mutation annotations. We will need a different kind of attribute for this.