### PR TITLE
Fixing extend type application range

### DIFF
--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -124,7 +124,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
         $this->typeRegistry->registerType($type);
         $this->classToTypeCache[$cacheKey] = $type;
 
-        $this->extendType($className, $type);
+        $this->extendType($closestClassName, $type);
 
         $type->freeze();
 
@@ -154,15 +154,14 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
     private function extendType(string $className, MutableObjectType $type): void
     {
         $classes = [];
+        // Let's find all the extended types, but only up to a valid type (since inheritance will then be used to bundle the extendtype)
         do {
-            if (! $this->typeMapper->canExtendTypeForClass($className, $type)) {
-                $className = get_parent_class($className);
-                continue;
+            if ($this->typeMapper->canExtendTypeForClass($className, $type)) {
+                $classes[] = $className;
             }
 
-            $classes[] = $className;
             $className = get_parent_class($className);
-        } while ($className !== false);
+        } while ($className !== false && !$this->typeMapper->canMapClassToType($className));
 
         // Let's apply extenders from the most basic type.
         $classes = array_reverse($classes);

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -161,7 +161,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
             }
 
             $className = get_parent_class($className);
-        } while ($className !== false && !$this->typeMapper->canMapClassToType($className));
+        } while ($className !== false && ! $this->typeMapper->canMapClassToType($className));
 
         // Let's apply extenders from the most basic type.
         $classes = array_reverse($classes);

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -148,6 +148,9 @@ class Contact
     public function repeatInnerName($data): string
     {
         $index = array_search($this, $data, false);
+        if ($index === false) {
+            throw new \RuntimeException('Index not found');
+        }
         return $data[$index]->getName();
     }
 

--- a/tests/Fixtures/Integration/Types/ContactType.php
+++ b/tests/Fixtures/Integration/Types/ContactType.php
@@ -33,7 +33,10 @@ class ContactType
      */
     public function repeatName(Contact $contact, $data, string $suffix): string
     {
-        $index = array_search($contact, $data['contacts'], true);
+        $index = array_search($contact, $data['contacts'], false);
+        if ($index === false) {
+            throw new \RuntimeException('Index not found');
+        }
         return $data['prefix'].$data['contacts'][$index]->getName().$suffix;
     }
 


### PR DESCRIPTION
The extended types (applied with @ExtendType) should be applied from the class declared in the annotation, up to the parent class that is also a type.

Until now, the whole class tree was taken in account. As a result, the @ExtendType was applied once for each parent class (when it really needs to be applied once).