### PR TITLE
Fixing GlobTypeCache duration

### DIFF
--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -103,8 +103,8 @@ final class GlobTypeMapper implements TypeMapperInterface
         $this->namingStrategy      = $namingStrategy;
         $this->cache               = $cache;
         $cachePrefix = str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $namespace);
-        $this->cacheContract       = new Psr16Adapter($this->cache, $cachePrefix, $this->globTtl ?? 0);
         $this->globTtl             = $globTtl;
+        $this->cacheContract       = new Psr16Adapter($this->cache, $cachePrefix, $this->globTtl ?? 0);
         $this->mapTtl              = $mapTtl;
         $this->inputTypeGenerator  = $inputTypeGenerator;
         $this->inputTypeUtils      = $inputTypeUtils;


### PR DESCRIPTION
Following migration to Symfony contracts, a bug was introduced in the management of TTL for the Glob cache.
This PR fixes the bug.