### PR TITLE
Factories in abstract classes are not handled correctly

### DIFF
--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -196,7 +196,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                     if ($factory !== null) {
                         [$inputName, $className] = $this->inputTypeUtils->getInputTypeNameAndClassName($method);
 
-                        $annotationsCache->registerFactory($method->getName(), $inputName, $className, $factory->isDefault(), $method->getDeclaringClass()->getName());
+                        $annotationsCache->registerFactory($method->getName(), $inputName, $className, $factory->isDefault(), $refClass->getName());
                         $containsAnnotations = true;
                     }
 
@@ -206,7 +206,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                         continue;
                     }
 
-                    $annotationsCache->registerDecorator($method->getName(), $decorator->getInputTypeName(), $method->getDeclaringClass()->getName());
+                    $annotationsCache->registerDecorator($method->getName(), $decorator->getInputTypeName(), $refClass->getName());
                     $containsAnnotations = true;
                 }
 

--- a/tests/Fixtures/InheritedInputTypes/AbstractTestFactory.php
+++ b/tests/Fixtures/InheritedInputTypes/AbstractTestFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\InheritedInputTypes;
+
+use DateTimeInterface;
+use function implode;
+use TheCodingMachine\GraphQLite\Annotations\Factory;
+use TheCodingMachine\GraphQLite\Fixtures\TestObject;
+use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
+use TheCodingMachine\GraphQLite\Fixtures\TestObjectWithRecursiveList;
+
+abstract class AbstractTestFactory
+{
+    /**
+     * @Factory()
+     */
+    public function myFactory(string $string, bool $bool = true): TestObject
+    {
+        return new TestObject($string, $bool);
+    }
+}

--- a/tests/Fixtures/InheritedInputTypes/ChildTestFactory.php
+++ b/tests/Fixtures/InheritedInputTypes/ChildTestFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\InheritedInputTypes;
+
+use DateTimeInterface;
+use function implode;
+use TheCodingMachine\GraphQLite\Annotations\Factory;
+use TheCodingMachine\GraphQLite\Fixtures\TestObject;
+use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
+use TheCodingMachine\GraphQLite\Fixtures\TestObjectWithRecursiveList;
+
+class ChildTestFactory extends AbstractTestFactory
+{
+
+}

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Cache\Simple\NullCache;
 use Test;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
+use TheCodingMachine\GraphQLite\Fixtures\InheritedInputTypes\ChildTestFactory;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Types\FilterDecorator;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
@@ -87,6 +88,24 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         $this->expectException(DuplicateMappingException::class);
         $this->expectExceptionMessage('The class \'TheCodingMachine\GraphQLite\Fixtures\TestObject\' should be mapped to only one GraphQL Input type. Two methods are pointing via the @Factory annotation to this class: \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory::myFactory\' and \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory2::myFactory\'');
         $mapper->canMapClassToInputType(TestObject::class);
+    }
+
+    public function testGlobTypeMapperInheritedInputTypesException()
+    {
+        $container = new Picotainer([
+            ChildTestFactory::class => function() {
+                return new ChildTestFactory();
+            }
+        ]);
+
+        $typeGenerator = $this->getTypeGenerator();
+
+        $mapper = new GlobTypeMapper('TheCodingMachine\GraphQLite\Fixtures\InheritedInputTypes', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), new NullCache());
+
+        //$this->expectException(DuplicateMappingException::class);
+        //$this->expectExceptionMessage('The class \'TheCodingMachine\GraphQLite\Fixtures\TestObject\' should be mapped to only one GraphQL Input type. Two methods are pointing via the @Factory annotation to this class: \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory::myFactory\' and \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory2::myFactory\'');
+        $this->assertTrue($mapper->canMapClassToInputType(TestObject::class));
+        $mapper->mapClassToInputType(TestObject::class);
     }
 
     public function testGlobTypeMapperClassNotFoundException()


### PR DESCRIPTION
A @Factory in an abstract class cannot be instantiated correctly because currently, GraphQLite tries to instantiate the abstract class instead of the main class in the container.