### PR TITLE
Fixing documentation on enums

### DIFF
--- a/docs/type_mapping.md
+++ b/docs/type_mapping.md
@@ -207,7 +207,9 @@ class StatusEnum extends Enum
  */
 public function users(StatusEnum $status): array
 {
-    if ($status === StatusEum::ON()) {
+    if ($status == StatusEum::ON()) {
+        // Note that the "magic" ON() method returns an instance of the StatusEnum class.
+        // Also, note that we are comparing this instance using "==" (using "===" would fail as we have 2 different instances here)
         // ...
     }
     // ...


### PR DESCRIPTION
As noted in #91, documentation about enum is wrong as a new instance of the enum class is returned for each call of the magic static method.
Closes #91.