### PR TITLE
Adding type checking of returned resolved value

### DIFF
--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -4,21 +4,14 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
-use function get_class;
-use function gettype;
 use GraphQL\Deferred;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\NullableType;
-use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
-use function is_array;
-use function is_iterable;
-use function is_object;
 use TheCodingMachine\GraphQLite\Middlewares\MissingAuthorizationException;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
@@ -28,6 +21,8 @@ use Webmozart\Assert\Assert;
 use function array_map;
 use function array_unshift;
 use function array_values;
+use function get_class;
+use function is_object;
 
 /**
  * A GraphQL field that maps to a PHP method automatically.
@@ -135,23 +130,24 @@ class QueryField extends FieldDefinition
      * We are sure the returned value is of the correct type... except if the return type is type-hinted as an array.
      * In this case, PHP does nothing for us and we should check the user returned what he documented.
      *
-     * @param $result
+     * @param mixed $result
      */
     private function assertReturnType($result): void
     {
         $type = $this->removeNonNull($this->getType());
-        if (!$type instanceof ListOfType) {
+        if (! $type instanceof ListOfType) {
             return;
         }
 
         ResolveUtils::assertInnerReturnType($result, $type);
     }
 
-    private function removeNonNull(Type $type): NullableType
+    private function removeNonNull(Type $type): Type
     {
         if ($type instanceof NonNull) {
             return $type->getWrappedType();
         }
+
         return $type;
     }
 

--- a/src/ResolveUtils.php
+++ b/src/ResolveUtils.php
@@ -48,10 +48,10 @@ class ResolveUtils
             return;
         }
 
+        // TODO: it would be great to check if this is the actual object type we were expecting
         if (! is_object($result)) {
             throw TypeMismatchException::expectedObject($result);
         }
-        // TODO: it would be great to check if this is the actual object type we were expecting
     }
 
     private static function removeNonNull(Type $type): Type

--- a/src/ResolveUtils.php
+++ b/src/ResolveUtils.php
@@ -48,10 +48,10 @@ class ResolveUtils
             return;
         }
 
-        // TODO: it would be great to check if this is the actual object type we were expecting
         if (! is_object($result)) {
             throw TypeMismatchException::expectedObject($result);
         }
+        // TODO: it would be great to check if this is the actual object type we were expecting
     }
 
     private static function removeNonNull(Type $type): Type

--- a/src/ResolveUtils.php
+++ b/src/ResolveUtils.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\NullableType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use function is_array;
@@ -19,6 +19,9 @@ use function is_object;
  */
 class ResolveUtils
 {
+    /**
+     * @param mixed $result
+     */
     public static function assertInnerReturnType($result, Type $type): void
     {
         if ($type instanceof NonNull && $result === null) {
@@ -29,7 +32,7 @@ class ResolveUtils
         }
         $type = self::removeNonNull($type);
         if ($type instanceof ListOfType) {
-            if (!is_iterable($result)) {
+            if (! is_iterable($result)) {
                 throw TypeMismatchException::expectedIterable($result);
             }
             // If this is an array, we can scan it and check the types.
@@ -41,20 +44,22 @@ class ResolveUtils
             // TODO: if this is an iterable (not an array, we might want to wrap the iterable in another
             // iterable that checks the type.
         }
-        if ($type instanceof ObjectType) {
-            if (!is_object($result)) {
-                throw TypeMismatchException::expectedObject($result);
-            }
-            // TODO: it would be great to check if this is the actual object type we were expecting
+        if (! ($type instanceof ObjectType)) {
+            return;
         }
+
+        if (! is_object($result)) {
+            throw TypeMismatchException::expectedObject($result);
+        }
+        // TODO: it would be great to check if this is the actual object type we were expecting
     }
 
-    private static function removeNonNull(Type $type): NullableType
+    private static function removeNonNull(Type $type): Type
     {
         if ($type instanceof NonNull) {
             return $type->getWrappedType();
         }
+
         return $type;
     }
-
 }

--- a/src/ResolveUtils.php
+++ b/src/ResolveUtils.php
@@ -1,0 +1,60 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite;
+
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\NullableType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use function is_array;
+use function is_iterable;
+use function is_object;
+
+/**
+ * Utility class to assert resolved values against a type.
+ *
+ * @internal
+ */
+class ResolveUtils
+{
+    public static function assertInnerReturnType($result, Type $type): void
+    {
+        if ($type instanceof NonNull && $result === null) {
+            throw TypeMismatchException::unexpectedNullValue();
+        }
+        if ($result === null) {
+            return;
+        }
+        $type = self::removeNonNull($type);
+        if ($type instanceof ListOfType) {
+            if (!is_iterable($result)) {
+                throw TypeMismatchException::expectedIterable($result);
+            }
+            // If this is an array, we can scan it and check the types.
+            if (is_array($result)) {
+                foreach ($result as $item) {
+                    self::assertInnerReturnType($item, $type->getWrappedType());
+                }
+            }
+            // TODO: if this is an iterable (not an array, we might want to wrap the iterable in another
+            // iterable that checks the type.
+        }
+        if ($type instanceof ObjectType) {
+            if (!is_object($result)) {
+                throw TypeMismatchException::expectedObject($result);
+            }
+            // TODO: it would be great to check if this is the actual object type we were expecting
+        }
+    }
+
+    private static function removeNonNull(Type $type): NullableType
+    {
+        if ($type instanceof NonNull) {
+            return $type->getWrappedType();
+        }
+        return $type;
+    }
+
+}

--- a/src/TypeMismatchException.php
+++ b/src/TypeMismatchException.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
+
+use function gettype;
 
 /**
  * An exception thrown when a resolver returns a value that is not compatible with the GraphQL type.
@@ -13,18 +16,24 @@ class TypeMismatchException extends GraphQLException
         return new self('Unexpected null value for non nullable field.');
     }
 
+    /**
+     * @param mixed $result
+     */
     public static function expectedIterable($result): self
     {
-        return new self('Expected resolved value to be iterable but got "'.gettype($result).'"');
+        return new self('Expected resolved value to be iterable but got "' . gettype($result) . '"');
     }
 
+    /**
+     * @param mixed $result
+     */
     public static function expectedObject($result): self
     {
-        return new self('Expected resolved value to be an object but got "'.gettype($result).'"');
+        return new self('Expected resolved value to be an object but got "' . gettype($result) . '"');
     }
 
     public function addInfo(string $fieldName, string $className, string $methodName): void
     {
-        $this->message = 'In '.$className.'::'.$methodName.'() (declaring field "'.$fieldName.'"): ' . $this->message;
+        $this->message = 'In ' . $className . '::' . $methodName . '() (declaring field "' . $fieldName . '"): ' . $this->message;
     }
 }

--- a/src/TypeMismatchException.php
+++ b/src/TypeMismatchException.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite;
+
+/**
+ * An exception thrown when a resolver returns a value that is not compatible with the GraphQL type.
+ */
+class TypeMismatchException extends GraphQLException
+{
+    public static function unexpectedNullValue(): self
+    {
+        return new self('Unexpected null value for non nullable field.');
+    }
+
+    public static function expectedIterable($result): self
+    {
+        return new self('Expected resolved value to be iterable but got "'.gettype($result).'"');
+    }
+
+    public static function expectedObject($result): self
+    {
+        return new self('Expected resolved value to be an object but got "'.gettype($result).'"');
+    }
+
+    public function addInfo(string $fieldName, string $className, string $methodName): void
+    {
+        $this->message = 'In '.$className.'::'.$methodName.'() (declaring field "'.$fieldName.'"): ' . $this->message;
+    }
+}

--- a/tests/Fixtures/Integration/Controllers/ProductController.php
+++ b/tests/Fixtures/Integration/Controllers/ProductController.php
@@ -28,6 +28,23 @@ class ProductController
     }
 
     /**
+     * This is supposed to return an array of products... but it returns an array of array of Products.
+     * Useful to test error messages.
+     *
+     * @Query()
+     * @return Product[]
+     */
+    public function getProductsBadType(): array
+    {
+        return [
+            [
+                new Product('Foo', 42.0, ProductTypeEnum::NON_FOOD()),
+                new Product('Foo', 42.0, ProductTypeEnum::NON_FOOD()),
+            ]
+        ];
+    }
+
+    /**
      * @Query()
      */
     public function echoProductType(ProductTypeEnum $productType): ProductTypeEnum

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -48,6 +48,7 @@ use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQLite\TypeGenerator;
+use TheCodingMachine\GraphQLite\TypeMismatchException;
 use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
@@ -765,5 +766,30 @@ class EndToEndTest extends TestCase
         $this->assertSame([
             'echoDate' => '2019-05-05T01:02:03+00:00'
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
+
+    public function testEndToEndErrorHandlingOfInconstentTypesInArrays(): void
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            productsBadType {
+                name
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->expectException(TypeMismatchException::class);
+        $this->expectExceptionMessage('In TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers\\ProductController::getProductsBadType() (declaring field "productsBadType"): Expected resolved value to be an object but got "array"');
+        $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS);
     }
 }

--- a/tests/ResolveUtilsTest.php
+++ b/tests/ResolveUtilsTest.php
@@ -2,8 +2,10 @@
 
 namespace TheCodingMachine\GraphQLite;
 
+use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class ResolveUtilsTest extends TestCase
 {
@@ -17,5 +19,11 @@ class ResolveUtilsTest extends TestCase
     {
         $this->expectException(TypeMismatchException::class);
         ResolveUtils::assertInnerReturnType(12, Type::nonNull(Type::listOf(Type::string())));
+    }
+
+    public function testAssertObjectOk(): void
+    {
+        ResolveUtils::assertInnerReturnType(new stdClass(), new ObjectType(['name'=>'foo']));
+        $this->assertTrue(true);
     }
 }

--- a/tests/ResolveUtilsTest.php
+++ b/tests/ResolveUtilsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite;
+
+use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\TestCase;
+
+class ResolveUtilsTest extends TestCase
+{
+    public function testAssertNull(): void
+    {
+        $this->expectException(TypeMismatchException::class);
+        ResolveUtils::assertInnerReturnType(null, Type::nonNull(Type::string()));
+    }
+
+    public function testAssertList(): void
+    {
+        $this->expectException(TypeMismatchException::class);
+        ResolveUtils::assertInnerReturnType(12, Type::nonNull(Type::listOf(Type::string())));
+    }
+}


### PR DESCRIPTION
This PR adds some level of type checking to verify that a value returned by a resolver actually matches the expected return type.
This is especially useful for "array" return type that cannot be checked in depth by PHP.