### PR TITLE
Migrating cache to thecodingmachine/cache-utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "psr/http-message": "^1",
         "ecodev/graphql-upload": "^4.0",
         "webmozart/assert": "^1.4",
-        "symfony/cache": "^4.3"
+        "symfony/cache": "^4.3",
+        "thecodingmachine/cache-utils": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.9",
@@ -59,5 +60,7 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,5 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/src/Mappers/GlobAnnotationsCache.php
+++ b/src/Mappers/GlobAnnotationsCache.php
@@ -1,0 +1,113 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+/**
+ * An object containing a description of ALL annotations relevant to GlobTypeMapper for a given class.
+ *
+ * @internal
+ */
+class GlobAnnotationsCache
+{
+    /**
+     * @var string|null
+     */
+    private $typeClassName;
+
+    /**
+     * @var string|null
+     */
+    private $typeName;
+
+    /**
+     * @var string|null
+     */
+    private $extendTypeClassName;
+
+    /**
+     * @var string|null
+     */
+    private $extendTypeName;
+
+    /**
+     * @var array<string, array<int, string|bool>> An array mapping a factory method name to an input name / class name / default flag / declaring class
+     */
+    private $factories = [];
+
+    /**
+     * @var array<string, array<int, string>> An array mapping a decorator method name to an input name / declaring class
+     */
+    private $decorators = [];
+
+    public function setType(string $className, string $typeName): void
+    {
+        $this->typeClassName = $className;
+        $this->typeName = $typeName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTypeClassName(): ?string
+    {
+        return $this->typeClassName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTypeName(): ?string
+    {
+        return $this->typeName;
+    }
+
+    public function setExtendType(string $className, string $typeName): void
+    {
+        $this->extendTypeClassName = $className;
+        $this->extendTypeName = $typeName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getExtendTypeClassName(): ?string
+    {
+        return $this->extendTypeClassName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getExtendTypeName(): ?string
+    {
+        return $this->extendTypeName;
+    }
+
+
+    public function registerFactory(string $methodName, string $inputName, ?string $className, bool $isDefault, string $declaringClass): void
+    {
+        $this->factories[$methodName] = [$inputName, $className, $isDefault, $declaringClass];
+    }
+
+    public function registerDecorator(string $methodName, string $inputName, string $declaringClass): void
+    {
+        $this->decorators[$methodName] = [$inputName, $declaringClass];
+    }
+
+    /**
+     * @return array<string, array<int, string|bool>>
+     */
+    public function getFactories(): array
+    {
+        return $this->factories;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function getDecorators(): array
+    {
+        return $this->decorators;
+    }
+}

--- a/src/Mappers/GlobAnnotationsCache.php
+++ b/src/Mappers/GlobAnnotationsCache.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
@@ -10,34 +11,22 @@ namespace TheCodingMachine\GraphQLite\Mappers;
  */
 class GlobAnnotationsCache
 {
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $typeClassName;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $typeName;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $extendTypeClassName;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $extendTypeName;
 
-    /**
-     * @var array<string, array<int, string|bool>> An array mapping a factory method name to an input name / class name / default flag / declaring class
-     */
+    /** @var array<string, array<int, string|bool>> An array mapping a factory method name to an input name / class name / default flag / declaring class */
     private $factories = [];
 
-    /**
-     * @var array<string, array<int, string>> An array mapping a decorator method name to an input name / declaring class
-     */
+    /** @var array<string, array<int, string>> An array mapping a decorator method name to an input name / declaring class */
     private $decorators = [];
 
     public function setType(string $className, string $typeName): void
@@ -46,17 +35,11 @@ class GlobAnnotationsCache
         $this->typeName = $typeName;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTypeClassName(): ?string
     {
         return $this->typeClassName;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTypeName(): ?string
     {
         return $this->typeName;
@@ -68,22 +51,15 @@ class GlobAnnotationsCache
         $this->extendTypeName = $typeName;
     }
 
-    /**
-     * @return string|null
-     */
     public function getExtendTypeClassName(): ?string
     {
         return $this->extendTypeClassName;
     }
 
-    /**
-     * @return string|null
-     */
     public function getExtendTypeName(): ?string
     {
         return $this->extendTypeName;
     }
-
 
     public function registerFactory(string $methodName, string $inputName, ?string $className, bool $isDefault, string $declaringClass): void
     {

--- a/src/Mappers/GlobExtendAnnotationsCache.php
+++ b/src/Mappers/GlobExtendAnnotationsCache.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+/**
+ * An object containing a description of ALL extend annotations relevant to GlobTypeMapper for a given class.
+ *
+ * @internal
+ */
+class GlobExtendAnnotationsCache
+{
+    /**
+     * @var string|null
+     */
+    private $extendTypeClassName;
+
+    /**
+     * @var string|null
+     */
+    private $extendTypeName;
+
+    public function setExtendType(string $className, string $typeName): void
+    {
+        $this->extendTypeClassName = $className;
+        $this->extendTypeName = $typeName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getExtendTypeClassName(): ?string
+    {
+        return $this->extendTypeClassName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getExtendTypeName(): ?string
+    {
+        return $this->extendTypeName;
+    }
+}

--- a/src/Mappers/GlobExtendAnnotationsCache.php
+++ b/src/Mappers/GlobExtendAnnotationsCache.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
@@ -10,14 +11,10 @@ namespace TheCodingMachine\GraphQLite\Mappers;
  */
 class GlobExtendAnnotationsCache
 {
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $extendTypeClassName;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $extendTypeName;
 
     public function setExtendType(string $className, string $typeName): void
@@ -26,17 +23,11 @@ class GlobExtendAnnotationsCache
         $this->extendTypeName = $typeName;
     }
 
-    /**
-     * @return string|null
-     */
     public function getExtendTypeClassName(): ?string
     {
         return $this->extendTypeClassName;
     }
 
-    /**
-     * @return string|null
-     */
     public function getExtendTypeName(): ?string
     {
         return $this->extendTypeName;

--- a/src/Mappers/GlobExtendTypeMapperCache.php
+++ b/src/Mappers/GlobExtendTypeMapperCache.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use function array_keys;
+use ReflectionClass;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * The cached results of a GlobTypeMapper
+ */
+class GlobExtendTypeMapperCache
+{
+    /** @var array<string,array<string,string>> Maps a domain class to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN */
+    private $mapClassToExtendTypeArray = [];
+    /** @var array<string,array<string,string>> Maps a GraphQL type name to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN */
+    private $mapNameToExtendType = [];
+
+    /**
+     * Merges annotations of a given class in the global cache.
+     *
+     * @param ReflectionClass $refClass
+     * @param GlobAnnotationsCache $globExtendAnnotationsCache
+     */
+    public function registerAnnotations(ReflectionClass $refClass, GlobExtendAnnotationsCache $globExtendAnnotationsCache): void
+    {
+        $className = $refClass->getName();
+
+        $typeClassName = $globExtendAnnotationsCache->getExtendTypeClassName();
+        if ($typeClassName !== null) {
+            $this->mapClassToExtendTypeArray[$typeClassName][$className] = $className;
+
+            $typeName = $globExtendAnnotationsCache->getExtendTypeName();
+            $this->mapNameToExtendType[$typeName][$className] = $className;
+        }
+    }
+
+    /**
+     * @return array<string,string>|null An array of classes with the @ExtendType annotation (key and value = FQCN)
+     */
+    public function getExtendTypesByObjectClass(string $className): ?array
+    {
+        return $this->mapClassToExtendTypeArray[$className] ?? null;
+    }
+
+    /**
+     * @return array<string,string>|null An array of classes with the @ExtendType annotation (key and value = FQCN)
+     */
+    public function getExtendTypesByGraphQLTypeName(string $graphqlTypeName): ?array
+    {
+        return $this->mapNameToExtendType[$graphqlTypeName] ?? null;
+    }
+}

--- a/src/Mappers/GlobExtendTypeMapperCache.php
+++ b/src/Mappers/GlobExtendTypeMapperCache.php
@@ -1,11 +1,10 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use function array_keys;
 use ReflectionClass;
-use TheCodingMachine\GraphQLite\Annotations\Type;
 
 /**
  * The cached results of a GlobTypeMapper
@@ -19,21 +18,20 @@ class GlobExtendTypeMapperCache
 
     /**
      * Merges annotations of a given class in the global cache.
-     *
-     * @param ReflectionClass $refClass
-     * @param GlobAnnotationsCache $globExtendAnnotationsCache
      */
     public function registerAnnotations(ReflectionClass $refClass, GlobExtendAnnotationsCache $globExtendAnnotationsCache): void
     {
         $className = $refClass->getName();
 
         $typeClassName = $globExtendAnnotationsCache->getExtendTypeClassName();
-        if ($typeClassName !== null) {
-            $this->mapClassToExtendTypeArray[$typeClassName][$className] = $className;
-
-            $typeName = $globExtendAnnotationsCache->getExtendTypeName();
-            $this->mapNameToExtendType[$typeName][$className] = $className;
+        if ($typeClassName === null) {
+            return;
         }
+
+        $this->mapClassToExtendTypeArray[$typeClassName][$className] = $className;
+
+        $typeName = $globExtendAnnotationsCache->getExtendTypeName();
+        $this->mapNameToExtendType[$typeName][$className] = $className;
     }
 
     /**

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -215,7 +215,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                 }
 
                 return $annotationsCache;
-            });
+            }, '', $this->mapTtl);
 
             if ($annotationsCache === 'nothing') {
                 continue;
@@ -249,7 +249,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                 }
 
                 return 'nothing';
-            });
+            }, '', $this->mapTtl);
 
             if ($annotationsCache === 'nothing') {
                 continue;

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -323,9 +323,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                     }*/
                     throw DuplicateMappingException::createForType($type->getClass(), $this->mapClassToTypeArray[$type->getClass()], $className);
                 }
-                $fileName = $refClass->getFileName();
-                Assert::string($fileName);
-                $this->storeTypeInCache($className, $type, $fileName, $refClass);
+                $this->storeTypeInCache($className, $type, $refClass);
             }
 
             $isAbstract = $refClass->isAbstract();
@@ -347,9 +345,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                         // If this is not the default factory, let's not map the class name to the factory.
                         $className = null;
                     }
-                    $fileName = $refClass->getFileName();
-                    Assert::string($fileName);
-                    $this->storeInputTypeInCache($method, $inputName, $className, $fileName, $refClass);
+                    $this->storeInputTypeInCache($method, $inputName, $className, $refClass);
                 }
 
                 $decorator = $this->annotationReader->getDecorateAnnotation($method);
@@ -374,9 +370,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                 continue;
             }
 
-            $fileName = $refClass->getFileName();
-            Assert::string($fileName);
-            $this->storeExtendTypeMapperByClassInCache($className, $extendType, $fileName, $refClass);
+            $this->storeExtendTypeMapperByClassInCache($className, $extendType, $refClass);
         }
     }
 
@@ -391,16 +385,14 @@ final class GlobTypeMapper implements TypeMapperInterface
                 continue;
             }
 
-            $fileName = $refClass->getFileName();
-            Assert::string($fileName);
-            $this->storeExtendTypeMapperByNameInCache($className, $extendType, $fileName, $refClass);
+            $this->storeExtendTypeMapperByNameInCache($className, $extendType, $refClass);
         }
     }
 
     /**
      * Stores in cache the mapping TypeClass <=> Object class <=> GraphQL type name.
      */
-    private function storeTypeInCache(string $typeClassName, Type $type, string $typeFileName, ReflectionClass $reflectionClass): void
+    private function storeTypeInCache(string $typeClassName, Type $type, ReflectionClass $reflectionClass): void
     {
         $objectClassName                             = $type->getClass();
         $this->mapClassToTypeArray[$objectClassName] = $typeClassName;
@@ -414,7 +406,7 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Stores in cache the mapping between InputType name <=> Object class
      */
-    private function storeInputTypeInCache(ReflectionMethod $refMethod, string $inputName, ?string $className, string $fileName, ReflectionClass $refClass): void
+    private function storeInputTypeInCache(ReflectionMethod $refMethod, string $inputName, ?string $className, ReflectionClass $refClass): void
     {
         $refArray = [$refMethod->getDeclaringClass()->getName(), $refMethod->getName()];
         if ($className !== null) {
@@ -428,7 +420,7 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Stores in cache the mapping ExtendTypeClass <=> Object class.
      */
-    private function storeExtendTypeMapperByClassInCache(string $extendTypeClassName, ExtendType $extendType, string $typeFileName, ReflectionClass $refClass): void
+    private function storeExtendTypeMapperByClassInCache(string $extendTypeClassName, ExtendType $extendType, ReflectionClass $refClass): void
     {
         $objectClassName                                                         = $extendType->getClass();
         $this->mapClassToExtendTypeArray[$objectClassName][$extendTypeClassName] = $extendTypeClassName;
@@ -438,7 +430,7 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Stores in cache the mapping ExtendTypeClass <=> name class.
      */
-    private function storeExtendTypeMapperByNameInCache(string $extendTypeClassName, ExtendType $extendType, string $typeFileName, ReflectionClass $refClass): void
+    private function storeExtendTypeMapperByNameInCache(string $extendTypeClassName, ExtendType $extendType, ReflectionClass $refClass): void
     {
         $targetType = $this->recursiveTypeMapper->mapClassToType($extendType->getClass(), null);
         $typeName   = $targetType->name;
@@ -454,8 +446,6 @@ final class GlobTypeMapper implements TypeMapperInterface
     private function storeDecoratorMapperByNameInCache(ReflectionMethod $reflectionMethod, Decorate $decorate): void
     {
         $typeName                                   = $decorate->getInputTypeName();
-        $typeFileName                               = $reflectionMethod->getFileName();
-        Assert::string($typeFileName);
         $this->mapInputNameToDecorator[$typeName][] = [$reflectionMethod->getDeclaringClass()->getName(), $reflectionMethod->getName()];
         $this->mapInputNameToDecoratorCache->set($typeName, $this->mapInputNameToDecorator[$typeName], $reflectionMethod->getDeclaringClass(), $this->mapTtl);
     }

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -11,10 +11,11 @@ use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use ReflectionException;
-use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
 use TheCodingMachine\CacheUtils\ClassBoundCache;
+use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
+use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
 use TheCodingMachine\CacheUtils\ClassBoundCacheInterface;
 use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
 use TheCodingMachine\CacheUtils\FileBoundCache;
@@ -29,10 +30,8 @@ use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeGenerator;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use Webmozart\Assert\Assert;
 use function array_keys;
 use function class_exists;
-use function filemtime;
 use function str_replace;
 
 /**
@@ -51,67 +50,26 @@ final class GlobTypeMapper implements TypeMapperInterface
     private $cache;
     /** @var int|null */
     private $globTtl;
-    /** @var array<string,string> Maps a domain class to the GraphQL type annotated class */
-    private $mapClassToTypeArray = [];
+
     /**
-     * Maps a domain class to the GraphQL type annotated class
-     * @var ClassBoundCacheInterface
+     * Cache storing the GlobAnnotationsCache objects linked to a given ReflectionClass.
+     *
+     * @var ClassBoundCacheContractInterface
      */
-    private $mapClassToTypeCache;
-    /** @var array<string,array<string,string>> Maps a domain class to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN */
-    private $mapClassToExtendTypeArray = [];
+    private $mapClassToAnnotationsCache;
     /**
-     * Maps a domain class to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN (array<string,string>)
-     * @var ClassBoundCacheInterface
+     * Cache storing the GlobAnnotationsCache objects linked to a given ReflectionClass.
+     *
+     * @var ClassBoundCacheContractInterface
      */
-    private $mapClassToExtendTypeCache;
-    /** @var array<string,string> Maps a GraphQL type name to the GraphQL type annotated class */
-    private $mapNameToType = [];
-    /**
-     * Maps a GraphQL type name to the GraphQL type annotated class
-     * @var ClassBoundCacheInterface
-     */
-    private $mapNameToTypeCache;
-    /** @var array<string,array<string,string>> Maps a GraphQL type name to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN */
-    private $mapNameToExtendType = [];
-    /**
-     * Maps a GraphQL type name to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN (array<string,string>)
-     * @var ClassBoundCacheInterface
-     */
-    private $mapNameToExtendTypeCache;
-    /** @var array<string,string[]> Maps a domain class to the factory method that creates the input type in the form [classname, methodname] */
-    private $mapClassToFactory = [];
-    /**
-     * Maps a domain class to the factory method that creates the input type in the form [classname, methodname]
-     * @var ClassBoundCacheInterface
-     */
-    private $mapClassToFactoryCache;
-    /** @var array<string,string[]> Maps a GraphQL input type name to the factory method that creates the input type in the form [classname, methodname] */
-    private $mapInputNameToFactory = [];
-    /**
-     * Maps a GraphQL input type name to the factory method that creates the input type in the form [classname, methodname]
-     * @var ClassBoundCacheInterface
-     */
-    private $mapInputNameToFactoryCache;
-    /** @var array<string,array<int, callable&array>> Maps a GraphQL type name to one or many decorators (with the @Decorator annotation) */
-    private $mapInputNameToDecorator = [];
-    /**
-     * Maps a GraphQL type name to one or many decorators (with the @Decorator annotation) array<int, callable&array>
-     * @var ClassBoundCacheInterface
-     */
-    private $mapInputNameToDecoratorCache;
+    private $mapClassToExtendAnnotationsCache;
+
     /** @var ContainerInterface */
     private $container;
     /** @var TypeGenerator */
     private $typeGenerator;
     /** @var int|null */
     private $mapTtl;
-    /** @var bool */
-    private $fullMapComputed = false;
-    /** @var bool */
-    private $fullMapClassToExtendTypeArrayComputed = false;
-    /** @var bool */
-    private $fullMapNameToExtendTypeArrayComputed = false;
     /** @var NamingStrategyInterface */
     private $namingStrategy;
     /** @var InputTypeGenerator */
@@ -132,6 +90,14 @@ final class GlobTypeMapper implements TypeMapperInterface
     private $recursiveTypeMapper;
     /** @var CacheContractInterface */
     private $cacheContract;
+    /**
+     * @var GlobTypeMapperCache
+     */
+    private $globTypeMapperCache;
+    /**
+     * @var GlobExtendTypeMapperCache
+     */
+    private $globExtendTypeMapperCache;
 
     /**
      * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
@@ -152,127 +118,35 @@ final class GlobTypeMapper implements TypeMapperInterface
         $this->inputTypeUtils      = $inputTypeUtils;
         $this->recursive           = $recursive;
         $this->recursiveTypeMapper = $recursiveTypeMapper;
-        $this->mapClassToTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globTypeMapperByClass_' . $cachePrefix)));
-        $this->mapNameToTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globTypeMapperByName_' . $cachePrefix)));
-        $this->mapNameToExtendTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globExtendTypeMapperByName_' . $cachePrefix)));
-        $this->mapClassToFactoryCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globInputTypeMapperByClass_' . $cachePrefix)));
-        $this->mapInputNameToFactoryCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globInputTypeMapperByName_' . $cachePrefix)));
-        $this->mapInputNameToDecoratorCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globDecoratorMapperByName_' . $cachePrefix)));
-        $this->mapClassToExtendTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globExtendTypeMapperByClass_' . $cachePrefix)));
+        $this->mapClassToAnnotationsCache = new ClassBoundCacheContract(new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'classToAnnotations_' . $cachePrefix))));
+        $this->mapClassToExtendAnnotationsCache = new ClassBoundCacheContract(new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'classToExtendAnnotations_' . $cachePrefix))));
     }
 
     /**
-     * Returns an array of fully qualified class names.
+     * Returns an object mapping all types.
      *
-     * @return array<string, array<string,string>>
+     * @return GlobTypeMapperCache
      */
-    private function getMaps(): array
+    private function getMaps(): GlobTypeMapperCache
     {
-        if ($this->fullMapComputed === false) {
-            [
-                'mapClassToTypeArray' => $this->mapClassToTypeArray,
-                'mapNameToType' => $this->mapNameToType,
-                'mapClassToFactory' => $this->mapClassToFactory,
-                'mapInputNameToFactory' => $this->mapInputNameToFactory,
-                'mapInputNameToDecorator' => $this->mapInputNameToDecorator,
-            ] = $this->cacheContract->get('fullMapComputed', function () {
-                $this->buildMap();
-
-                return [
-                    'mapClassToTypeArray' => $this->mapClassToTypeArray,
-                    'mapNameToType' => $this->mapNameToType,
-                    'mapClassToFactory' => $this->mapClassToFactory,
-                    'mapInputNameToFactory' => $this->mapInputNameToFactory,
-                    'mapInputNameToDecorator' => $this->mapInputNameToDecorator,
-                ];
+        if ($this->globTypeMapperCache === null) {
+            $this->globTypeMapperCache = $this->cacheContract->get('fullMapComputed', function () {
+                return $this->buildMap();
             });
-
-            $this->fullMapComputed = true;
         }
 
-        return [
-            'mapClassToTypeArray' => $this->mapClassToTypeArray,
-            'mapNameToType' => $this->mapNameToType,
-            'mapClassToFactory' => $this->mapClassToFactory,
-            'mapInputNameToFactory' => $this->mapInputNameToFactory,
-            'mapInputNameToDecorator' => $this->mapInputNameToDecorator,
-        ];
+        return $this->globTypeMapperCache;
     }
 
-    /**
-     * @return array<string,string> Maps a domain class to the GraphQL type annotated class
-     */
-    private function getMapClassToType(): array
+    private function getMapClassToExtendTypeArray(): GlobExtendTypeMapperCache
     {
-        return $this->getMaps()['mapClassToTypeArray'];
-    }
-
-    /**
-     * @return array<string,string> Maps a GraphQL type name to the GraphQL type annotated class
-     */
-    private function getMapNameToType(): array
-    {
-        return $this->getMaps()['mapNameToType'];
-    }
-
-    /**
-     * @return array<string,string[]> Maps a domain class to the factory method that creates the input type in the form [classname, methodname]
-     */
-    private function getMapClassToFactory(): array
-    {
-        return $this->getMaps()['mapClassToFactory'];
-    }
-
-    /**
-     * @return array<string,string[]> Maps a GraphQL input type name to the factory method that creates the input type in the form [classname, methodname]
-     */
-    private function getMapInputNameToFactory(): array
-    {
-        return $this->getMaps()['mapInputNameToFactory'];
-    }
-
-    /**
-     * @return array<string,array<int, callable&array>> Maps a GraphQL type name to one or many decorators (with the @Decorator annotation)
-     */
-    private function getMapInputNameToDecorator(): array
-    {
-        return $this->getMaps()['mapInputNameToDecorator'];
-    }
-
-    /**
-     * @return array<string,array<string,string>> Maps a domain class to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN
-     */
-    private function getMapClassToExtendTypeArray(): array
-    {
-        if ($this->fullMapClassToExtendTypeArrayComputed === false) {
-            $this->mapClassToExtendTypeArray = $this->cacheContract->get('globTypeMapperExtend', function () {
-                $this->buildMapClassToExtendTypeArray();
-
-                return $this->mapClassToExtendTypeArray;
+        if ($this->globExtendTypeMapperCache === null) {
+            $this->globExtendTypeMapperCache = $this->cacheContract->get('fullExtendMapComputed', function () {
+                return $this->buildMapClassToExtendTypeArray();
             });
-
-            $this->fullMapClassToExtendTypeArrayComputed = true;
         }
 
-        return $this->mapClassToExtendTypeArray;
-    }
-
-    /**
-     * @return array<string,array<string,string>> Maps a GraphQL type name to one or many type extenders (with the @ExtendType annotation) The array of type extenders has a key and value equals to FQCN
-     */
-    private function getMapNameToExtendType(): array
-    {
-        if ($this->fullMapNameToExtendTypeArrayComputed === false) {
-            $this->mapNameToExtendType = $this->cacheContract->get('globTypeMapperExtend_names', function () {
-                $this->buildMapNameToExtendTypeArray();
-
-                return $this->mapNameToExtendType;
-            });
-
-            $this->fullMapNameToExtendTypeArrayComputed = true;
-        }
-
-        return $this->mapNameToExtendType;
+        return $this->globExtendTypeMapperCache;
     }
 
     /**
@@ -302,253 +176,92 @@ final class GlobTypeMapper implements TypeMapperInterface
         return $this->classes;
     }
 
-    private function buildMap(): void
+    private function buildMap(): GlobTypeMapperCache
     {
-        $this->mapClassToTypeArray     = [];
-        $this->mapNameToType           = [];
-        $this->mapClassToFactory       = [];
-        $this->mapInputNameToFactory   = [];
-        $this->mapInputNameToDecorator = [];
+        $globTypeMapperCache = new GlobTypeMapperCache();
 
         /** @var ReflectionClass[] $classes */
         $classes = $this->getClassList();
         foreach ($classes as $className => $refClass) {
-            $type = $this->annotationReader->getTypeAnnotation($refClass);
+            $annotationsCache = $this->mapClassToAnnotationsCache->get($refClass, function() use ($refClass, $className) {
+                $annotationsCache = new GlobAnnotationsCache();
 
-            if ($type !== null) {
-                if (isset($this->mapClassToTypeArray[$type->getClass()])) {
-                    /*if ($this->mapClassToTypeArray[$type->getClass()] === $className) {
-                        // Already mapped. Let's continue
+                $containsAnnotations = false;
+
+                $type = $this->annotationReader->getTypeAnnotation($refClass);
+                if ($type !== null) {
+                    $typeName = $this->namingStrategy->getOutputTypeName($className, $type);
+                    $annotationsCache->setType($type->getClass(), $typeName);
+                    $containsAnnotations = true;
+                }
+
+                $isAbstract = $refClass->isAbstract();
+
+                foreach ($refClass->getMethods() as $method) {
+                    if (! $method->isPublic() || ($isAbstract && ! $method->isStatic())) {
                         continue;
-                    }*/
-                    throw DuplicateMappingException::createForType($type->getClass(), $this->mapClassToTypeArray[$type->getClass()], $className);
-                }
-                $this->storeTypeInCache($className, $type, $refClass);
-            }
-
-            $isAbstract = $refClass->isAbstract();
-
-            foreach ($refClass->getMethods() as $method) {
-                if (! $method->isPublic() || ($isAbstract && ! $method->isStatic())) {
-                    continue;
-                }
-                $factory = $this->annotationReader->getFactoryAnnotation($method);
-
-                if ($factory !== null) {
-                    [$inputName, $className] = $this->inputTypeUtils->getInputTypeNameAndClassName($method);
-
-                    if ($factory->isDefault()) {
-                        if (isset($this->mapClassToFactory[$className])) {
-                            throw DuplicateMappingException::createForFactory($className, $this->mapClassToFactory[$className][0], $this->mapClassToFactory[$className][1], $refClass->getName(), $method->name);
-                        }
-                    } else {
-                        // If this is not the default factory, let's not map the class name to the factory.
-                        $className = null;
                     }
-                    $this->storeInputTypeInCache($method, $inputName, $className, $refClass);
+                    $factory = $this->annotationReader->getFactoryAnnotation($method);
+
+                    if ($factory !== null) {
+                        [$inputName, $className] = $this->inputTypeUtils->getInputTypeNameAndClassName($method);
+
+                        $annotationsCache->registerFactory($method->getName(), $inputName, $className, $factory->isDefault(), $method->getDeclaringClass()->getName());
+                        $containsAnnotations = true;
+                    }
+
+                    $decorator = $this->annotationReader->getDecorateAnnotation($method);
+
+                    if ($decorator !== null) {
+                        $annotationsCache->registerDecorator($method->getName(), $decorator->getInputTypeName(), $method->getDeclaringClass()->getName());
+                        $containsAnnotations = true;
+                    }
                 }
 
-                $decorator = $this->annotationReader->getDecorateAnnotation($method);
+                if (!$containsAnnotations) {
+                    return 'nothing';
+                }
+                return $annotationsCache;
+            });
 
-                if ($decorator === null) {
-                    continue;
+            if ($annotationsCache !== 'nothing') {
+                $globTypeMapperCache->registerAnnotations($refClass, $annotationsCache);
+            }
+        }
+
+        return $globTypeMapperCache;
+    }
+
+    private function buildMapClassToExtendTypeArray(): GlobExtendTypeMapperCache
+    {
+        $globExtendTypeMapperCache = new GlobExtendTypeMapperCache();
+
+        /** @var ReflectionClass[] $classes */
+        $classes = $this->getClassList();
+        foreach ($classes as $className => $refClass) {
+            $annotationsCache = $this->mapClassToExtendAnnotationsCache->get($refClass, function() use ($refClass) {
+                $extendAnnotationsCache = new GlobExtendAnnotationsCache();
+
+                $extendType = $this->annotationReader->getExtendTypeAnnotation($refClass);
+
+                if ($extendType !== null) {
+                    $targetType = $this->recursiveTypeMapper->mapClassToType($extendType->getClass(), null);
+                    $typeName   = $targetType->name;
+
+                    $extendAnnotationsCache->setExtendType($extendType->getClass(), $typeName);
+
+                    return $extendAnnotationsCache;
                 }
 
-                $this->storeDecoratorMapperByNameInCache($method, $decorator);
+                return 'nothing';
+            });
+
+            if ($annotationsCache !== 'nothing') {
+                $globExtendTypeMapperCache->registerAnnotations($refClass, $annotationsCache);
             }
         }
-    }
 
-    private function buildMapClassToExtendTypeArray(): void
-    {
-        $this->mapClassToExtendTypeArray = [];
-        $classes                         = $this->getClassList();
-        foreach ($classes as $className => $refClass) {
-            $extendType = $this->annotationReader->getExtendTypeAnnotation($refClass);
-
-            if ($extendType === null) {
-                continue;
-            }
-
-            $this->storeExtendTypeMapperByClassInCache($className, $extendType, $refClass);
-        }
-    }
-
-    private function buildMapNameToExtendTypeArray(): void
-    {
-        $this->mapNameToExtendType = [];
-        $classes                   = $this->getClassList();
-        foreach ($classes as $className => $refClass) {
-            $extendType = $this->annotationReader->getExtendTypeAnnotation($refClass);
-
-            if ($extendType === null) {
-                continue;
-            }
-
-            $this->storeExtendTypeMapperByNameInCache($className, $extendType, $refClass);
-        }
-    }
-
-    /**
-     * Stores in cache the mapping TypeClass <=> Object class <=> GraphQL type name.
-     */
-    private function storeTypeInCache(string $typeClassName, Type $type, ReflectionClass $reflectionClass): void
-    {
-        $objectClassName                             = $type->getClass();
-        $this->mapClassToTypeArray[$objectClassName] = $typeClassName;
-        $this->mapClassToTypeCache->set($objectClassName, $typeClassName, $reflectionClass, $this->mapTtl);
-
-        $typeName                       = $this->namingStrategy->getOutputTypeName($typeClassName, $type);
-        $this->mapNameToType[$typeName] = $typeClassName;
-        $this->mapNameToTypeCache->set($typeName, $typeClassName, $reflectionClass, $this->mapTtl);
-    }
-
-    /**
-     * Stores in cache the mapping between InputType name <=> Object class
-     */
-    private function storeInputTypeInCache(ReflectionMethod $refMethod, string $inputName, ?string $className, ReflectionClass $refClass): void
-    {
-        $refArray = [$refMethod->getDeclaringClass()->getName(), $refMethod->getName()];
-        if ($className !== null) {
-            $this->mapClassToFactory[$className] = $refArray;
-            $this->mapClassToFactoryCache->set($className, $refArray, $refClass, $this->mapTtl);
-        }
-        $this->mapInputNameToFactory[$inputName] = $refArray;
-        $this->mapInputNameToFactoryCache->set($inputName, $refArray, $refClass, $this->mapTtl);
-    }
-
-    /**
-     * Stores in cache the mapping ExtendTypeClass <=> Object class.
-     */
-    private function storeExtendTypeMapperByClassInCache(string $extendTypeClassName, ExtendType $extendType, ReflectionClass $refClass): void
-    {
-        $objectClassName                                                         = $extendType->getClass();
-        $this->mapClassToExtendTypeArray[$objectClassName][$extendTypeClassName] = $extendTypeClassName;
-        $this->mapClassToExtendTypeCache->set($objectClassName, $this->mapClassToExtendTypeArray[$objectClassName], $refClass, $this->mapTtl);
-    }
-
-    /**
-     * Stores in cache the mapping ExtendTypeClass <=> name class.
-     */
-    private function storeExtendTypeMapperByNameInCache(string $extendTypeClassName, ExtendType $extendType, ReflectionClass $refClass): void
-    {
-        $targetType = $this->recursiveTypeMapper->mapClassToType($extendType->getClass(), null);
-        $typeName   = $targetType->name;
-
-        $this->mapNameToExtendType[$typeName][$extendTypeClassName] = $extendTypeClassName;
-
-        $this->mapNameToExtendTypeCache->set($typeName, $this->mapNameToExtendType[$typeName], $refClass, $this->mapTtl);
-    }
-
-    /**
-     * Stores in cache the mapping ExtendTypeClass <=> name class.
-     */
-    private function storeDecoratorMapperByNameInCache(ReflectionMethod $reflectionMethod, Decorate $decorate): void
-    {
-        $typeName                                   = $decorate->getInputTypeName();
-        $this->mapInputNameToDecorator[$typeName][] = [$reflectionMethod->getDeclaringClass()->getName(), $reflectionMethod->getName()];
-        $this->mapInputNameToDecoratorCache->set($typeName, $this->mapInputNameToDecorator[$typeName], $reflectionMethod->getDeclaringClass(), $this->mapTtl);
-    }
-
-    private function getTypeFromCacheByObjectClass(string $className): ?string
-    {
-        if (isset($this->mapClassToTypeArray[$className])) {
-            return $this->mapClassToTypeArray[$className];
-        }
-
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: we need a memory adapter for ClassBoundCache
-        // TODO: + buildMap must RETURN the full map (instead of storing it)
-        // TODO: + buildMap must RETURN the full map (instead of storing it)
-        // TODO: + buildMap must RETURN the full map (instead of storing it)
-        // TODO: + buildMap must RETURN the full map (instead of storing it)
-        // TODO: + buildMap must RETURN the full map (instead of storing it)
-        // TODO: + buildMap must RETURN the full map (instead of storing it)
-        // TODO: + buildMap must RETURN the full map (instead of storing it)
-
-        // Let's try from the cache
-        return $this->mapClassToTypeArray[$className] = $this->mapClassToTypeCache->get($className);
-    }
-
-    private function getTypeFromCacheByGraphQLTypeName(string $graphqlTypeName): ?string
-    {
-        if (isset($this->mapNameToType[$graphqlTypeName])) {
-            return $this->mapNameToType[$graphqlTypeName];
-        }
-
-        // Let's try from the cache
-        return $this->mapNameToType[$graphqlTypeName] = $this->mapNameToTypeCache->get($graphqlTypeName);
-    }
-
-    /**
-     * @return string[]|null A pointer to the factory [$className, $methodName] or null on cache miss
-     */
-    private function getFactoryFromCacheByObjectClass(string $className): ?array
-    {
-        if (isset($this->mapClassToFactory[$className])) {
-            return $this->mapClassToFactory[$className];
-        }
-
-        // Let's try from the cache
-        return $this->mapClassToFactory[$className] = $this->mapClassToFactoryCache->get($className);
-    }
-
-    /**
-     * @return array<string,string>|null An array of classes with the @ExtendType annotation (key and value = FQCN)
-     */
-    private function getExtendTypesFromCacheByObjectClass(string $className): ?array
-    {
-        if (isset($this->mapClassToExtendTypeArray[$className])) {
-            return $this->mapClassToExtendTypeArray[$className];
-        }
-
-        // Let's try from the cache
-        return $this->mapClassToExtendTypeArray[$className] = $this->mapClassToExtendTypeCache->get($className);
-    }
-
-    /**
-     * @return array<string,string>|null An array of classes with the @ExtendType annotation (key and value = FQCN)
-     */
-    private function getExtendTypesFromCacheByGraphQLTypeName(string $graphqlTypeName): ?array
-    {
-        if (isset($this->mapNameToExtendType[$graphqlTypeName])) {
-            return $this->mapNameToExtendType[$graphqlTypeName];
-        }
-
-        // Let's try from the cache
-        return $this->mapNameToExtendType[$graphqlTypeName] = $this->mapNameToExtendTypeCache->get($graphqlTypeName);
-    }
-
-    /**
-     * @return string[]|null A pointer to the factory [$className, $methodName] or null on cache miss
-     */
-    private function getFactoryFromCacheByGraphQLInputTypeName(string $graphqlTypeName): ?array
-    {
-        if (isset($this->mapInputNameToFactory[$graphqlTypeName])) {
-            return $this->mapInputNameToFactory[$graphqlTypeName];
-        }
-
-        // Let's try from the cache
-        return $this->mapInputNameToFactory[$graphqlTypeName] = $this->mapInputNameToFactoryCache->get($graphqlTypeName);
-    }
-
-    /**
-     * @return array<int, string[]>|null A pointer to the decorators methods [$className, $methodName] or null on cache miss
-     */
-    private function getDecorateFromCacheByGraphQLInputTypeName(string $graphqlTypeName): ?array
-    {
-        if (isset($this->mapInputNameToDecorator[$graphqlTypeName])) {
-            return $this->mapInputNameToDecorator[$graphqlTypeName];
-        }
-
-        // Let's try from the cache
-        return $this->mapInputNameToDecorator[$graphqlTypeName] = $this->mapInputNameToDecoratorCache->get($graphqlTypeName);
+        return $globExtendTypeMapperCache;
     }
 
     /**
@@ -556,15 +269,7 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function canMapClassToType(string $className): bool
     {
-        $typeClassName = $this->getTypeFromCacheByObjectClass($className);
-
-        if ($typeClassName !== null) {
-            return true;
-        }
-
-        $map = $this->getMapClassToType();
-
-        return isset($map[$className]);
+        return $this->getMaps()->getTypeByObjectClass($className) !== null;
     }
 
     /**
@@ -577,14 +282,10 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType
     {
-        $typeClassName = $this->getTypeFromCacheByObjectClass($className);
+        $typeClassName = $this->getMaps()->getTypeByObjectClass($className);
 
         if ($typeClassName === null) {
-            $map = $this->getMapClassToType();
-            if (! isset($map[$className])) {
-                throw CannotMapTypeException::createForType($className);
-            }
-            $typeClassName = $map[$className];
+            throw CannotMapTypeException::createForType($className);
         }
 
         return $this->typeGenerator->mapAnnotatedObject($typeClassName);
@@ -597,7 +298,7 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function getSupportedClasses(): array
     {
-        return array_keys($this->getMapClassToType());
+        return $this->getMaps()->getSupportedClasses();
     }
 
     /**
@@ -605,14 +306,7 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function canMapClassToInputType(string $className): bool
     {
-        $factory = $this->getFactoryFromCacheByObjectClass($className);
-
-        if ($factory !== null) {
-            return true;
-        }
-        $map = $this->getMapClassToFactory();
-
-        return isset($map[$className]);
+        return $this->getMaps()->getFactoryByObjectClass($className) !== null;
     }
 
     /**
@@ -624,14 +318,10 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function mapClassToInputType(string $className): ResolvableMutableInputInterface
     {
-        $factory = $this->getFactoryFromCacheByObjectClass($className);
+        $factory = $this->getMaps()->getFactoryByObjectClass($className);
 
         if ($factory === null) {
-            $map = $this->getMapClassToFactory();
-            if (! isset($map[$className])) {
-                throw CannotMapTypeException::createForInputType($className);
-            }
-            $factory = $map[$className];
+            throw CannotMapTypeException::createForInputType($className);
         }
 
         return $this->inputTypeGenerator->mapFactoryMethod($factory[0], $factory[1], $this->container);
@@ -649,26 +339,14 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function mapNameToType(string $typeName): \GraphQL\Type\Definition\Type
     {
-        $typeClassName = $this->getTypeFromCacheByGraphQLTypeName($typeName);
-        if ($typeClassName === null) {
-            $factory = $this->getFactoryFromCacheByGraphQLInputTypeName($typeName);
-            if ($factory === null) {
-                $mapNameToType = $this->getMapNameToType();
-                if (isset($mapNameToType[$typeName])) {
-                    $typeClassName = $mapNameToType[$typeName];
-                } else {
-                    $mapInputNameToFactory = $this->getMapInputNameToFactory();
-                    if (isset($mapInputNameToFactory[$typeName])) {
-                        $factory = $mapInputNameToFactory[$typeName];
-                    }
-                }
-            }
-        }
+        $typeClassName = $this->getMaps()->getTypeByGraphQLTypeName($typeName);
 
-        if (isset($typeClassName)) {
+        if ($typeClassName !== null) {
             return $this->typeGenerator->mapAnnotatedObject($typeClassName);
         }
-        if (isset($factory)) {
+
+        $factory = $this->getMaps()->getFactoryByGraphQLInputTypeName($typeName);
+        if ($factory !== null) {
             return $this->inputTypeGenerator->mapFactoryMethod($factory[0], $factory[1], $this->container);
         }
 
@@ -682,20 +360,18 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function canMapNameToType(string $typeName): bool
     {
-        $typeClassName = $this->getTypeFromCacheByGraphQLTypeName($typeName);
+        $typeClassName = $this->getMaps()->getTypeByGraphQLTypeName($typeName);
 
         if ($typeClassName !== null) {
             return true;
         }
 
-        $factory = $this->getFactoryFromCacheByGraphQLInputTypeName($typeName);
+        $factory = $this->getMaps()->getFactoryByGraphQLInputTypeName($typeName);
         if ($factory !== null) {
             return true;
         }
 
-        $this->getMaps();
-
-        return isset($this->mapNameToType[$typeName]) || isset($this->mapInputNameToFactory[$typeName]);
+        return false;
     }
 
     /**
@@ -703,13 +379,7 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function canExtendTypeForClass(string $className, MutableObjectType $type): bool
     {
-        $extendTypeClassName = $this->getExtendTypesFromCacheByObjectClass($className);
-
-        if ($extendTypeClassName === null) {
-            $map = $this->getMapClassToExtendTypeArray();
-        }
-
-        return isset($this->mapClassToExtendTypeArray[$className]);
+        return $this->getMapClassToExtendTypeArray()->getExtendTypesByObjectClass($className) !== null;
     }
 
     /**
@@ -719,17 +389,13 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function extendTypeForClass(string $className, MutableObjectType $type): void
     {
-        $extendTypeClassNames = $this->getExtendTypesFromCacheByObjectClass($className);
+        $extendTypeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByObjectClass($className);
 
         if ($extendTypeClassNames === null) {
-            $this->getMapClassToExtendTypeArray();
-        }
-
-        if (! isset($this->mapClassToExtendTypeArray[$className])) {
             throw CannotMapTypeException::createForExtendType($className, $type);
         }
 
-        foreach ($this->mapClassToExtendTypeArray[$className] as $extendedTypeClass) {
+        foreach ($extendTypeClassNames as $extendedTypeClass) {
             $this->typeGenerator->extendAnnotatedObject($this->container->get($extendedTypeClass), $type);
         }
     }
@@ -739,20 +405,9 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool
     {
-        $typeClassNames = $this->getExtendTypesFromCacheByGraphQLTypeName($typeName);
+        $typeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByGraphQLTypeName($typeName);
 
-        if ($typeClassNames !== null) {
-            return true;
-        }
-
-        /*$factory = $this->getFactoryFromCacheByGraphQLInputTypeName($typeName);
-        if ($factory !== null) {
-            return true;
-        }*/
-
-        $map = $this->getMapNameToExtendType();
-
-        return isset($map[$typeName]);/* || isset($this->mapInputNameToFactory[$typeName])*/
+        return $typeClassNames !== null;
     }
 
     /**
@@ -762,27 +417,14 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function extendTypeForName(string $typeName, MutableObjectType $type): void
     {
-        $extendTypeClassNames = $this->getExtendTypesFromCacheByGraphQLTypeName($typeName);
+        $extendTypeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByGraphQLTypeName($typeName);
         if ($extendTypeClassNames === null) {
-            /*$factory = $this->getFactoryFromCacheByGraphQLInputTypeName($typeName);
-            if ($factory === null) {*/
-                $map = $this->getMapNameToExtendType();
-            if (! isset($map[$typeName])) {
-                throw CannotMapTypeException::createForExtendName($typeName, $type);
-            }
-                $extendTypeClassNames = $map[$typeName];
-
-            //}
+            throw CannotMapTypeException::createForExtendName($typeName, $type);
         }
 
         foreach ($extendTypeClassNames as $extendedTypeClass) {
             $this->typeGenerator->extendAnnotatedObject($this->container->get($extendedTypeClass), $type);
         }
-
-        /*if (isset($this->mapInputNameToFactory[$typeName])) {
-            $factory = $this->mapInputNameToFactory[$typeName];
-            return $this->inputTypeGenerator->mapFactoryMethod($this->container->get($factory[0]), $factory[1], $recursiveTypeMapper);
-        }*/
     }
 
     /**
@@ -790,15 +432,7 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function canDecorateInputTypeForName(string $typeName, ResolvableMutableInputInterface $type): bool
     {
-        $typeClassNames = $this->getDecorateFromCacheByGraphQLInputTypeName($typeName);
-
-        if ($typeClassNames !== null) {
-            return true;
-        }
-
-        $map = $this->getMapInputNameToDecorator();
-
-        return isset($map[$typeName]);
+        return !empty($this->getMaps()->getDecorateByGraphQLInputTypeName($typeName));
     }
 
     /**
@@ -810,13 +444,10 @@ final class GlobTypeMapper implements TypeMapperInterface
      */
     public function decorateInputTypeForName(string $typeName, ResolvableMutableInputInterface $type): void
     {
-        $decorators = $this->getDecorateFromCacheByGraphQLInputTypeName($typeName);
-        if ($decorators === null) {
-            $map = $this->getMapInputNameToDecorator();
-            if (! isset($map[$typeName])) {
-                throw CannotMapTypeException::createForDecorateName($typeName, $type);
-            }
-            $decorators = $map[$typeName];
+        $decorators = $this->getMaps()->getDecorateByGraphQLInputTypeName($typeName);
+
+        if (empty($decorators)) {
+            throw CannotMapTypeException::createForDecorateName($typeName, $type);
         }
 
         foreach ($decorators as $decorator) {

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -16,8 +16,8 @@ use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
 use TheCodingMachine\CacheUtils\ClassBoundCache;
 use TheCodingMachine\CacheUtils\ClassBoundCacheInterface;
+use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
 use TheCodingMachine\CacheUtils\FileBoundCache;
-use TheCodingMachine\CacheUtils\MemoryAdapter;
 use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
 use TheCodingMachine\GraphQLite\AnnotationReader;
 use TheCodingMachine\GraphQLite\Annotations\Decorate;
@@ -152,13 +152,13 @@ final class GlobTypeMapper implements TypeMapperInterface
         $this->inputTypeUtils      = $inputTypeUtils;
         $this->recursive           = $recursive;
         $this->recursiveTypeMapper = $recursiveTypeMapper;
-        $this->mapClassToTypeCache = new ClassBoundCache(new MemoryAdapter(new FileBoundCache($this->cache, 'globTypeMapperByClass_'.$cachePrefix)));
-        $this->mapNameToTypeCache = new ClassBoundCache(new MemoryAdapter(new FileBoundCache($this->cache, 'globTypeMapperByName_'.$cachePrefix)));
-        $this->mapNameToExtendTypeCache = new ClassBoundCache(new MemoryAdapter(new FileBoundCache($this->cache, 'globExtendTypeMapperByName_'.$cachePrefix)));
-        $this->mapClassToFactoryCache = new ClassBoundCache(new MemoryAdapter(new FileBoundCache($this->cache, 'globInputTypeMapperByClass_'.$cachePrefix)));
-        $this->mapInputNameToFactoryCache = new ClassBoundCache(new MemoryAdapter(new FileBoundCache($this->cache, 'globInputTypeMapperByName_'.$cachePrefix)));
-        $this->mapInputNameToDecoratorCache = new ClassBoundCache(new MemoryAdapter(new FileBoundCache($this->cache, 'globDecoratorMapperByName_'.$cachePrefix)));
-        $this->mapClassToExtendTypeCache = new ClassBoundCache(new MemoryAdapter(new FileBoundCache($this->cache, 'globExtendTypeMapperByClass_'.$cachePrefix)));
+        $this->mapClassToTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globTypeMapperByClass_' . $cachePrefix)));
+        $this->mapNameToTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globTypeMapperByName_' . $cachePrefix)));
+        $this->mapNameToExtendTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globExtendTypeMapperByName_' . $cachePrefix)));
+        $this->mapClassToFactoryCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globInputTypeMapperByClass_' . $cachePrefix)));
+        $this->mapInputNameToFactoryCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globInputTypeMapperByName_' . $cachePrefix)));
+        $this->mapInputNameToDecoratorCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globDecoratorMapperByName_' . $cachePrefix)));
+        $this->mapClassToExtendTypeCache = new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'globExtendTypeMapperByClass_' . $cachePrefix)));
     }
 
     /**

--- a/src/Mappers/GlobTypeMapperCache.php
+++ b/src/Mappers/GlobTypeMapperCache.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use function array_keys;
 use ReflectionClass;
-use TheCodingMachine\GraphQLite\Annotations\Type;
+use function array_keys;
 
 /**
  * The cached results of a GlobTypeMapper
@@ -25,9 +25,6 @@ class GlobTypeMapperCache
 
     /**
      * Merges annotations of a given class in the global cache.
-     *
-     * @param ReflectionClass $refClass
-     * @param GlobAnnotationsCache $globAnnotationsCache
      */
     public function registerAnnotations(ReflectionClass $refClass, GlobAnnotationsCache $globAnnotationsCache): void
     {

--- a/src/Mappers/GlobTypeMapperCache.php
+++ b/src/Mappers/GlobTypeMapperCache.php
@@ -1,0 +1,106 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use function array_keys;
+use ReflectionClass;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * The cached results of a GlobTypeMapper
+ */
+class GlobTypeMapperCache
+{
+    /** @var array<string,string> Maps a domain class to the GraphQL type annotated class */
+    private $mapClassToTypeArray = [];
+    /** @var array<string,string> Maps a GraphQL type name to the GraphQL type annotated class */
+    private $mapNameToType = [];
+    /** @var array<string,string[]> Maps a domain class to the factory method that creates the input type in the form [classname, methodname] */
+    private $mapClassToFactory = [];
+    /** @var array<string,string[]> Maps a GraphQL input type name to the factory method that creates the input type in the form [classname, methodname] */
+    private $mapInputNameToFactory = [];
+    /** @var array<string,array<int, callable&array>> Maps a GraphQL type name to one or many decorators (with the @Decorator annotation) */
+    private $mapInputNameToDecorator = [];
+
+    /**
+     * Merges annotations of a given class in the global cache.
+     *
+     * @param ReflectionClass $refClass
+     * @param GlobAnnotationsCache $globAnnotationsCache
+     */
+    public function registerAnnotations(ReflectionClass $refClass, GlobAnnotationsCache $globAnnotationsCache): void
+    {
+        $className = $refClass->getName();
+
+        $typeClassName = $globAnnotationsCache->getTypeClassName();
+        if ($typeClassName !== null) {
+            if (isset($this->mapClassToTypeArray[$typeClassName])) {
+                throw DuplicateMappingException::createForType($typeClassName, $this->mapClassToTypeArray[$typeClassName], $className);
+            }
+
+            $objectClassName                             = $typeClassName;
+            $this->mapClassToTypeArray[$objectClassName] = $className;
+
+            $typeName = $globAnnotationsCache->getTypeName();
+            $this->mapNameToType[$typeName] = $className;
+        }
+
+        foreach ($globAnnotationsCache->getFactories() as $methodName => [$inputName, $inputClassName, $isDefault, $declaringClass]) {
+            if ($isDefault) {
+                if (isset($this->mapClassToFactory[$inputClassName])) {
+                    throw DuplicateMappingException::createForFactory($inputClassName, $this->mapClassToFactory[$inputClassName][0], $this->mapClassToFactory[$inputClassName][1], $refClass->getName(), $methodName);
+                }
+            } else {
+                // If this is not the default factory, let's not map the class name to the factory.
+                $inputClassName = null;
+            }
+
+            $refArray = [$declaringClass, $methodName];
+            if ($inputClassName !== null) {
+                $this->mapClassToFactory[$inputClassName] = $refArray;
+            }
+            $this->mapInputNameToFactory[$inputName] = $refArray;
+        }
+
+        foreach ($globAnnotationsCache->getDecorators() as $methodName => [$inputName, $declaringClass]) {
+            $this->mapInputNameToDecorator[$inputName][] = [$declaringClass, $methodName];
+        }
+    }
+
+    public function getTypeByObjectClass(string $className): ?string
+    {
+        return $this->mapClassToTypeArray[$className] ?? null;
+    }
+
+    public function getSupportedClasses(): array
+    {
+        return array_keys($this->mapClassToTypeArray);
+    }
+
+    public function getTypeByGraphQLTypeName(string $graphqlTypeName): ?string
+    {
+        return $this->mapNameToType[$graphqlTypeName] ?? null;
+    }
+
+    public function getFactoryByGraphQLInputTypeName(string $graphqlTypeName): ?array
+    {
+        return $this->mapInputNameToFactory[$graphqlTypeName] ?? null;
+    }
+
+    /**
+     * @return array<int, string[]>|null A pointer to the decorators methods [$className, $methodName] or null on cache miss
+     */
+    public function getDecorateByGraphQLInputTypeName(string $graphqlTypeName): ?array
+    {
+        return $this->mapInputNameToDecorator[$graphqlTypeName] ?? null;
+    }
+
+    /**
+     * @return string[]|null A pointer to the factory [$className, $methodName] or null on cache miss
+     */
+    public function getFactoryByObjectClass(string $className): ?array
+    {
+        return $this->mapClassToFactory[$className] ?? null;
+    }
+}

--- a/src/Mappers/GlobTypeMapperCache.php
+++ b/src/Mappers/GlobTypeMapperCache.php
@@ -70,6 +70,9 @@ class GlobTypeMapperCache
         return $this->mapClassToTypeArray[$className] ?? null;
     }
 
+    /**
+     * @return string[]
+     */
     public function getSupportedClasses(): array
     {
         return array_keys($this->mapClassToTypeArray);
@@ -80,6 +83,9 @@ class GlobTypeMapperCache
         return $this->mapNameToType[$graphqlTypeName] ?? null;
     }
 
+    /**
+     * @return string[] Maps a GraphQL input type name to the factory method that creates the input type in the form [classname, methodname]
+     */
     public function getFactoryByGraphQLInputTypeName(string $graphqlTypeName): ?array
     {
         return $this->mapInputNameToFactory[$graphqlTypeName] ?? null;


### PR DESCRIPTION
The cache handling code of GlobTypeMapper is extremely complex and makes the class hard to understand.

This PR simplifies this by moving the cache handling code to a third party package.

TODO: mark the library thecodingmachine/cache-utils as stable and remove the minimum-stability:dev section of composer.json before merging this PR.