### PR TITLE
Allowing targetting @ExtendType by name

### DIFF
--- a/docs/annotations_reference.md
+++ b/docs/annotations_reference.md
@@ -35,6 +35,8 @@ The `@Type` annotation is used to declare a GraphQL object type.
 Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 class          | *no*       | string | The targeted class. If no class is passed, the type applies to the current class. The current class is assumed to be an entity. If the "class" attribute is passed, [the class annotated with `@Type` is a service](external_type_declaration.md).
+name           | *no*       | string | The name of the GraphQL type generated. If not passed, the name of the class is used. If the class ends with "Type", the "Type" suffix is removed
+default        | *no*       | bool   | Defaults to *true*. Whether the targeted PHP class should be mapped by default to this type.
 
 
 ## @ExtendType annotation
@@ -45,7 +47,10 @@ The `@ExtendType` annotation is used to add fields to an existing GraphQL object
 
 Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
-class          | *yes*       | string | The targeted class. [The class annotated with `@ExtendType` is a service](extend_type.md).
+class          | see below  | string | The targeted class. [The class annotated with `@ExtendType` is a service](extend_type.md).
+name           | see below  | string | The targeted GraphQL output type.
+
+One and only one of "class" and "name" parameter can be passed at the same time.
 
 ## @Field annotation
 

--- a/docs/multiple_output_types.md
+++ b/docs/multiple_output_types.md
@@ -101,3 +101,26 @@ Notice how the "outputType" attribute is used in the `@Field` annotation to forc
 Is a result, when the end user calls the `product` query, we will have the possibility to fetch the `name` and `price` fields,
 but if he calls the `products` query, each product in the list will have a `name` field but no `price` field. We managed
 to successfully expose a different set of fields based on the query context.
+
+## Extending a non-default type
+
+If you want to extend a type using the `@ExtendType` annotation and if this type is declared as non-default,
+you need to target the type by name instead of by class.
+
+So instead of writing:
+
+```php
+/**
+ * @ExtendType(class=Product::class)
+ */
+```
+
+you will write:
+
+```php
+/**
+ * @ExtendType(name="LimitedProduct")
+ */
+```
+
+Notice how we use the "name" attribute instead of the "class" attribute in the `@ExtendType` annotation.

--- a/src/Annotations/ExtendType.php
+++ b/src/Annotations/ExtendType.php
@@ -16,23 +16,27 @@ use function ltrim;
  * @Target({"CLASS"})
  * @Attributes({
  *   @Attribute("class", type = "string"),
+ *   @Attribute("name", type = "string"),
  * })
  */
 class ExtendType
 {
-    /** @var string */
+    /** @var string|null */
     private $class;
+    /** @var string|null */
+    private $name;
 
     /**
      * @param mixed[] $attributes
      */
     public function __construct(array $attributes = [])
     {
-        if (! isset($attributes['class'])) {
-            throw new BadMethodCallException('In annotation @ExtendType, missing compulsory parameter "class".');
+        if (! isset($attributes['class']) && ! isset($attributes['name'])) {
+            throw new BadMethodCallException('In annotation @ExtendType, missing one of the compulsory parameter "class" or "name".');
         }
-        $this->class = $attributes['class'];
-        if (! class_exists($this->class)) {
+        $this->class = $attributes['class'] ?? null;
+        $this->name = $attributes['name'] ?? null;
+        if ($this->class !== null && ! class_exists($this->class)) {
             throw ClassNotFoundException::couldNotFindClass($this->class);
         }
     }
@@ -41,8 +45,19 @@ class ExtendType
      * Returns the name of the GraphQL query/mutation/field.
      * If not specified, the name of the method should be used instead.
      */
-    public function getClass(): string
+    public function getClass(): ?string
     {
+        if ($this->class === null) {
+            return null;
+        }
         return ltrim($this->class, '\\');
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
     }
 }

--- a/src/Annotations/ExtendType.php
+++ b/src/Annotations/ExtendType.php
@@ -50,12 +50,10 @@ class ExtendType
         if ($this->class === null) {
             return null;
         }
+
         return ltrim($this->class, '\\');
     }
 
-    /**
-     * @return string|null
-     */
     public function getName(): ?string
     {
         return $this->name;

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -26,7 +26,7 @@ use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewareInterface;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
-use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use Webmozart\Assert\Assert;
 use function array_merge;
@@ -363,10 +363,13 @@ class FieldsBuilder
                 $typeName = $extendTypeField->getName();
                 Assert::notNull($typeName);
                 $targetedType = $this->recursiveTypeMapper->mapNameToType($typeName);
-                if (! $targetedType instanceof TypeAnnotatedObjectType) {
-                    return [];
+                if (! $targetedType instanceof MutableObjectType) {
+                    throw CannotMapTypeException::extendTypeWithBadTargetedClass($refClass->getName(), $extendTypeField);
                 }
                 $objectClass = $targetedType->getMappedClassName();
+                if ($objectClass === null) {
+                    throw new CannotMapTypeException('@ExtendType(name="' . $extendTypeField->getName() . '") points to a GraphQL type that does not map a PHP class. Therefore, you cannot use the @SourceField annotation in conjunction with this @ExtendType.');
+                }
             }
         } else {
             throw MissingAnnotationException::missingTypeExceptionToUseSourceField();

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -360,8 +360,10 @@ class FieldsBuilder
             $objectClass = $extendTypeField->getClass();
             if ($objectClass === null) {
                 // We need to be able to fetch the mapped PHP class from the object type!
-                $targetedType = $this->recursiveTypeMapper->mapNameToType($extendTypeField->getName());
-                if (!$targetedType instanceof TypeAnnotatedObjectType) {
+                $typeName = $extendTypeField->getName();
+                Assert::notNull($typeName);
+                $targetedType = $this->recursiveTypeMapper->mapNameToType($typeName);
+                if (! $targetedType instanceof TypeAnnotatedObjectType) {
                     return [];
                 }
                 $objectClass = $targetedType->getMappedClassName();

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -26,6 +26,7 @@ use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewareInterface;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
+use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use Webmozart\Assert\Assert;
 use function array_merge;
@@ -357,6 +358,14 @@ class FieldsBuilder
             $objectClass = $typeField->getClass();
         } elseif ($extendTypeField !== null) {
             $objectClass = $extendTypeField->getClass();
+            if ($objectClass === null) {
+                // We need to be able to fetch the mapped PHP class from the object type!
+                $targetedType = $this->recursiveTypeMapper->mapNameToType($extendTypeField->getName());
+                if (!$targetedType instanceof TypeAnnotatedObjectType) {
+                    return [];
+                }
+                $objectClass = $targetedType->getMappedClassName();
+            }
         } else {
             throw MissingAnnotationException::missingTypeExceptionToUseSourceField();
         }

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -13,6 +13,7 @@ use GraphQL\Type\Definition\Type;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
 use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
 use Webmozart\Assert\Assert;
 use function array_filter;
@@ -122,5 +123,10 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
     public static function createForDecorateName(string $name, InputObjectType $type): self
     {
         return new self('cannot decorate GraphQL input type "' . $type->name . '" with type "' . $name . '". Check your TypeMapper configuration.');
+    }
+
+    public static function extendTypeWithInvalidName(ExtendType $extendType, string $className): self
+    {
+        return new self('For @ExtendType(name="'.$extendType->getName().'") annotation declared in class "'.$className.'", the "'.$extendType->getName().'" GraphQL type cannot be extended. You can only target types created with the @Type annotation.');
     }
 }

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -125,8 +125,18 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
         return new self('cannot decorate GraphQL input type "' . $type->name . '" with type "' . $name . '". Check your TypeMapper configuration.');
     }
 
-    public static function extendTypeWithInvalidName(ExtendType $extendType, string $className): self
+    public static function extendTypeWithBadTargetedClass(string $className, ExtendType $extendType): self
     {
-        return new self('For @ExtendType(name="' . $extendType->getName() . '") annotation declared in class "' . $className . '", the "' . $extendType->getName() . '" GraphQL type cannot be extended. You can only target types created with the @Type annotation.');
+        return new self('For ' . self::extendTypeToString($extendType) . ' annotation declared in class "' . $className . '", the pointed at GraphQL type cannot be extended. You can only target types extending the MutableObjectType (like types created with the @Type annotation).');
+    }
+
+    private static function extendTypeToString(ExtendType $extendType): string
+    {
+        $attribute = 'class="' . $extendType->getClass() . '"';
+        if ($extendType->getName() !== null) {
+            $attribute = 'name="' . $extendType->getName() . '"';
+        }
+
+        return '@ExtendType(' . $attribute . ')';
     }
 }

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -127,6 +127,6 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
 
     public static function extendTypeWithInvalidName(ExtendType $extendType, string $className): self
     {
-        return new self('For @ExtendType(name="'.$extendType->getName().'") annotation declared in class "'.$className.'", the "'.$extendType->getName().'" GraphQL type cannot be extended. You can only target types created with the @Type annotation.');
+        return new self('For @ExtendType(name="' . $extendType->getName() . '") annotation declared in class "' . $className . '", the "' . $extendType->getName() . '" GraphQL type cannot be extended. You can only target types created with the @Type annotation.');
     }
 }

--- a/src/Mappers/GlobExtendAnnotationsCache.php
+++ b/src/Mappers/GlobExtendAnnotationsCache.php
@@ -14,10 +14,10 @@ class GlobExtendAnnotationsCache
     /** @var string|null */
     private $extendTypeClassName;
 
-    /** @var string|null */
+    /** @var string */
     private $extendTypeName;
 
-    public function setExtendType(string $className, string $typeName): void
+    public function setExtendType(?string $className, string $typeName): void
     {
         $this->extendTypeClassName = $className;
         $this->extendTypeName = $typeName;
@@ -28,7 +28,7 @@ class GlobExtendAnnotationsCache
         return $this->extendTypeClassName;
     }
 
-    public function getExtendTypeName(): ?string
+    public function getExtendTypeName(): string
     {
         return $this->extendTypeName;
     }

--- a/src/Mappers/GlobExtendTypeMapperCache.php
+++ b/src/Mappers/GlobExtendTypeMapperCache.php
@@ -24,11 +24,9 @@ class GlobExtendTypeMapperCache
         $className = $refClass->getName();
 
         $typeClassName = $globExtendAnnotationsCache->getExtendTypeClassName();
-        if ($typeClassName === null) {
-            return;
+        if ($typeClassName !== null) {
+            $this->mapClassToExtendTypeArray[$typeClassName][$className] = $className;
         }
-
-        $this->mapClassToExtendTypeArray[$typeClassName][$className] = $className;
 
         $typeName = $globExtendAnnotationsCache->getExtendTypeName();
         $this->mapNameToExtendType[$typeName][$className] = $className;

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -21,16 +21,16 @@ use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
 use TheCodingMachine\CacheUtils\FileBoundCache;
 use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
 use TheCodingMachine\GraphQLite\AnnotationReader;
-use TheCodingMachine\GraphQLite\GraphQLException;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeGenerator;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
+use Webmozart\Assert\Assert;
 use function class_exists;
 use function str_replace;
-use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
 
 /**
  * Scans all the classes in a given namespace of the main project (not the vendor directory).
@@ -244,15 +244,17 @@ final class GlobTypeMapper implements TypeMapperInterface
                 if ($extendType !== null) {
                     $extendClassName = $extendType->getClass();
                     if ($extendClassName !== null) {
-                        $targetType = $this->recursiveTypeMapper->mapClassToType($extendType->getClass(), null);
+                        $targetType = $this->recursiveTypeMapper->mapClassToType($extendClassName, null);
+                        $typeName   = $targetType->name;
                     } else {
-                        $targetType = $this->recursiveTypeMapper->mapNameToType($extendType->getName());
-                        if (!$targetType instanceof TypeAnnotatedObjectType) {
+                        $typeName = $extendType->getName();
+                        Assert::notNull($typeName);
+                        $targetType = $this->recursiveTypeMapper->mapNameToType($typeName);
+                        if (! $targetType instanceof TypeAnnotatedObjectType) {
                             throw CannotMapTypeException::extendTypeWithInvalidName($extendType, $refClass->getName());
                         }
                         $extendClassName = $targetType->getMappedClassName();
                     }
-                    $typeName   = $targetType->name;
 
                     $extendAnnotationsCache->setExtendType($extendClassName, $typeName);
 

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -27,7 +27,6 @@ use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeGenerator;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
 use Webmozart\Assert\Assert;
 use function class_exists;
 use function str_replace;
@@ -250,12 +249,13 @@ final class GlobTypeMapper implements TypeMapperInterface
                         $typeName = $extendType->getName();
                         Assert::notNull($typeName);
                         $targetType = $this->recursiveTypeMapper->mapNameToType($typeName);
-                        if (! $targetType instanceof TypeAnnotatedObjectType) {
-                            throw CannotMapTypeException::extendTypeWithInvalidName($extendType, $refClass->getName());
+                        if (! $targetType instanceof MutableObjectType) {
+                            throw CannotMapTypeException::extendTypeWithBadTargetedClass($refClass->getName(), $extendType);
                         }
                         $extendClassName = $targetType->getMappedClassName();
                     }
 
+                    // FIXME: $extendClassName === NULL!!!!!!
                     $extendAnnotationsCache->setExtendType($extendClassName, $typeName);
 
                     return $extendAnnotationsCache;

--- a/src/Types/MutableObjectType.php
+++ b/src/Types/MutableObjectType.php
@@ -27,15 +27,18 @@ class MutableObjectType extends ObjectType
 
     /** @var FieldDefinition[]|null */
     private $finalFields;
+    /** @var string|null */
+    private $className;
 
     /**
      * @param mixed[] $config
      */
-    public function __construct(array $config)
+    public function __construct(array $config, ?string $className = null)
     {
         $this->status = self::STATUS_PENDING;
 
         parent::__construct($config);
+        $this->className = $className;
     }
 
     public function freeze(): void
@@ -108,5 +111,13 @@ class MutableObjectType extends ObjectType
         }
 
         return $this->finalFields;
+    }
+
+    /**
+     * Returns the PHP class mapping this GraphQL type (if any)
+     */
+    public function getMappedClassName(): ?string
+    {
+        return $this->className;
     }
 }

--- a/src/Types/TypeAnnotatedObjectType.php
+++ b/src/Types/TypeAnnotatedObjectType.php
@@ -13,17 +13,12 @@ use function get_parent_class;
  */
 class TypeAnnotatedObjectType extends MutableObjectType
 {
-    /** @var string */
-    private $className;
-
     /**
      * @param mixed[] $config
      */
     public function __construct(string $className, array $config)
     {
-        $this->className = $className;
-
-        parent::__construct($config);
+        parent::__construct($config, $className);
     }
 
     public static function createFromAnnotatedClass(string $typeName, string $className, ?object $annotatedObject, FieldsBuilder $fieldsBuilder, RecursiveTypeMapperInterface $recursiveTypeMapper, bool $doNotMapInterfaces): self
@@ -63,10 +58,5 @@ class TypeAnnotatedObjectType extends MutableObjectType
                 return $recursiveTypeMapper->findInterfaces($className);
             },
         ]);
-    }
-
-    public function getMappedClassName(): string
-    {
-        return $this->className;
     }
 }

--- a/tests/Annotations/ExtendTypeTest.php
+++ b/tests/Annotations/ExtendTypeTest.php
@@ -11,7 +11,7 @@ class ExtendTypeTest extends TestCase
     public function testException()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('In annotation @ExtendType, missing compulsory parameter "class".');
+        $this->expectExceptionMessage('In annotation @ExtendType, missing one of the compulsory parameter "class" or "name".');
         new ExtendType([]);
     }
 }

--- a/tests/Fixtures/BadExtendType/BadExtendType.php
+++ b/tests/Fixtures/BadExtendType/BadExtendType.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\BadExtendType;
+
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
+
+/**
+ * @ExtendType(name="TestObject")
+ */
+class BadExtendType
+{
+}

--- a/tests/Fixtures/BadExtendType/BadExtendType.php
+++ b/tests/Fixtures/BadExtendType/BadExtendType.php
@@ -6,7 +6,7 @@ namespace TheCodingMachine\GraphQLite\Fixtures\BadExtendType;
 use TheCodingMachine\GraphQLite\Annotations\ExtendType;
 
 /**
- * @ExtendType(name="TestObject")
+ * @ExtendType(name="TestObjectInput")
  */
 class BadExtendType
 {

--- a/tests/Fixtures/Integration/Types/ExtendedContactOtherType.php
+++ b/tests/Fixtures/Integration/Types/ExtendedContactOtherType.php
@@ -13,6 +13,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
 
 /**
  * @ExtendType(name="ContactOther")
+ * @SourceField(name="name")
  */
 class ExtendedContactOtherType
 {

--- a/tests/Fixtures/Integration/Types/ExtendedContactOtherType.php
+++ b/tests/Fixtures/Integration/Types/ExtendedContactOtherType.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Types;
+
+use function array_search;
+use function strtoupper;
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
+
+/**
+ * @ExtendType(name="ContactOther")
+ */
+class ExtendedContactOtherType
+{
+    /**
+     * @Field()
+     */
+    public function phone(Contact $contact): string
+    {
+        return "0123456789";
+    }
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -803,6 +803,7 @@ class EndToEndTest extends TestCase
         $queryString = '
         query {
             otherContact {
+                name
                 fullName
                 phone
             }
@@ -816,6 +817,7 @@ class EndToEndTest extends TestCase
 
         $this->assertSame([
             'otherContact' => [
+                'name' => 'Joe',
                 'fullName' => 'JOE',
                 'phone' => '0123456789'
             ]

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -804,6 +804,7 @@ class EndToEndTest extends TestCase
         query {
             otherContact {
                 fullName
+                phone
             }
         }
         ';
@@ -815,7 +816,8 @@ class EndToEndTest extends TestCase
 
         $this->assertSame([
             'otherContact' => [
-                'fullName' => 'JOE'
+                'fullName' => 'JOE',
+                'phone' => '0123456789'
             ]
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Cache\Simple\NullCache;
 use Test;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
+use TheCodingMachine\GraphQLite\Fixtures\BadExtendType\BadExtendType;
 use TheCodingMachine\GraphQLite\Fixtures\InheritedInputTypes\ChildTestFactory;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Types\FilterDecorator;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
@@ -194,21 +195,21 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $mapper = new GlobTypeMapper('TheCodingMachine\GraphQLite\Fixtures\Types', $typeGenerator, $inputTypeGenerator, $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), $cache);
 
-        $type = $mapper->mapClassToType(TestObject::class, null, $this->getTypeMapper());
+        $type = $mapper->mapClassToType(TestObject::class, null);
 
-        $this->assertTrue($mapper->canExtendTypeForClass(TestObject::class, $type, $this->getTypeMapper()));
-        $mapper->extendTypeForClass(TestObject::class, $type, $this->getTypeMapper());
-        $mapper->extendTypeForName('TestObject', $type, $this->getTypeMapper());
-        $this->assertTrue($mapper->canExtendTypeForName('TestObject', $type, $this->getTypeMapper()));
-        $this->assertFalse($mapper->canExtendTypeForName('NotExists', $type, $this->getTypeMapper()));
+        $this->assertTrue($mapper->canExtendTypeForClass(TestObject::class, $type));
+        $mapper->extendTypeForClass(TestObject::class, $type);
+        $mapper->extendTypeForName('TestObject', $type);
+        $this->assertTrue($mapper->canExtendTypeForName('TestObject', $type));
+        $this->assertFalse($mapper->canExtendTypeForName('NotExists', $type));
 
         // Again to test cache
         $anotherMapperSameCache = new GlobTypeMapper('TheCodingMachine\GraphQLite\Fixtures\Types', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), $cache);
-        $this->assertTrue($anotherMapperSameCache->canExtendTypeForClass(TestObject::class, $type, $this->getTypeMapper()));
-        $this->assertTrue($anotherMapperSameCache->canExtendTypeForName('TestObject', $type, $this->getTypeMapper()));
+        $this->assertTrue($anotherMapperSameCache->canExtendTypeForClass(TestObject::class, $type));
+        $this->assertTrue($anotherMapperSameCache->canExtendTypeForName('TestObject', $type));
 
         $this->expectException(CannotMapTypeException::class);
-        $mapper->extendTypeForClass(\stdClass::class, $type, $this->getTypeMapper());
+        $mapper->extendTypeForClass(\stdClass::class, $type);
     }
 
     public function testEmptyGlobTypeMapper()
@@ -276,7 +277,10 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
             },
             FooExtendType::class => function () {
                 return new FooExtendType();
-            }
+            },
+            BadExtendType::class => function () {
+                return new BadExtendType();
+            },
         ]);
 
         $typeGenerator = $this->getTypeGenerator();
@@ -294,7 +298,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
         ]);
 
         $this->expectException(CannotMapTypeException::class);
-        $this->expectExceptionMessage('For @ExtendType(name="TestObject") annotation declared in class "TheCodingMachine\GraphQLite\Fixtures\BadExtendType\BadExtendType", the "TestObject" GraphQL type cannot be extended. You can only target types created with the @Type annotation.');
+        $this->expectExceptionMessage('For @ExtendType(name="TestObjectInput") annotation declared in class "TheCodingMachine\GraphQLite\Fixtures\BadExtendType\BadExtendType", the pointed at GraphQL type cannot be extended. You can only target types extending the MutableObjectType (like types created with the @Type annotation).');
         $mapper->extendTypeForName('TestObject', $testObjectType);
     }
 


### PR DESCRIPTION
Since we can now create non default output types (that do not map the PHP class by default),
if we want to be able to extend those types (using the @ExtendType annotation),
the @ExtendType annotation must accept a "name" attribute (instead of a "class attribute)
since the "class" attribute would not allow us to make a distinctions between all output types targeting the same PHP class.

This commit adds support the "name" attribute in @ExtendType.