### PR TITLE
Lowering minimum version of symfony/cache to 4.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psr/http-message": "^1",
         "ecodev/graphql-upload": "^4.0",
         "webmozart/assert": "^1.4",
-        "symfony/cache": "^4.3",
+        "symfony/cache": "^4.2.10",
         "thecodingmachine/cache-utils": "^1",
         "ocramius/package-versions": "^1.4"
     },


### PR DESCRIPTION
Cache contracts seem to appear in Symfony 4.2.
Therefore, we can request only this version and not ^4.3.