### PR TITLE
Fixing the default value type in FailWith annotation

### DIFF
--- a/src/Annotations/FailWith.php
+++ b/src/Annotations/FailWith.php
@@ -11,7 +11,7 @@ use function array_key_exists;
  * @Annotation
  * @Target({"METHOD", "ANNOTATION"})
  * @Attributes({
- *   @Attribute("value", type = "string"),
+ *   @Attribute("value", type = "mixed"),
  *   @Attribute("mode", type = "string")
  * })
  */


### PR DESCRIPTION
Default value is not necessarily a string. It can be anything (an array, a bool, etc...)