### PR TITLE
Forcing declaration of autowired services through @Autowire annotation

### DIFF
--- a/docs/other_frameworks.md
+++ b/docs/other_frameworks.md
@@ -70,10 +70,6 @@ $factory->prodMode();
 // Enables dev-mode (this is the default mode: cache settings optimized for best developer experience).
 // This is a shortcut for `$schemaFactory->setGlobTtl(2)`
 $factory->devMode();
-// Autowiring parameter: Look-up services based on the type-hint (enabled by default)
-$schemaFactory::setAutowireServiceOnClassName(true);
-// Autowiring parameter: Look-up services based on the parameter name (disabled by default)
-$schemaFactory::setAutowireServiceOnParameterName(true);
 ```
 
 ## Minimal example

--- a/src/Annotations/Autowire.php
+++ b/src/Annotations/Autowire.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Annotations;
+
+/**
+ * Use this annotation to autowire a service from the container into a given parameter of a field/query/mutation.
+ *
+ * @Annotation
+ * @Target({"ANNOTATION"})
+ * @Attributes({
+ *   @Attribute("identifier", type = "string")
+ * })
+ */
+class Autowire implements ParameterAnnotationInterface
+{
+    /** @var string|null */
+    private $identifier;
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public function __construct(array $values)
+    {
+        $this->identifier = $values['identifier'] ?? $values['value'] ?? null;
+    }
+
+    public function getIdentifier(): ?string
+    {
+        return $this->identifier;
+    }
+}

--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use BadMethodCallException;
+use function array_filter;
+use function array_pop;
+use function count;
 use function ltrim;
 
 /**
@@ -14,15 +17,18 @@ use function ltrim;
  * @Target({"METHOD"})
  * @Attributes({
  *   @Attribute("for", type = "string"),
- *   @Attribute("inputType", type = "string")
+ *   @Attribute("inputType", type = "string"),
+ *   @Attribute("annotations", type = "array<TheCodingMachine\GraphQLite\Annotations\ParameterAnnotationInterface>")
  * })
  */
 class Parameter
 {
     /** @var string */
     private $for;
-    /** @var string */
+    /** @var string|null */
     private $inputType;
+    /** @var array<ParameterAnnotationInterface> */
+    private $annotations;
 
     /**
      * @param array<string, mixed> $values
@@ -31,11 +37,12 @@ class Parameter
      */
     public function __construct(array $values)
     {
-        if (! isset($values['for'], $values['inputType'])) {
-            throw new BadMethodCallException('The @Parameter annotation must be passed a target and an input type. For instance: "@Parameter(for="$input", inputType="MyInputType")"');
+        if (! isset($values['for'])) {
+            throw new BadMethodCallException('The @Parameter annotation must be passed a target. For instance: "@Parameter(for="$input", inputType="MyInputType")"');
         }
         $this->for       = ltrim($values['for'], '$');
-        $this->inputType = $values['inputType'];
+        $this->inputType = $values['inputType'] ?? null;
+        $this->annotations = $values['annotations'] ?? [];
     }
 
     public function getFor(): string
@@ -43,8 +50,46 @@ class Parameter
         return $this->for;
     }
 
-    public function getInputType(): string
+    public function getInputType(): ?string
     {
         return $this->inputType;
+    }
+
+    /**
+     * @return array<ParameterAnnotationInterface>
+     */
+    public function getAllAnnotations(): array
+    {
+        return $this->annotations;
+    }
+
+    /**
+     * Return annotations of the $className type
+     *
+     * @return array<int, ParameterAnnotationInterface>
+     */
+    public function getAnnotationsByType(string $className): array
+    {
+        return array_filter($this->annotations, static function (ParameterAnnotationInterface $annotation) use ($className) {
+            return $annotation instanceof $className;
+        });
+    }
+
+    /**
+     * Returns at most 1 annotation of the $className type.
+     */
+    public function getAnnotationByType(string $className): ?ParameterAnnotationInterface
+    {
+        $annotations = $this->getAnnotationsByType($className);
+        $count = count($annotations);
+        if ($count > 1) {
+            throw TooManyAnnotationsException::forClass($className);
+        }
+
+        if ($count === 0) {
+            return null;
+        }
+
+        return array_pop($annotations);
     }
 }

--- a/src/Annotations/ParameterAnnotationInterface.php
+++ b/src/Annotations/ParameterAnnotationInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Annotations;
+
+/**
+ * Modifies the behaviour of a single parameter.
+ *
+ * Annotations implementing this interface can be used inside \@Parameter(annotations={})
+ */
+interface ParameterAnnotationInterface
+{
+}

--- a/src/Mappers/Parameters/ContainerParameterMapper.php
+++ b/src/Mappers/Parameters/ContainerParameterMapper.php
@@ -8,44 +8,48 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Type;
 use Psr\Container\ContainerInterface;
 use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Annotations\Autowire;
 use TheCodingMachine\GraphQLite\Annotations\Parameter;
 use TheCodingMachine\GraphQLite\Parameters\ContainerParameter;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 
 /**
- * Tries to map parameters with FQCN type hints to a container entry with the FQCN or the parameter name.
+ * Maps parameters with the \@Autowire annotation to container entry based on the FQCN or the passed identifier.
  */
 class ContainerParameterMapper implements ParameterMapperInterface
 {
     /** @var ContainerInterface */
     private $container;
-    /** @var bool */
-    private $mapFullyQualifiedClassName;
-    /** @var bool */
-    private $mapParameterName;
 
-    public function __construct(ContainerInterface $container, bool $mapFullyQualifiedClassName, bool $mapParameterName)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-        $this->mapFullyQualifiedClassName = $mapFullyQualifiedClassName;
-        $this->mapParameterName = $mapParameterName;
     }
 
     public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, ?Type $paramTagType, ?Parameter $parameterAnnotation): ?ParameterInterface
     {
-        if ($this->mapParameterName) {
-            $parameterName = $parameter->getName();
-            if ($this->container->has($parameterName)) {
-                return new ContainerParameter($this->container, $parameterName);
-            }
-        }
-        if ($this->mapFullyQualifiedClassName) {
-            $type = $parameter->getType();
-            if ($type !== null && $this->container->has($type->getName())) {
-                return new ContainerParameter($this->container, $type->getName());
-            }
+        if ($parameterAnnotation === null) {
+            return null;
         }
 
-        return null;
+        /**
+         * @var Autowire|null $autowire
+         */
+        $autowire = $parameterAnnotation->getAnnotationByType(Autowire::class);
+
+        if ($autowire === null) {
+            return null;
+        }
+
+        $id = $autowire->getIdentifier();
+        if ($id === null) {
+            $type = $parameter->getType();
+            if ($type === null) {
+                throw MissingAutowireTypeException::create($parameter);
+            }
+            $id = $type->getName();
+        }
+
+        return new ContainerParameter($this->container, $id);
     }
 }

--- a/src/Mappers/Parameters/MissingAutowireTypeException.php
+++ b/src/Mappers/Parameters/MissingAutowireTypeException.php
@@ -15,6 +15,6 @@ class MissingAutowireTypeException extends Exception
         $declaringClass = $refParameter->getDeclaringClass();
         Assert::notNull($declaringClass, 'Parameter passed must be a parameter of a method, not a parameter of a function.');
 
-        return new self('For parameter $' . $refParameter->getName() . ' in ' . $declaringClass . '::' . $refParameter->getDeclaringFunction() . ', annotated with annotation @Autowire, you must either provide a type-hint or specify the container identifier with @Autowire(identifier="my_service")');
+        return new self('For parameter $' . $refParameter->getName() . ' in ' . $declaringClass->getName() . '::' . $refParameter->getDeclaringFunction()->getName() . ', annotated with annotation @Autowire, you must either provide a type-hint or specify the container identifier with @Autowire(identifier="my_service")');
     }
 }

--- a/src/Mappers/Parameters/MissingAutowireTypeException.php
+++ b/src/Mappers/Parameters/MissingAutowireTypeException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
+
+use Exception;
+use ReflectionParameter;
+use Webmozart\Assert\Assert;
+
+class MissingAutowireTypeException extends Exception
+{
+    public static function create(ReflectionParameter $refParameter): self
+    {
+        $declaringClass = $refParameter->getDeclaringClass();
+        Assert::notNull($declaringClass, 'Parameter passed must be a parameter of a method, not a parameter of a function.');
+
+        return new self('For parameter $' . $refParameter->getName() . ' in ' . $declaringClass . '::' . $refParameter->getDeclaringFunction() . ', annotated with annotation @Autowire, you must either provide a type-hint or specify the container identifier with @Autowire(identifier="my_service")');
+    }
+}

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -76,10 +76,6 @@ class SchemaFactory
     private $globTtl = 2;
     /** @var array<int, FieldMiddlewareInterface> */
     private $fieldMiddlewares = [];
-    /** @var bool */
-    private $autowireServiceOnClassName = true;
-    /** @var bool */
-    private $autowireServiceOnParameterName = false;
 
     public function __construct(CacheInterface $cache, ContainerInterface $container)
     {
@@ -244,22 +240,6 @@ class SchemaFactory
         return $this;
     }
 
-    /**
-     * Whether we should autowire services from the container in the function parameters based on the fully-qualified class name.
-     */
-    public function setAutowireServiceOnClassName(bool $autowireServiceOnClassName): void
-    {
-        $this->autowireServiceOnClassName = $autowireServiceOnClassName;
-    }
-
-    /**
-     * Whether we should autowire services from the container in the function parameters based on the parameter name.
-     */
-    public function setAutowireServiceOnParameterName(bool $autowireServiceOnParameterName): void
-    {
-        $this->autowireServiceOnParameterName = $autowireServiceOnParameterName;
-    }
-
     public function createSchema(): Schema
     {
         $annotationReader      = new AnnotationReader($this->getDoctrineAnnotationReader(), AnnotationReader::LAX_MODE);
@@ -289,9 +269,7 @@ class SchemaFactory
 
         $parameterMappers         = $this->parameterMappers;
         $parameterMappers[]       = new ResolveInfoParameterMapper();
-        if ($this->autowireServiceOnClassName === true || $this->autowireServiceOnParameterName === true) {
-            $parameterMappers[]       = new ContainerParameterMapper($this->container, $this->autowireServiceOnClassName, $this->autowireServiceOnParameterName);
-        }
+        $parameterMappers[]       = new ContainerParameterMapper($this->container);
         $compositeParameterMapper = new CompositeParameterMapper($parameterMappers);
 
         $fieldsBuilder = new FieldsBuilder(

--- a/tests/Annotations/ParameterTest.php
+++ b/tests/Annotations/ParameterTest.php
@@ -11,7 +11,7 @@ class ParameterTest extends TestCase
     public function testException()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('The @Parameter annotation must be passed a target and an input type. For instance: "@Parameter(for="$input", inputType="MyInputType")"');
-        new Parameter(['for'=>'foo']);
+        $this->expectExceptionMessage('The @Parameter annotation must be passed a target. For instance: "@Parameter(for="$input", inputType="MyInputType")"');
+        new Parameter(['annotations'=>[]]);
     }
 }

--- a/tests/Annotations/ParameterTest.php
+++ b/tests/Annotations/ParameterTest.php
@@ -14,4 +14,33 @@ class ParameterTest extends TestCase
         $this->expectExceptionMessage('The @Parameter annotation must be passed a target. For instance: "@Parameter(for="$input", inputType="MyInputType")"');
         new Parameter(['annotations'=>[]]);
     }
+
+    public function testGetAnnotationByTypeException()
+    {
+        $parameter = new Parameter([
+            'for' => 'foo',
+            'annotations' => [
+                new Autowire([]),
+                new Autowire([])
+            ]
+        ]);
+
+        $this->expectException(TooManyAnnotationsException::class);
+        $parameter->getAnnotationByType(Autowire::class);
+    }
+
+    public function testGetAllAnnotations()
+    {
+        $annotations = [
+            new Autowire([]),
+            new Autowire([])
+        ];
+
+        $parameter = new Parameter([
+            'for' => 'foo',
+            'annotations' => $annotations
+        ]);
+
+        $this->assertSame($annotations, $parameter->getAllAnnotations());
+    }
 }

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -10,12 +10,14 @@ use Psr\Http\Message\UploadedFileInterface;
 use stdClass;
 use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\Logged;
+use TheCodingMachine\GraphQLite\Annotations\Parameter;
 use TheCodingMachine\GraphQLite\Annotations\Right;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
 use TheCodingMachine\GraphQLite\TypeRegistry;
+use TheCodingMachine\GraphQLite\Annotations\Autowire;
 
 /**
  * @Type()
@@ -176,6 +178,8 @@ class Contact
 
     /**
      * @Field()
+     * @Parameter(for="testService", annotations={@Autowire(identifier="testService")})
+     * @Parameter(for="$otherTestService", annotations={@Autowire})
      * @return string
      */
     public function injectService(string $testService, stdClass $otherTestService = null): string

--- a/tests/Mappers/Parameters/ContainerParameterMapperTest.php
+++ b/tests/Mappers/Parameters/ContainerParameterMapperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
+
+use phpDocumentor\Reflection\DocBlock;
+use ReflectionMethod;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\Annotations\Parameter;
+use TheCodingMachine\GraphQLite\Annotations\Autowire;
+
+class ContainerParameterMapperTest extends AbstractQueryProviderTest
+{
+
+    public function testMapParameter()
+    {
+        $mapper = new ContainerParameterMapper($this->getRegistry());
+
+        $refMethod = new ReflectionMethod(__CLASS__, 'dummy');
+        $parameter = $refMethod->getParameters()[0];
+
+        $this->expectException(MissingAutowireTypeException::class);
+        $this->expectExceptionMessage('For parameter $foo in TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterMapperTest::dummy, annotated with annotation @Autowire, you must either provide a type-hint or specify the container identifier with @Autowire(identifier="my_service")');
+        $mapper->mapParameter($parameter,
+            new DocBlock(), null, $this->getAnnotationReader()->getParameterAnnotation($parameter));
+    }
+
+    /**
+     * @Parameter(for="foo", annotations={@Autowire})
+     */
+    private function dummy($foo) {
+
+    }
+}

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -35,8 +35,6 @@ class SchemaFactoryTest extends TestCase
         $factory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
         $factory->addQueryProvider(new AggregateQueryProvider([]));
         $factory->addFieldMiddleware(new FieldMiddlewarePipe());
-        $factory->setAutowireServiceOnClassName(true);
-        $factory->setAutowireServiceOnParameterName(true);
 
         $schema = $factory->createSchema();
 


### PR DESCRIPTION
The fact that GraphQLite tries automatically to autowire dependencies leads to problems, especially with autowiring containers.
Indeed, with autowiring containers, it is not immediately clear whether a parameter type-hint means we want an input type or a service from the container.

As a result, a misconfigured factory could go unnoticed as the autowiring container would automatically kick in and respond instead of the input type generator.
This leads to hard to debug code.

A simple solution is to make autowiring explicit. By stating that a parameter is meant to be autowired, we make error messages more relevant and when reading the code, the intent is clearer.