### PR TITLE
Adding type mapper factory

### DIFF
--- a/docs/other_frameworks.md
+++ b/docs/other_frameworks.md
@@ -57,6 +57,9 @@ $factory->setAuthorizationService(new VoidAuthorizationService());
 $factory->setNamingStrategy(new NamingStrategy());
 // Add a custom type mapper.
 $factory->addTypeMapper($typeMapper);
+// Add a custom type mapper using a factory to create it.
+// Type mapper factories are useful if you need to inject the "recursive type mapper" into your type mapper constructor.
+$factory->addTypeMapperFactory($typeMapperFactory);
 // Add custom options to the Webonyx underlying Schema.
 $factory->setSchemaConfig($schemaConfig);
 // Configures the time-to-live for the GraphQLite cache. Defaults to 2 seconds in dev mode.

--- a/src/Mappers/TypeMapperFactoryInterface.php
+++ b/src/Mappers/TypeMapperFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+/**
+ * Class in charge of creating a type mapper.
+ * You can pass a type mapper factory to the SchemaFactory instead of a type mapper if the type mapper you want to
+ * pass requires the "recursive type mapper".
+ */
+interface TypeMapperFactoryInterface
+{
+    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper): TypeMapperInterface;
+}

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -10,7 +10,11 @@ use Symfony\Component\Cache\Simple\PhpFilesCache;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\TypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\TypeMapperFactoryInterface;
+use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
 use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
@@ -51,6 +55,12 @@ class SchemaFactoryTest extends TestCase
                 ->setAuthorizationService(new VoidAuthorizationService())
                 ->setNamingStrategy(new NamingStrategy())
                 ->addTypeMapper(new CompositeTypeMapper())
+                ->addTypeMapperFactory(new class implements TypeMapperFactoryInterface {
+                    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper): TypeMapperInterface
+                    {
+                        return new CompositeTypeMapper();
+                    }
+                })
                 ->addRootTypeMapper(new CompositeRootTypeMapper([]))
                 ->setSchemaConfig(new SchemaConfig())
                 ->devMode()


### PR DESCRIPTION
Sometimes, a type mapper requires a the recursive type mapper to be created.
While it is possible to pass it using dependency injection, it is not
easy if you use the simpler SchemaFactory.

Using a TypeMapperFactory, you can now easily create a TypeMapper that
will be passed a recursive type mapper.