### PR TITLE
Mapping ENUM keys to GraphQL Enum names

### DIFF
--- a/src/Mappers/Root/MyCLabsEnumTypeMapper.php
+++ b/src/Mappers/Root/MyCLabsEnumTypeMapper.php
@@ -37,7 +37,7 @@ class MyCLabsEnumTypeMapper implements RootTypeMapperInterface
             $consts         = $enumClass::toArray();
             $constInstances = [];
             foreach ($consts as $key => $value) {
-                $constInstances[$value] = ['value' => $enumClass::$key()];
+                $constInstances[$key] = ['value' => $enumClass::$key()];
             }
 
             return new EnumType([

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -107,7 +107,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             'dateTimeImmutable' => '2017-01-01 01:01:01',
             'dateTime' => '2017-01-01 01:01:01',
             'id' => 42,
-            'enum' => 'on'
+            'enum' => 'ON'
         ];
 
         $resolve = $usersQuery->resolveFn;


### PR DESCRIPTION
So far, ENUM names in GraphQL were mapped to the const values.
This PR changes this to using const keys instead of const values.

So:

```php
class TestEnum extends Enum
{
    private const ON = 'on';
    private const OFF = 'off';
}
```

This will generate an enum with ("ON"/"OFF") instead of ("on"/"off").
This is a more natural match for GraphQL Enum names because enum names are limited to /[_A-Za-z][_0-9A-Za-z]*/ (just like the CONST names and not like the CONST values).