### PR TITLE
Fixing cache purging issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "ecodev/graphql-upload": "^4.0",
         "webmozart/assert": "^1.4",
         "symfony/cache": "^4.3",
-        "thecodingmachine/cache-utils": "^1"
+        "thecodingmachine/cache-utils": "^1",
+        "ocramius/package-versions": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.9",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,6 +14,7 @@
     <!-- <file>tests</file> -->
 
     <exclude-pattern>tests/dependencies/*</exclude-pattern>
+    <exclude-pattern>src/Utils/NamespacedCache.php</exclude-pattern>
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine">

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,5 +9,6 @@ parameters:
         - "#Parameter .* of class ReflectionMethod constructor expects string, object|string given.#"
         - "#Method TheCodingMachine\\\\GraphQLite\\\\Types\\\\MutableObjectType::getFields() should return array<GraphQL\\\\Type\\\\Definition\\\\FieldDefinition> but returns array|float|int.#"
         - "#Parameter \\#2 \\$inputTypeNode of static method GraphQL\\\\Utils\\\\AST::typeFromAST() expects GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode, GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NameNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode given.#"
+        - "#PHPDoc tag @throws with type Psr\\\\SimpleCache\\\\InvalidArgumentException is not subtype of Throwable#"
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -9,15 +9,11 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ApcuCache;
-use Doctrine\Common\Cache\FilesystemCache;
 use Doctrine\Common\Cache\PhpFileCache;
 use GraphQL\Type\SchemaConfig;
-use function md5;
 use PackageVersions\Versions;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
-use function substr;
-use function sys_get_temp_dir;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
@@ -42,8 +38,12 @@ use TheCodingMachine\GraphQLite\Security\FailAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\FailAuthorizationService;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
-use function function_exists;
 use TheCodingMachine\GraphQLite\Utils\NamespacedCache;
+use function crc32;
+use function function_exists;
+use function md5;
+use function substr;
+use function sys_get_temp_dir;
 
 /**
  * A class to help getting started with GraphQLite.
@@ -177,8 +177,7 @@ class SchemaFactory
             AnnotationRegistry::registerLoader('class_exists');
             $doctrineAnnotationReader = new DoctrineAnnotationReader();
 
-
-            $cache = function_exists('apcu_fetch') ? new ApcuCache() : new PhpFileCache(sys_get_temp_dir().'/graphqlite.'.crc32(__DIR__));
+            $cache = function_exists('apcu_fetch') ? new ApcuCache() : new PhpFileCache(sys_get_temp_dir() . '/graphqlite.' . crc32(__DIR__));
 
             $namespace = substr(md5(Versions::getVersion('thecodingmachine/graphqlite')), 0, 8);
             $cache->setNamespace($namespace);

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -9,9 +9,15 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ApcuCache;
+use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\Common\Cache\PhpFileCache;
 use GraphQL\Type\SchemaConfig;
+use function md5;
+use PackageVersions\Versions;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
+use function substr;
+use function sys_get_temp_dir;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
@@ -37,6 +43,7 @@ use TheCodingMachine\GraphQLite\Security\FailAuthorizationService;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use function function_exists;
+use TheCodingMachine\GraphQLite\Utils\NamespacedCache;
 
 /**
  * A class to help getting started with GraphQLite.
@@ -79,7 +86,7 @@ class SchemaFactory
 
     public function __construct(CacheInterface $cache, ContainerInterface $container)
     {
-        $this->cache     = $cache;
+        $this->cache     = new NamespacedCache($cache);
         $this->container = $container;
     }
 
@@ -170,9 +177,13 @@ class SchemaFactory
             AnnotationRegistry::registerLoader('class_exists');
             $doctrineAnnotationReader = new DoctrineAnnotationReader();
 
-            if (function_exists('apcu_fetch')) {
-                $doctrineAnnotationReader = new CachedReader($doctrineAnnotationReader, new ApcuCache(), true);
-            }
+
+            $cache = function_exists('apcu_fetch') ? new ApcuCache() : new PhpFileCache(sys_get_temp_dir().'/graphqlite.'.crc32(__DIR__));
+
+            $namespace = substr(md5(Versions::getVersion('thecodingmachine/graphqlite')), 0, 8);
+            $cache->setNamespace($namespace);
+
+            $doctrineAnnotationReader = new CachedReader($doctrineAnnotationReader, $cache, true);
 
             return $doctrineAnnotationReader;
         }

--- a/src/Utils/NamespacedCache.php
+++ b/src/Utils/NamespacedCache.php
@@ -1,0 +1,183 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Utils;
+
+
+use PackageVersions\Versions;
+use Psr\SimpleCache\CacheInterface;
+use function substr;
+
+/**
+ * A cache adapter that adds a namespace depending on the package version.
+ * On each new version, the cache is automatically purged.
+ */
+class NamespacedCache implements CacheInterface
+{
+
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @var string
+     */
+    private $namespace;
+
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+        $this->namespace = substr(md5(Versions::getVersion('thecodingmachine/graphqlite')), 0, 8);
+    }
+
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key The unique key of this item in the cache.
+     * @param mixed $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function get($key, $default = null)
+    {
+        return $this->cache->get($this->namespace.$key, $default);
+    }
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        return $this->cache->set($this->namespace.$key, $value, $ttl);
+    }
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        return $this->cache->delete($this->namespace.$key);
+    }
+
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear()
+    {
+        return $this->cache->clear();
+    }
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $values = $this->cache->getMultiple($this->namespacedKeys($keys), $default);
+        $shortenedKeys = [];
+        foreach ($values as $key => $value) {
+            $shortenedKeys[substr($key, 8)] = $value;
+        }
+        return $shortenedKeys;
+    }
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                       the driver supports TTL then the library may set a default value
+     *                                       for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $namespacedValues = [];
+        foreach ($values as $key => $value) {
+            $namespacedValues[$this->namespace.$key] = $value;
+        }
+        return $this->cache->setMultiple($namespacedValues, $ttl);
+    }
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        return $this->cache->deleteMultiple($this->namespacedKeys($keys));
+    }
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        return $this->cache->has($this->namespace.$key);
+    }
+
+    private function namespacedKeys(iterable $keys): array
+    {
+        $namespacedKeys = [];
+        foreach ($keys as $key) {
+            $namespacedKeys[] = $this->namespace.$key;
+        }
+        return $namespacedKeys;
+    }
+}

--- a/tests/Utils/NamespacedCacheTest.php
+++ b/tests/Utils/NamespacedCacheTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Simple\ArrayCache;
+
+class NamespacedCacheTest extends TestCase
+{
+    public function testCache()
+    {
+        $cache = new NamespacedCache(new ArrayCache());
+
+        $cache->set('foo', 'bar');
+        $this->assertSame('bar', $cache->get('foo'));
+        $cache->delete('foo');
+        $this->assertSame('baz', $cache->get('foo', 'baz'));
+
+        $cache->setMultiple(['foo' => 'bar']);
+        $this->assertSame(['foo' => 'bar'], $cache->getMultiple(['foo']));
+        $this->assertTrue($cache->has('foo'));
+        $cache->deleteMultiple(['foo']);
+        $this->assertFalse($cache->has('foo'));
+
+        $cache->set('foo', 'bar');
+        $cache->clear();
+        $this->assertFalse($cache->has('foo'));
+    }
+}

--- a/tests/Utils/PSR16DoctrineCacheAdapter.php
+++ b/tests/Utils/PSR16DoctrineCacheAdapter.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Utils;
+
+
+use Doctrine\Common\Cache\CacheProvider;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * An adapter to turn a PSR-16 cache into a Doctrine Cache
+ */
+class PSR16DoctrineCacheAdapter extends CacheProvider
+{
+    /**
+     * PSR-16 cache.
+     *
+     * @var CacheInterface
+     */
+    protected $cache;
+    /**
+     * PsrDoctrineCacheBridge constructor.
+     *
+     * @param CacheInterface $cache
+     */
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+    protected function doFetch($id)
+    {
+        return $this->cache->get($id, false);
+    }
+    protected function doContains($id)
+    {
+        return $this->cache->has($id);
+    }
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        return $this->cache->set($id, $data, (int) $lifeTime ?: null);
+    }
+    protected function doDelete($id)
+    {
+        return $this->cache->delete($id);
+    }
+    protected function doFlush()
+    {
+        $this->cache->clear();
+    }
+    protected function doGetStats()
+    {
+        // Do nothing
+    }
+}


### PR DESCRIPTION
For each new version of GraphQLite, the cache is now automatically purged, thanks to a namespace that will change with each new version.

+ the SchemaFactory will now use Doctrine PHPFileCache is APCu is not available.

Closes #100 