### PR TITLE
Adding the ability to have non default @Type mapping

### DIFF
--- a/docs/multiple_output_types.md
+++ b/docs/multiple_output_types.md
@@ -1,0 +1,103 @@
+---
+id: multiple_output_types
+title: Mapping multiple output types for the same class
+sidebar_label: Class with multiple output types
+---
+<small>Available in GraphQLite 4.0+</small>
+
+In most cases, you have one PHP class and you want to map it to one GraphQL output type.
+
+But in very specific cases, you may want to use different GraphQL output type for the same class.
+For instance, depending on the context, you might want to prevent the user from accessing some fields of your object.
+
+To do so, you need to create 2 output types for the same PHP class. You typically do this using the "default" attribute of the `@Type` annotation.
+
+## Example
+
+Here is an example. Say we are manipulating products. When I query a `Product` details, I want to have access to all fields.
+But for some reason, I don't want to expose the price field of a product if I query the list of all products.  
+
+```php
+/**
+ * @Type()
+ */
+class Product
+{
+    // ...
+
+    /**
+     * @Field()
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @Field()
+     */
+    public function getPrice(): ?float
+    {
+        return $this->price;
+    }
+}
+```
+
+The `Product` class is declaring a classic GraphQL output type named "Product".
+
+```php
+/**
+ * @Type(class=Product::class, name="LimitedProduct", default=false)
+ * @SourceField(name="name")
+ */
+class LimitedProductType
+{
+    // ...
+
+    /**
+     * @Field()
+     */
+    public function getName(Product $product): string
+    {
+        return $product->getName();
+    }
+}
+```
+
+
+The `LimitedProductType` also declares a ["external" type](external_type_declaration.md) mapping the `Product` class.
+But pay special attention to the `@Type` annotation.
+
+First of all, we specify `name="LimitedProduct"`. This is useful to avoid having colliding names with the "Product" GraphQL output type
+that is already declared.
+
+Then, we specify `default=false`. This means that by default, the `Product` class should not be mapped to the `LimitedProductType`.
+This type will only be used when we explicitly request it.
+
+Finally, we can write our requests:
+
+```php
+class ProductController
+{
+    /**
+     * This field will use the default type.
+     *
+     * @Field
+     */
+    public function getProduct(int $id): Product { /* ... */ } 
+    
+    /**
+     * Because we use the "outputType" attribute, this field will use the other type.
+     *
+     * @Field(outputType="[LimitedProduct!]!")
+     * @return Product[]
+     */
+    public function getProducts(): array { /* ... */ } 
+}
+``` 
+
+Notice how the "outputType" attribute is used in the `@Field` annotation to force the output type.
+
+Is a result, when the end user calls the `product` query, we will have the possibility to fetch the `name` and `price` fields,
+but if he calls the `products` query, each product in the list will have a `name` field but no `price` field. We managed
+to successfully expose a different set of fields based on the query context.

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -18,6 +18,7 @@ use function ltrim;
  * @Attributes({
  *   @Attribute("class", type = "string"),
  *   @Attribute("name", type = "string"),
+ *   @Attribute("default", type = "bool")
  * })
  */
 class Type
@@ -27,6 +28,9 @@ class Type
 
     /** @var string|null */
     private $name;
+
+    /** @var bool */
+    private $default;
 
     /**
      * Is the class having the annotation a GraphQL type itself?
@@ -45,7 +49,11 @@ class Type
         } else {
             $this->selfType = true;
         }
+
         $this->name = $attributes['name'] ?? null;
+
+        // If no value is passed for default, "default" = true
+        $this->default = $attributes['default'] ?? true;
     }
 
     /**
@@ -79,5 +87,13 @@ class Type
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    /**
+     * Returns true if this type should map the targeted class by default.
+     */
+    public function isDefault(): bool
+    {
+        return $this->default;
     }
 }

--- a/src/Mappers/GlobAnnotationsCache.php
+++ b/src/Mappers/GlobAnnotationsCache.php
@@ -9,7 +9,7 @@ namespace TheCodingMachine\GraphQLite\Mappers;
  *
  * @internal
  */
-class GlobAnnotationsCache
+final class GlobAnnotationsCache
 {
     /** @var string|null */
     private $typeClassName;
@@ -17,16 +17,20 @@ class GlobAnnotationsCache
     /** @var string|null */
     private $typeName;
 
+    /** @var bool */
+    private $default;
+
     /** @var array<string, array<int, string|bool>> An array mapping a factory method name to an input name / class name / default flag / declaring class */
     private $factories = [];
 
     /** @var array<string, array<int, string>> An array mapping a decorator method name to an input name / declaring class */
     private $decorators = [];
 
-    public function setType(string $className, string $typeName): void
+    public function setType(string $className, string $typeName, bool $isDefault): void
     {
         $this->typeClassName = $className;
         $this->typeName = $typeName;
+        $this->default = $isDefault;
     }
 
     public function getTypeClassName(): ?string
@@ -37,6 +41,11 @@ class GlobAnnotationsCache
     public function getTypeName(): ?string
     {
         return $this->typeName;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->default;
     }
 
     public function registerFactory(string $methodName, string $inputName, ?string $className, bool $isDefault, string $declaringClass): void

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -181,7 +181,7 @@ final class GlobTypeMapper implements TypeMapperInterface
                 $type = $this->annotationReader->getTypeAnnotation($refClass);
                 if ($type !== null) {
                     $typeName = $this->namingStrategy->getOutputTypeName($className, $type);
-                    $annotationsCache->setType($type->getClass(), $typeName);
+                    $annotationsCache->setType($type->getClass(), $typeName, $type->isDefault());
                     $containsAnnotations = true;
                 }
 

--- a/src/Mappers/GlobTypeMapperCache.php
+++ b/src/Mappers/GlobTypeMapperCache.php
@@ -16,9 +16,9 @@ class GlobTypeMapperCache
     private $mapClassToTypeArray = [];
     /** @var array<string,string> Maps a GraphQL type name to the GraphQL type annotated class */
     private $mapNameToType = [];
-    /** @var array<string,string[]> Maps a domain class to the factory method that creates the input type in the form [classname, methodname] */
+    /** @var array<string,string[]> Maps a domain class to the factory method that creates the input type in the form [classname, methodName] */
     private $mapClassToFactory = [];
-    /** @var array<string,string[]> Maps a GraphQL input type name to the factory method that creates the input type in the form [classname, methodname] */
+    /** @var array<string,string[]> Maps a GraphQL input type name to the factory method that creates the input type in the form [classname, methodName] */
     private $mapInputNameToFactory = [];
     /** @var array<string,array<int, callable&array>> Maps a GraphQL type name to one or many decorators (with the @Decorator annotation) */
     private $mapInputNameToDecorator = [];
@@ -32,12 +32,14 @@ class GlobTypeMapperCache
 
         $typeClassName = $globAnnotationsCache->getTypeClassName();
         if ($typeClassName !== null) {
-            if (isset($this->mapClassToTypeArray[$typeClassName])) {
+            if (isset($this->mapClassToTypeArray[$typeClassName]) && $globAnnotationsCache->isDefault()) {
                 throw DuplicateMappingException::createForType($typeClassName, $this->mapClassToTypeArray[$typeClassName], $className);
             }
 
-            $objectClassName                             = $typeClassName;
-            $this->mapClassToTypeArray[$objectClassName] = $className;
+            if ($globAnnotationsCache->isDefault()) {
+                $objectClassName                             = $typeClassName;
+                $this->mapClassToTypeArray[$objectClassName] = $className;
+            }
 
             $typeName = $globAnnotationsCache->getTypeName();
             $this->mapNameToType[$typeName] = $className;

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -73,7 +73,7 @@ class TypeGenerator
             $annotatedObject = null;
         }
 
-        return TypeAnnotatedObjectType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper);
+        return TypeAnnotatedObjectType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper, ! $typeField->isDefault());
 
         /*return new ObjectType([
             'name' => $typeName,

--- a/src/Types/TypeAnnotatedObjectType.php
+++ b/src/Types/TypeAnnotatedObjectType.php
@@ -26,7 +26,7 @@ class TypeAnnotatedObjectType extends MutableObjectType
         parent::__construct($config);
     }
 
-    public static function createFromAnnotatedClass(string $typeName, string $className, ?object $annotatedObject, FieldsBuilder $fieldsBuilder, RecursiveTypeMapperInterface $recursiveTypeMapper): self
+    public static function createFromAnnotatedClass(string $typeName, string $className, ?object $annotatedObject, FieldsBuilder $fieldsBuilder, RecursiveTypeMapperInterface $recursiveTypeMapper, bool $doNotMapInterfaces): self
     {
         return new self($className, [
             'name' => $typeName,
@@ -55,7 +55,11 @@ class TypeAnnotatedObjectType extends MutableObjectType
 
                 return $fields;
             },
-            'interfaces' => static function () use ($className, $recursiveTypeMapper) {
+            'interfaces' => static function () use ($className, $recursiveTypeMapper, $doNotMapInterfaces) {
+                if ($doNotMapInterfaces === true) {
+                    return [];
+                }
+
                 return $recursiveTypeMapper->findInterfaces($className);
             },
         ]);

--- a/tests/Fixtures/Integration/Controllers/ContactController.php
+++ b/tests/Fixtures/Integration/Controllers/ContactController.php
@@ -58,4 +58,12 @@ class ContactController
             'Bill',
         ]);
     }
+
+    /**
+     * @Query(outputType="ContactOther")
+     */
+    public function getOtherContact(): Contact
+    {
+        return new Contact('Joe');
+    }
 }

--- a/tests/Fixtures/Integration/Types/ContactOtherType.php
+++ b/tests/Fixtures/Integration/Types/ContactOtherType.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Types;
+
+use function array_search;
+use function strtoupper;
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
+
+/**
+ * A test type that is not a default type.
+ *
+ * @Type(class=Contact::class, name="ContactOther", default=false)
+ */
+class ContactOtherType
+{
+    /**
+     * @Field()
+     */
+    public function fullName(Contact $contact): string
+    {
+        return strtoupper($contact->getName());
+    }
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -792,4 +792,31 @@ class EndToEndTest extends TestCase
         $this->expectExceptionMessage('In TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers\\ProductController::getProductsBadType() (declaring field "productsBadType"): Expected resolved value to be an object but got "array"');
         $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS);
     }
+
+    public function testEndToEndNonDefaultOutputType(): void
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            otherContact {
+                fullName
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'otherContact' => [
+                'fullName' => 'JOE'
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
 }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -6,6 +6,7 @@ use GraphQL\Error\Debug;
 use GraphQL\GraphQL;
 use GraphQL\Type\SchemaConfig;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\PhpFilesCache;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
@@ -27,7 +28,7 @@ class SchemaFactoryTest extends TestCase
     public function testCreateSchema(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new PhpFilesCache();
+        $cache = new ArrayCache();
 
         $factory = new SchemaFactory($cache, $container);
         $factory->setAuthenticationService(new VoidAuthenticationService());
@@ -46,7 +47,7 @@ class SchemaFactoryTest extends TestCase
     public function testSetters(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new PhpFilesCache();
+        $cache = new ArrayCache();
 
         $factory = new SchemaFactory($cache, $container);
 
@@ -77,7 +78,7 @@ class SchemaFactoryTest extends TestCase
     public function testException(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new PhpFilesCache();
+        $cache = new ArrayCache();
 
         $factory = new SchemaFactory($cache, $container);
 
@@ -88,7 +89,7 @@ class SchemaFactoryTest extends TestCase
     public function testException2(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
-        $cache = new PhpFilesCache();
+        $cache = new ArrayCache();
 
         $factory = new SchemaFactory($cache, $container);
         $factory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -4,7 +4,7 @@
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
     "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance"],
     "Performance": ["query-plan", "prefetch-method"],
-    "Advanced": ["file-uploads", "pagination", "custom-types", "field-middlewares", "extend_input_type", "internals", "troubleshooting", "migrating"],
+    "Advanced": ["file-uploads", "pagination", "custom-types", "field-middlewares", "extend_input_type", "multiple_output_types", "internals", "troubleshooting", "migrating"],
     "Reference": ["annotations_reference"]
   }
 }


### PR DESCRIPTION
This PR adds the ability to define a new output type using the @Type annotation without making this mapping map to the targetted PHP class by default.

In most cases, you have one PHP class and you want to map it to one GraphQL output type.

But in very specific cases, you may want to use different GraphQL output type for the same class.
For instance, depending on the context, you might want to prevent the user from accessing some fields of your object.

To do so, you need to create 2 output types for the same PHP class. You typically do this using the "default" attribute of the `@Type` annotation.

## Example

Here is an example. Say we are manipulating products. When I query a `Product` details, I want to have access to all fields.
But for some reason, I don't want to expose the price field of a product if I query the list of all products.  

```php
/**
 * @Type()
 */
class Product
{
    // ...

    /**
     * @Field()
     */
    public function getName(): string
    {
        return $this->name;
    }

    /**
     * @Field()
     */
    public function getPrice(): ?float
    {
        return $this->price;
    }
}
```

The `Product` class is declaring a classic GraphQL output type named "Product".

```php
/**
 * @Type(class=Product::class, name="LimitedProduct", default=false)
 * @SourceField(name="name")
 */
class LimitedProductType
{
    // ...

    /**
     * @Field()
     */
    public function getName(Product $product): string
    {
        return $product->getName();
    }
}
```


The `LimitedProductType` also declares a ["external" type](external_type_declaration.md) mapping the `Product` class.
But pay special attention to the `@Type` annotation.

First of all, we specify `name="LimitedProduct"`. This is useful to avoid having colliding names with the "Product" GraphQL output type
that is already declared.

Then, we specify `default=false`. This means that by default, the `Product` class should not be mapped to the `LimitedProductType`.
This type will only be used when we explicitly request it.

Finally, we can write our requests:

```php
class ProductController
{
    /**
     * This field will use the default type.
     *
     * @Field
     */
    public function getProduct(int $id): Product { /* ... */ } 
    
    /**
     * Because we use the "outputType" attribute, this field will use the other type.
     *
     * @Field(outputType="[LimitedProduct!]!")
     * @return Product[]
     */
    public function getProducts(): array { /* ... */ } 
}
``` 

Notice how the "outputType" attribute is used in the `@Field` annotation to force the output type.

Is a result, when the end user calls the `product` query, we will have the possibility to fetch the `name` and `price` fields,
but if he calls the `products` query, each product in the list will have a `name` field but no `price` field. We managed
to successfully expose a different set of fields based on the query context.
