### PR TITLE
Improving non nullable arguments

### DIFF
--- a/src/InputTypeGenerator.php
+++ b/src/InputTypeGenerator.php
@@ -45,7 +45,7 @@ class InputTypeGenerator
 
         if (! isset($this->cache[$inputName])) {
             // TODO: add comment argument.
-            $this->cache[$inputName] = new ResolvableMutableInputObjectType($inputName, $this->fieldsBuilder, $object, $methodName, null);
+            $this->cache[$inputName] = new ResolvableMutableInputObjectType($inputName, $this->fieldsBuilder, $object, $methodName, null, $method->getNumberOfRequiredParameters() === 0);
         }
 
         return $this->cache[$inputName];

--- a/src/Mappers/Parameters/TypeMapper.php
+++ b/src/Mappers/Parameters/TypeMapper.php
@@ -37,6 +37,7 @@ use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\TypeMappingException;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
+use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use TheCodingMachine\GraphQLite\Types\UnionType;
 use Webmozart\Assert\Assert;
@@ -166,7 +167,10 @@ class TypeMapper implements ParameterMapperInterface
         } else {
             try {
                 $graphQlType = $this->toGraphQlType($type, null, $mapToInputType, $refMethod, $docBlockObj, $argumentName);
-                if (! $isNullable) {
+                // The type is non nullable if the PHP argument is non nullable
+                // There is an exception: if the PHP argument is non nullable but points to a factory that can called without passing any argument,
+                // then, the input type is nullable (and we can still create an empty object).
+                if (! $isNullable && (! $graphQlType instanceof ResolvableMutableInputObjectType || $graphQlType->isInstantiableWithoutParameters() === false)) {
                     $graphQlType = GraphQLType::nonNull($graphQlType);
                 }
             } catch (TypeMappingException | CannotMapTypeExceptionInterface $e) {

--- a/src/Parameters/InputTypeParameter.php
+++ b/src/Parameters/InputTypeParameter.php
@@ -8,10 +8,8 @@ use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
+use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
 
-/**
- * Typically the first parameter of "external" fields that will be filled with the Source object.
- */
 class InputTypeParameter implements ParameterInterface
 {
     /** @var string */
@@ -52,6 +50,12 @@ class InputTypeParameter implements ParameterInterface
 
         if ($this->doesHaveDefaultValue) {
             return $this->defaultValue;
+        }
+
+        // Special case: if an argument is not provided for a factory BUT the factory can be instantiated without
+        // passing any argument. Let's resolve that.
+        if ($this->type instanceof ResolvableMutableInputObjectType && $this->type->isInstantiableWithoutParameters()) {
+            return $this->argumentResolver->resolve($source, [], $context, $info, $this->type);
         }
 
         throw MissingArgumentException::create($this->name);

--- a/tests/Fixtures/Integration/Controllers/FilterController.php
+++ b/tests/Fixtures/Integration/Controllers/FilterController.php
@@ -4,6 +4,7 @@
 namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Controllers;
 
 
+use function array_map;
 use GraphQL\Type\Definition\ResolveInfo;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Filter;
@@ -17,6 +18,18 @@ class FilterController
     public function echoFilters(Filter $filter): array
     {
         return array_map(static function($item) { return (string) $item; }, $filter->getValues());
+    }
+
+    /**
+     * @Query()
+     * @return string[]|null
+     */
+    public function echoNullableFilters(?Filter $filter): ?array
+    {
+        if ($filter === null) {
+            return null;
+        }
+        return $this->echoFilters($filter);
     }
 
     /**

--- a/tests/Fixtures/Integration/Models/Filter.php
+++ b/tests/Fixtures/Integration/Models/Filter.php
@@ -40,7 +40,7 @@ class Filter
      * @Factory()
      * @param string[] $values
      */
-    public static function create(array $values): self
+    public static function create(array $values = []): self
     {
         return new self($values);
     }

--- a/tests/Fixtures/Integration/Types/FilterDecorator.php
+++ b/tests/Fixtures/Integration/Types/FilterDecorator.php
@@ -17,7 +17,7 @@ class FilterDecorator
      * @param int[] $moreValues
      * @return Filter
      */
-    public function decorate(Filter $filter, array $moreValues): Filter
+    public function decorate(Filter $filter, array $moreValues = []): Filter
     {
         $filter->mergeValues($moreValues);
         return $filter;
@@ -29,7 +29,7 @@ class FilterDecorator
      * @param int[] $evenMoreValues
      * @return Filter
      */
-    public static function staticDecorate(Filter $filter, array $evenMoreValues): Filter
+    public static function staticDecorate(Filter $filter, array $evenMoreValues = []): Filter
     {
         $filter->mergeValues($evenMoreValues);
         return $filter;

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -589,6 +589,29 @@ class EndToEndTest extends TestCase
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
 
+    public function testNullableTypesWithOptionnalFactoryArguments()
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            echoNullableFilters
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'echoNullableFilters' => null
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
+
     public function testEndToEndResolveInfo()
     {
         /**

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -50,6 +50,7 @@ use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use function var_dump;
+use function var_export;
 
 class EndToEndTest extends TestCase
 {
@@ -562,6 +563,29 @@ class EndToEndTest extends TestCase
 
         $this->assertSame([
             'echoFilters' => [ "foo", "bar", "12", "42", "62" ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
+
+    public function testNonNullableTypesWithOptionnalFactoryArguments()
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            echoFilters
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'echoFilters' => []
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
 

--- a/tests/Types/ResolvableInputObjectTypeTest.php
+++ b/tests/Types/ResolvableInputObjectTypeTest.php
@@ -21,7 +21,8 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
             $this->getFieldsBuilder(),
             new TestFactory(),
             'myFactory',
-            'my comment');
+            'my comment',
+            false);
 
         $this->assertSame('InputObject', $inputType->name);
         $inputType->freeze();
@@ -52,7 +53,8 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
             $this->getFieldsBuilder(),
             $testFactory,
             'myFactory',
-            'my comment');
+            'my comment',
+            false);
 
         $inputType->decorate([$testFactory, 'myDecorator']);
 
@@ -69,7 +71,8 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
             $this->getFieldsBuilder(),
             new TestFactory(),
             'myListFactory',
-            null);
+            null,
+            false);
 
         $obj = $inputType->resolve(new stdClass(), ['date' => '2018-12-25', 'stringList' =>
             [

--- a/tests/Types/ResolvableMutableInputObjectTypeTest.php
+++ b/tests/Types/ResolvableMutableInputObjectTypeTest.php
@@ -66,6 +66,20 @@ class ResolvableMutableInputObjectTypeTest extends AbstractQueryProviderTest
         $inputType->resolve(new stdClass(), ['string' => 'foobar'], null, $resolveInfo);
     }
 
+    public function testDecoratorDoesNotModifyInstantiableWithoutParameters(): void
+    {
+        $testFactory = new TestFactory();
+        $inputType = new ResolvableMutableInputObjectType('InputObject',
+            $this->getFieldsBuilder(),
+            $testFactory,
+            'myFactory',
+            'my comment',
+            false);
+
+        $inputType->decorate([$testFactory, 'myDecorator']);
+        $this->assertFalse($inputType->isInstantiableWithoutParameters());
+    }
+
     public function testListResolve(): void
     {
         $inputType = new ResolvableMutableInputObjectType('InputObject2',

--- a/tests/Types/ResolvableMutableInputObjectTypeTest.php
+++ b/tests/Types/ResolvableMutableInputObjectTypeTest.php
@@ -12,7 +12,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory;
 use TheCodingMachine\GraphQLite\GraphQLException;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 
-class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
+class ResolvableMutableInputObjectTypeTest extends AbstractQueryProviderTest
 {
 
     public function testResolve(): void
@@ -54,9 +54,10 @@ class ResolvableInputObjectTypeTest extends AbstractQueryProviderTest
             $testFactory,
             'myFactory',
             'my comment',
-            false);
+            true);
 
         $inputType->decorate([$testFactory, 'myDecorator']);
+        $this->assertFalse($inputType->isInstantiableWithoutParameters());
 
         $resolveInfo = $this->createMock(ResolveInfo::class);
 


### PR DESCRIPTION
Currently, if an argument is non-nullable in PHP, it is also non nullable in GraphQL.
But sometimes, it could be interesting for a non-nullable argument in PHP to be nullable in GraphQL.

In the very specific case where we can create the factory with no parameters.
In this case, it makes little sense to force the GraphQL user to pass the parameters.

```php
/**
 * @Factory()
 */
public function createFilter(int $somevalue = 3, string $someothervalue = "foo"): Filter { ... }
```

In this case, if a query looks like this:

```php
/**
 * @Query()
 */
public function myQuery(Filter $filter): ...
```

it makes little sense to force the user to pass a "filter: {}" in the GraphQL parameters. Not specifying the filter should still call the Factory and not trigger an error.

Beware!
If the factory is:

```php
/**
 * @Query()
 */
public function myQuery(?Filter $filter): ...
```

Then we should still aim for "null" as the default value.