### PR TITLE
Adding a QueryProviderFactory

### DIFF
--- a/docs/other_frameworks.md
+++ b/docs/other_frameworks.md
@@ -64,6 +64,11 @@ $factory->addTypeMapperFactory($typeMapperFactory);
 $factory->addRootTypeMapper($rootTypeMapper);
 // Add a parameter mapper.
 $factory->addParameterMapper($parameterMapper);
+// Add a query provider. These are used to find queries and mutations in the application.
+$factory->addQueryProvider($queryProvider);
+// Add a query provider using a factory to create it.
+// Query provider factories are useful if you need to inject the "fields builder" into your query provider constructor.
+$factory->addQueryProviderFactory($queryProviderFactory);
 // Add custom options to the Webonyx underlying Schema.
 $factory->setSchemaConfig($schemaConfig);
 // Configures the time-to-live for the GraphQLite cache. Defaults to 2 seconds in dev mode.

--- a/src/AggregateControllerQueryProviderFactory.php
+++ b/src/AggregateControllerQueryProviderFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * A factory that creates an AggregateControllerQueryProvider.
+ */
+class AggregateControllerQueryProviderFactory implements QueryProviderFactoryInterface
+{
+    /** @var array|string[] */
+    private $controllers;
+    /** @var ContainerInterface */
+    private $controllersContainer;
+
+    /**
+     * @param string[]           $controllers          A list of controllers name in the container.
+     * @param ContainerInterface $controllersContainer The container we will fetch controllers from.
+     */
+    public function __construct(iterable $controllers, ContainerInterface $controllersContainer)
+    {
+        $this->controllers          = $controllers;
+        $this->controllersContainer = $controllersContainer;
+    }
+
+    public function create(FieldsBuilder $fieldsBuilder): QueryProviderInterface
+    {
+        return new AggregateControllerQueryProvider($this->controllers, $fieldsBuilder, $this->controllersContainer);
+    }
+}

--- a/src/QueryProviderFactoryInterface.php
+++ b/src/QueryProviderFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite;
+
+/**
+ * Class in charge of creating a query factory.
+ * You can pass a query provider factory to the SchemaFactory instead of a query factory if the query factory you want to
+ * pass requires the "FieldsBuilder" (that is created by the SchemaFactory itself).
+ */
+interface QueryProviderFactoryInterface
+{
+    public function create(FieldsBuilder $fieldsBuilder): QueryProviderInterface;
+}

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -57,6 +57,8 @@ class SchemaFactory
     private $typeNamespaces = [];
     /** @var QueryProviderInterface[] */
     private $queryProviders = [];
+    /** @var QueryProviderFactoryInterface[] */
+    private $queryProviderFactories = [];
     /** @var RootTypeMapperInterface[] */
     private $rootTypeMappers = [];
     /** @var TypeMapperInterface[] */
@@ -116,6 +118,16 @@ class SchemaFactory
     public function addQueryProvider(QueryProviderInterface $queryProvider): self
     {
         $this->queryProviders[] = $queryProvider;
+
+        return $this;
+    }
+
+    /**
+     * Registers a query provider factory.
+     */
+    public function addQueryProviderFactory(QueryProviderFactoryInterface $queryProviderFactory): self
+    {
+        $this->queryProviderFactories[] = $queryProviderFactory;
 
         return $this;
     }
@@ -350,6 +362,10 @@ class SchemaFactory
 
         foreach ($this->queryProviders as $queryProvider) {
             $queryProviders[] = $queryProvider;
+        }
+
+        foreach ($this->queryProviderFactories as $queryProviderFactory) {
+            $queryProviders[] = $queryProviderFactory->create($fieldsBuilder);
         }
 
         if ($queryProviders === []) {

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -66,6 +66,7 @@ class SchemaFactoryTest extends TestCase
                 })
                 ->addRootTypeMapper(new CompositeRootTypeMapper([]))
                 ->addParameterMapper(new CompositeParameterMapper([]))
+                ->addQueryProviderFactory(new AggregateControllerQueryProviderFactory([], $container))
                 ->setSchemaConfig(new SchemaConfig())
                 ->devMode()
                 ->prodMode();


### PR DESCRIPTION
Query providers cannot be created using the SchemaFactory if they require the FieldsBuilder.
Using the new QueryProviderFactory, we make this possible as the factory will pass the FieldsBuilder in parameter of the create method.