### PR TITLE
 Adding autowiring capabilities 

### DIFF
--- a/docs/autowiring.md
+++ b/docs/autowiring.md
@@ -1,0 +1,112 @@
+---
+id: autowiring
+title: Autowiring services
+sidebar_label: Autowiring services
+---
+
+GraphQLite can automatically inject services in your fields/queries/mutations signatures.
+
+Some of your fields may be computed. In order to compute these fields, you might need to call a service.
+
+Most of the time, your `@Type` annotation will be put on a model. And models do not have access to services.
+Hopefully, if you add a type-hinted service in your field's declaration, GraphQLite will automatically fill it with
+the service instance.
+
+## Sample
+
+Let's assume you are running an international store. You have a `Product` class. Each product has many names (depending
+on the language of the user).
+
+```php
+namespace App\Entities;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @Type()
+ */
+class Product
+{
+    // ...
+
+    /**
+     * @Field()
+     */
+    public function getName(TranslatorInterface $translator): string
+    {
+        return $translator->trans('product_name_'.$this->id);
+    }
+}
+```
+
+When GraphQLite queries the name, it will automatically fetch the translator service.
+
+<div class="alert alert-warning">As with most autowiring solutions, GraphQLite assumes that the service identifier
+in the container is the fully qualified class name of the type-hint. So in the example above, GraphQLite will 
+look for a service whose name is <code>Symfony\Component\Translation\TranslatorInterface</code>.</div>
+
+Note: you can configure this lookup behaviour. Optionally, GraphQLite can look for services based on the parameter name
+(and not the parameter type). In the example above, that means GraphQLite would search for a service whose name is "translator".
+
+The way you configure autowiring in GraphQLite depends on the framework you are using.
+
+### Configuring autowiring using the SchemaFactory.
+
+If you are bootstrapping GraphQLite using the `SchemaFactory`, you can use the `SchemaFactory::setAutowireServiceOnClassName()`
+and `SchemaFactory::setAutowireServiceOnParameterName()` methods.
+
+```php
+// Look-up services based on the type-hint (enabled by default)
+$schemaFactory::setAutowireServiceOnClassName(true);
+// Look-up services based on the parameter name (disabled by default)
+$schemaFactory::setAutowireServiceOnParameterName(true);
+```
+
+## Best practices
+
+It is a good idea to refrain from type-hinting on concrete implementations.
+Most often, your field declaration will be in your model. If you add a type-hint on a service, you are binding your domain
+with a particular service implementation. This makes your code tightly coupled and less testable.
+
+<div class="alert alert-error">
+Please don't do that:
+
+<pre><code>    /**
+     * @Field()
+     */
+    public function getName(MyTranslator $translator): string
+    {
+        // Your domain is suddenly tightly coupled to the MyTranslator class.
+    }
+</code></pre>
+</div>
+
+Instead, be sure to type-hint against an interface.
+
+<div class="alert alert-success">
+Do this instead:
+
+<pre><code>    /**
+     * @Field()
+     */
+    public function getName(TranslatorInterface $translator): string
+    {
+        // Good. You can switch translator implementation any time.
+    }
+</code></pre>
+</div>
+
+By type-hinting against an interface, your code remains testable and is decoupled from the service implementation.
+
+## Alternative solution
+
+You may find yourself uncomfortable with the autowiring mechanism of GraphQLite. For instance maybe:
+
+- Your service identifier in the container is not the fully qualified class name of the service (this is often true if you are not using a container supporting autowiring)
+- You do not want to inject a service in a domain object
+- You simply do not like the magic of injecting services in a method signature
+
+If you do not want to use autowiring and if you still need to access services to compute a field, please read on 
+the next chapter to learn [how to extend a type](extend_type).

--- a/docs/other_frameworks.md
+++ b/docs/other_frameworks.md
@@ -70,6 +70,10 @@ $factory->prodMode();
 // Enables dev-mode (this is the default mode: cache settings optimized for best developer experience).
 // This is a shortcut for `$schemaFactory->setGlobTtl(2)`
 $factory->devMode();
+// Autowiring parameter: Look-up services based on the type-hint (enabled by default)
+$schemaFactory::setAutowireServiceOnClassName(true);
+// Autowiring parameter: Look-up services based on the parameter name (disabled by default)
+$schemaFactory::setAutowireServiceOnParameterName(true);
 ```
 
 ## Minimal example

--- a/docs/type_mapping.md
+++ b/docs/type_mapping.md
@@ -228,4 +228,4 @@ GraphQL supports "custom" scalar types. GraphQLite supports adding more GraphQL 
 If you need more types, you can check the [GraphQLite Misc. Types library](https://github.com/thecodingmachine/graphqlite-misc-types).
 It adds support for more scalar types out of the box in GraphQLite.
 
-Or if you have some special needs, [you can develop your own scalar types](custom-types.md#registering-a-custom-scalar-type-advanced).
+Or if you have some special needs, [you can develop your own scalar types](custom-types#registering-a-custom-scalar-type-advanced).

--- a/src/Mappers/Parameters/ContainerParameterMapper.php
+++ b/src/Mappers/Parameters/ContainerParameterMapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
 
-use GraphQL\Type\Definition\ResolveInfo;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Type;
 use Psr\Container\ContainerInterface;
@@ -12,29 +11,21 @@ use ReflectionParameter;
 use TheCodingMachine\GraphQLite\Annotations\Parameter;
 use TheCodingMachine\GraphQLite\Parameters\ContainerParameter;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
-use TheCodingMachine\GraphQLite\Parameters\ResolveInfoParameter;
 
 /**
  * Tries to map parameters with FQCN type hints to a container entry with the FQCN or the parameter name.
  */
 class ContainerParameterMapper implements ParameterMapperInterface
 {
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     private $container;
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $mapFullyQualifiedClassName;
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $mapParameterName;
 
     public function __construct(ContainerInterface $container, bool $mapFullyQualifiedClassName, bool $mapParameterName)
     {
-
         $this->container = $container;
         $this->mapFullyQualifiedClassName = $mapFullyQualifiedClassName;
         $this->mapParameterName = $mapParameterName;

--- a/src/Mappers/Parameters/ContainerParameterMapper.php
+++ b/src/Mappers/Parameters/ContainerParameterMapper.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use Psr\Container\ContainerInterface;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Annotations\Parameter;
+use TheCodingMachine\GraphQLite\Parameters\ContainerParameter;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+use TheCodingMachine\GraphQLite\Parameters\ResolveInfoParameter;
+
+/**
+ * Tries to map parameters with FQCN type hints to a container entry with the FQCN or the parameter name.
+ */
+class ContainerParameterMapper implements ParameterMapperInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+    /**
+     * @var bool
+     */
+    private $mapFullyQualifiedClassName;
+    /**
+     * @var bool
+     */
+    private $mapParameterName;
+
+    public function __construct(ContainerInterface $container, bool $mapFullyQualifiedClassName, bool $mapParameterName)
+    {
+
+        $this->container = $container;
+        $this->mapFullyQualifiedClassName = $mapFullyQualifiedClassName;
+        $this->mapParameterName = $mapParameterName;
+    }
+
+    public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, ?Type $paramTagType, ?Parameter $parameterAnnotation): ?ParameterInterface
+    {
+        if ($this->mapParameterName) {
+            $parameterName = $parameter->getName();
+            if ($this->container->has($parameterName)) {
+                return new ContainerParameter($this->container, $parameterName);
+            }
+        }
+        if ($this->mapFullyQualifiedClassName) {
+            $type = $parameter->getType();
+            if ($type !== null && $this->container->has($type->getName())) {
+                return new ContainerParameter($this->container, $type->getName());
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Parameters/ContainerParameter.php
+++ b/src/Parameters/ContainerParameter.php
@@ -12,13 +12,9 @@ use Psr\Container\ContainerInterface;
  */
 class ContainerParameter implements ParameterInterface
 {
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     private $container;
-    /**
-     * @var string
-     */
+    /** @var string */
     private $identifier;
 
     public function __construct(ContainerInterface $container, string $identifier)

--- a/src/Parameters/ContainerParameter.php
+++ b/src/Parameters/ContainerParameter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Parameters;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use Psr\Container\ContainerInterface;
+
+/**
+ * A parameter filled from the container.
+ */
+class ContainerParameter implements ParameterInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+    /**
+     * @var string
+     */
+    private $identifier;
+
+    public function __construct(ContainerInterface $container, string $identifier)
+    {
+        $this->container = $container;
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     * @param mixed                $context
+     *
+     * @return mixed
+     */
+    public function resolve(?object $source, array $args, $context, ResolveInfo $info)
+    {
+        return $this->container->get($this->identifier);
+    }
+}

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -81,13 +81,9 @@ class SchemaFactory
     private $globTtl = 2;
     /** @var array<int, FieldMiddlewareInterface> */
     private $fieldMiddlewares = [];
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $autowireServiceOnClassName = true;
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $autowireServiceOnParameterName = false;
 
     public function __construct(CacheInterface $cache, ContainerInterface $container)
@@ -255,8 +251,6 @@ class SchemaFactory
 
     /**
      * Whether we should autowire services from the container in the function parameters based on the fully-qualified class name.
-     *
-     * @param bool $autowireServiceOnClassName
      */
     public function setAutowireServiceOnClassName(bool $autowireServiceOnClassName): void
     {
@@ -265,8 +259,6 @@ class SchemaFactory
 
     /**
      * Whether we should autowire services from the container in the function parameters based on the parameter name.
-     *
-     * @param bool $autowireServiceOnParameterName
      */
     public function setAutowireServiceOnParameterName(bool $autowireServiceOnParameterName): void
     {

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -7,10 +7,15 @@ namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
 use function array_search;
 use DateTimeInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use stdClass;
 use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\Logged;
 use TheCodingMachine\GraphQLite\Annotations\Right;
 use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
+use TheCodingMachine\GraphQLite\TypeRegistry;
 
 /**
  * @Type()
@@ -167,5 +172,20 @@ class Contact
     public function secret(): string
     {
         return 'you can see this only if you have the good right';
+    }
+
+    /**
+     * @Field()
+     * @return string
+     */
+    public function injectService(string $testService, stdClass $otherTestService = null): string
+    {
+        if ($testService !== 'foo') {
+            return 'KO';
+        }
+        if (!$otherTestService instanceof stdClass) {
+            return 'KO';
+        }
+        return 'OK';
     }
 }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\NonNull;
 use Mouf\Picotainer\Picotainer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use stdClass;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Lock\Factory as LockFactory;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -21,6 +22,7 @@ use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
@@ -195,9 +197,20 @@ class EndToEndTest extends TestCase
                     new BaseTypeMapper($container->get(RecursiveTypeMapperInterface::class))
                 ]);
             },
+            ContainerParameterMapper::class => function(ContainerInterface $container) {
+                return new ContainerParameterMapper($container, true, true);
+            },
+            'testService' => function() {
+                return 'foo';
+            },
+            stdClass::class => function() {
+                // Empty test service for autowiring
+                return new stdClass();
+            },
             ParameterMapperInterface::class => function(ContainerInterface $container) {
                 return new CompositeParameterMapper([
-                    new ResolveInfoParameterMapper()
+                    new ResolveInfoParameterMapper(),
+                    $container->get(ContainerParameterMapper::class)
                 ]);
             }
         ]);
@@ -636,5 +649,38 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame('You do not have sufficient rights to access this field', $result->toArray(Debug::RETHROW_UNSAFE_EXCEPTIONS)['errors'][0]['message']);
+    }
+
+    public function testAutowireService()
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            contacts {
+                injectService
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'contacts' => [
+                [
+                    'injectService' => 'OK',
+                ],
+                [
+                    'injectService' => 'OK',
+                ]
+
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
 }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -35,6 +35,8 @@ class SchemaFactoryTest extends TestCase
         $factory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
         $factory->addQueryProvider(new AggregateQueryProvider([]));
         $factory->addFieldMiddleware(new FieldMiddlewarePipe());
+        $factory->setAutowireServiceOnClassName(true);
+        $factory->setAutowireServiceOnParameterName(true);
 
         $schema = $factory->createSchema();
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,7 +2,7 @@
   "docs": {
     "Introduction": ["features"],
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
-    "Usage": ["queries", "mutations", "type_mapping", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance"],
+    "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance"],
     "Performance": ["query-plan", "prefetch-method"],
     "Advanced": ["file-uploads", "pagination", "custom-types", "field-middlewares", "extend_input_type", "internals", "troubleshooting", "migrating"],
     "Reference": ["annotations_reference"]


### PR DESCRIPTION
This PR adds support for autowiring services into fields/queries/mutations signatures.
This allows accessing services without having to extend a type.

See documentation inside the PR code.