### PR TITLE
Adding support for annotating PHP interfaces

### DIFF
--- a/docs/extend_type.md
+++ b/docs/extend_type.md
@@ -11,7 +11,7 @@ Use the `@ExtendType` annotation to add additional fields to a type that is alre
 <div class="alert alert-info">
     Extending a type has nothing to do with type inheritance. 
     If you are looking for a way to expose a class and its children classes, have a look at 
-    the <a href="inheritance">Inheritance</a> section</a>
+    the <a href="inheritance-interfaces">Inheritance</a> section</a>
 </div>
 
 Let's assume you have a `Product` class. In order to get the name of a product, there is no `getName()` method in 

--- a/docs/inheritance-interfaces.md
+++ b/docs/inheritance-interfaces.md
@@ -1,5 +1,5 @@
 ---
-id: inheritance
+id: inheritance-interfaces
 title: Inheritance and interfaces
 sidebar_label: Inheritance and interfaces
 ---
@@ -102,7 +102,38 @@ interface UserInterface {
 }
 ```
 
-Note: You don't have to explicitly put a @Type annotation on the class implementing the interface (though this
+### Implementing interfaces
+
+You don't have to do anything special to implement an interface in your GraphQL types.
+Simply "implement" the interface in PHP and you are done!
+
+```php
+/**
+ * @Type
+ */
+class User implements UserInterface
+{
+    public function getUserName(): string;
+}
+```
+
+This will translate in GraphQL schema as:
+
+```graphql
+interface UserInterface {
+    userName: String!
+}
+
+type User implements UserInterface {
+    userName: String!
+}
+```
+
+Please note that you do not need to put the `@Field` annotation again in the implementing class.
+
+### Interfaces without an explicit implementing type
+
+You don't have to explicitly put a `@Type` annotation on the class implementing the interface (though this
 is usually a good idea).
 
 ```php
@@ -111,9 +142,6 @@ is usually a good idea).
  */
 class User implements UserInterface
 {
-    /**
-     * ... and getUserName has no @Field annotation
-     */
     public function getUserName(): string;
 }
 ```
@@ -146,4 +174,3 @@ type UserImpl implements UserInterface {
     userName: String!
 }
 ```
-

--- a/docs/inheritance.md
+++ b/docs/inheritance.md
@@ -4,6 +4,8 @@ title: Inheritance and interfaces
 sidebar_label: Inheritance and interfaces
 ---
 
+## Modeling inheritance
+
 Some of your entities may extend other entities. GraphQLite will do its best to represent this hierarchy of objects in GraphQL using interfaces.
 
 Let's say you have two classes, `Contact` and `User` (which extends `Contact`):
@@ -28,7 +30,7 @@ class User extends Contact
 
 Now, let's assume you have a query that returns a contact:
 
-```
+```php
 class ContactController
 {
     /**
@@ -75,8 +77,73 @@ Because the class is extended, a GraphQL `ContactInterface` interface is created
 The GraphQL `User` type will also automatically implement this `ContactInterface`. The interface contains all the fields
 available in the `Contact` type.
 
-<div class="alert alert-warning">
-Right now, there is no way to explicitly declare a GraphQL interface using GraphQLite.<br>
-GraphQLite automatically declares interfaces when it sees an inheritance relationship between to classes that
-are GraphQL types.
-</div>
+## Mapping interfaces
+
+If you want to create a pure GraphQL interface, you can also add a `@Type` annotation on a PHP interface.
+
+```php
+/**
+ * @Type
+ */
+interface UserInterface
+{
+    /**
+     * @Field
+     */
+    public function getUserName(): string;
+}
+```
+
+This will automatically create a GraphQL interface whose description is:
+
+```graphql
+interface UserInterface {
+    userName: String!
+}
+```
+
+Note: You don't have to explicitly put a @Type annotation on the class implementing the interface (though this
+is usually a good idea).
+
+```php
+/**
+ * Look, this class has no @Type annotation
+ */
+class User implements UserInterface
+{
+    /**
+     * ... and getUserName has no @Field annotation
+     */
+    public function getUserName(): string;
+}
+```
+
+```php
+class UserController
+{
+    /**
+     * @Query()
+     */
+    public function getUser(): UserInterface // This will work!
+    {
+        // ...
+    }
+}
+```
+
+<div class="alert alert-info">If GraphQLite cannot find a proper GraphQL Object type implementing an interface, it
+will create an object type "on the fly".</div>
+
+In the example above, because the `User` class has no `@Type` annotations, GraphQLite will
+create a `UserImpl` type that implements `UserInterface`.
+
+```graphql
+interface UserInterface {
+    userName: String!
+}
+
+type UserImpl implements UserInterface {
+    userName: String!
+}
+```
+

--- a/docs/type_mapping.md
+++ b/docs/type_mapping.md
@@ -82,6 +82,9 @@ Hopefully, you can force the name of the GraphQL output type using the "name" at
 class Product { /* ... */ }
 ```
 
+<div class="alert alert-info">You can also put a <a href="inheritance-interfaces#mapping-interfaces"><code>@Type</code> annotation on a PHP interface
+to map your code to a GraphQL interface</a>.</div>
+
 ## Array mapping
 
 You can type-hint against arrays (or iterators) as long as you add a detailed `@return` statement in the PHPDoc.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,6 +15,7 @@
 
     <exclude-pattern>tests/dependencies/*</exclude-pattern>
     <exclude-pattern>src/Utils/NamespacedCache.php</exclude-pattern>
+    <exclude-pattern>src/Types/TypeAnnotatedInterfaceType.php</exclude-pattern>
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine">

--- a/src/Annotations/ExtendType.php
+++ b/src/Annotations/ExtendType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use BadMethodCallException;
+use function interface_exists;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
 use function class_exists;
 use function ltrim;
@@ -36,7 +37,7 @@ class ExtendType
         }
         $this->class = $attributes['class'] ?? null;
         $this->name = $attributes['name'] ?? null;
-        if ($this->class !== null && ! class_exists($this->class)) {
+        if ($this->class !== null && ! class_exists($this->class) && ! interface_exists($this->class)) {
             throw ClassNotFoundException::couldNotFindClass($this->class);
         }
     }

--- a/src/Annotations/ExtendType.php
+++ b/src/Annotations/ExtendType.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use BadMethodCallException;
-use function interface_exists;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
 use function class_exists;
+use function interface_exists;
 use function ltrim;
 
 /**

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Annotations;
 
-use function interface_exists;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
 use function class_exists;
+use function interface_exists;
 use function ltrim;
 
 /**

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Annotations;
 
+use function interface_exists;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
 use function class_exists;
@@ -85,7 +86,7 @@ class Type
     public function setClass(string $class): void
     {
         $this->class = ltrim($class, '\\');
-        if (! class_exists($this->class)) {
+        if (! class_exists($this->class) && ! interface_exists($this->class)) {
             throw ClassNotFoundException::couldNotFindClass($this->class);
         }
     }

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -6,10 +6,10 @@ namespace TheCodingMachine\GraphQLite\Annotations;
 
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
+use TheCodingMachine\GraphQLite\GraphQLException;
 use function class_exists;
 use function interface_exists;
 use function ltrim;
-use TheCodingMachine\GraphQLite\GraphQLException;
 
 /**
  * The Type annotation must be put in a GraphQL type class docblock and is used to map to the underlying PHP class
@@ -92,13 +92,15 @@ class Type
             throw ClassNotFoundException::couldNotFindClass($this->class);
         }
 
-        if ($isInterface) {
-            if ($this->default === false) {
-                throw new GraphQLException('Problem in annotation @Type for interface "'.$class.'": you cannot use the default="false" attribute on interfaces');
-            }
-            if ($this->disableInheritance === true) {
-                throw new GraphQLException('Problem in annotation @Type for interface "'.$class.'": you cannot use the disableInheritance="true" attribute on interfaces');
-            }
+        if (! $isInterface) {
+            return;
+        }
+
+        if ($this->default === false) {
+            throw new GraphQLException('Problem in annotation @Type for interface "' . $class . '": you cannot use the default="false" attribute on interfaces');
+        }
+        if ($this->disableInheritance === true) {
+            throw new GraphQLException('Problem in annotation @Type for interface "' . $class . '": you cannot use the disableInheritance="true" attribute on interfaces');
         }
     }
 

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -9,6 +9,7 @@ use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
 use function class_exists;
 use function interface_exists;
 use function ltrim;
+use TheCodingMachine\GraphQLite\GraphQLException;
 
 /**
  * The Type annotation must be put in a GraphQL type class docblock and is used to map to the underlying PHP class
@@ -86,8 +87,18 @@ class Type
     public function setClass(string $class): void
     {
         $this->class = ltrim($class, '\\');
-        if (! class_exists($this->class) && ! interface_exists($this->class)) {
+        $isInterface = interface_exists($this->class);
+        if (! class_exists($this->class) && ! $isInterface) {
             throw ClassNotFoundException::couldNotFindClass($this->class);
+        }
+
+        if ($isInterface) {
+            if ($this->default === false) {
+                throw new GraphQLException('Problem in annotation @Type for interface "'.$class.'": you cannot use the default="false" attribute on interfaces');
+            }
+            if ($this->disableInheritance === true) {
+                throw new GraphQLException('Problem in annotation @Type for interface "'.$class.'": you cannot use the disableInheritance="true" attribute on interfaces');
+            }
         }
     }
 

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\FieldDefinition;
+use function interface_exists;
 use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
@@ -92,7 +93,7 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
         $classes   = $explorer->getClasses();
         $instances = [];
         foreach ($classes as $className) {
-            if (! class_exists($className)) {
+            if (! class_exists($className) && ! interface_exists($className)) {
                 continue;
             }
             $refClass = new ReflectionClass($className);

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\FieldDefinition;
-use function interface_exists;
 use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
@@ -14,6 +13,7 @@ use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
 use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
 use function class_exists;
+use function interface_exists;
 use function str_replace;
 
 /**

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -68,8 +68,8 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
     }
 
     /**
-     * @param string $className
      * @param NamedType&(ObjectType|InterfaceType) $type
+     *
      * @return CannotMapTypeException
      */
     public static function createForExtendType(string $className, NamedType $type): self
@@ -78,8 +78,8 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
     }
 
     /**
-     * @param string $name
      * @param NamedType&(ObjectType|InterfaceType) $type
+     *
      * @return CannotMapTypeException
      */
     public static function createForExtendName(string $name, NamedType $type): self

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use Exception;
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
@@ -66,12 +67,22 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
         return new self('type "' . $subTypeName . '" must be an input type.');
     }
 
-    public static function createForExtendType(string $className, ObjectType $type): self
+    /**
+     * @param string $className
+     * @param NamedType&(ObjectType|InterfaceType) $type
+     * @return CannotMapTypeException
+     */
+    public static function createForExtendType(string $className, NamedType $type): self
     {
         return new self('cannot extend GraphQL type "' . $type->name . '" mapped by class "' . $className . '". Check your TypeMapper configuration.');
     }
 
-    public static function createForExtendName(string $name, ObjectType $type): self
+    /**
+     * @param string $name
+     * @param NamedType&(ObjectType|InterfaceType) $type
+     * @return CannotMapTypeException
+     */
+    public static function createForExtendName(string $name, NamedType $type): self
     {
         return new self('cannot extend GraphQL type "' . $type->name . '" with type "' . $name . '". Check your TypeMapper configuration.');
     }

--- a/src/Mappers/CompositeTypeMapper.php
+++ b/src/Mappers/CompositeTypeMapper.php
@@ -9,6 +9,8 @@ use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use function array_map;
 use function array_merge;
 use function array_unique;
@@ -47,9 +49,12 @@ class CompositeTypeMapper implements TypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
+     * @param string $className
+     * @param (OutputType&Type)|null $subType
+     * @return \TheCodingMachine\GraphQLite\Types\MutableInterface
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType
+    public function mapClassToType(string $className, ?OutputType $subType): \TheCodingMachine\GraphQLite\Types\MutableInterface
     {
         foreach ($this->typeMappers as $typeMapper) {
             if ($typeMapper->canMapClassToType($className)) {
@@ -116,7 +121,7 @@ class CompositeTypeMapper implements TypeMapperInterface
      *
      * @param string $typeName The name of the GraphQL type
      *
-     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType)
+     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableInterface)
      */
     public function mapNameToType(string $typeName): Type
     {
@@ -146,8 +151,11 @@ class CompositeTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForClass(string $className, MutableObjectType $type): bool
+    public function canExtendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
     {
         foreach ($this->typeMappers as $typeMapper) {
             if ($typeMapper->canExtendTypeForClass($className, $type)) {
@@ -161,9 +169,11 @@ class CompositeTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, MutableObjectType $type): void
+    public function extendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
     {
         foreach ($this->typeMappers as $typeMapper) {
             if (! $typeMapper->canExtendTypeForClass($className, $type)) {
@@ -176,8 +186,11 @@ class CompositeTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool
+    public function canExtendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
     {
         foreach ($this->typeMappers as $typeMapper) {
             if ($typeMapper->canExtendTypeForName($typeName, $type)) {
@@ -191,9 +204,11 @@ class CompositeTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, MutableObjectType $type): void
+    public function extendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
     {
         foreach ($this->typeMappers as $typeMapper) {
             if (! $typeMapper->canExtendTypeForName($typeName, $type)) {

--- a/src/Mappers/CompositeTypeMapper.php
+++ b/src/Mappers/CompositeTypeMapper.php
@@ -7,10 +7,10 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
-use TheCodingMachine\GraphQLite\Types\MutableObjectType;
-use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
+use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use function array_map;
 use function array_merge;
 use function array_unique;
@@ -49,12 +49,11 @@ class CompositeTypeMapper implements TypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
-     * @param string $className
      * @param (OutputType&Type)|null $subType
-     * @return \TheCodingMachine\GraphQLite\Types\MutableInterface
+     *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): \TheCodingMachine\GraphQLite\Types\MutableInterface
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
     {
         foreach ($this->typeMappers as $typeMapper) {
             if ($typeMapper->canMapClassToType($className)) {
@@ -151,11 +150,10 @@ class CompositeTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
-     * @param string $className
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
-    public function canExtendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
+    public function canExtendTypeForClass(string $className, MutableInterface $type): bool
     {
         foreach ($this->typeMappers as $typeMapper) {
             if ($typeMapper->canExtendTypeForClass($className, $type)) {
@@ -169,11 +167,11 @@ class CompositeTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
-     * @param string $className
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
+    public function extendTypeForClass(string $className, MutableInterface $type): void
     {
         foreach ($this->typeMappers as $typeMapper) {
             if (! $typeMapper->canExtendTypeForClass($className, $type)) {
@@ -186,11 +184,10 @@ class CompositeTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
-     * @param string $typeName
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
+    public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
     {
         foreach ($this->typeMappers as $typeMapper) {
             if ($typeMapper->canExtendTypeForName($typeName, $type)) {
@@ -204,11 +201,11 @@ class CompositeTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
-     * @param string $typeName
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
+    public function extendTypeForName(string $typeName, MutableInterface $type): void
     {
         foreach ($this->typeMappers as $typeMapper) {
             if (! $typeMapper->canExtendTypeForName($typeName, $type)) {

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -25,7 +25,9 @@ use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeGenerator;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use Webmozart\Assert\Assert;
 use function class_exists;
@@ -290,12 +292,13 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
-     * @param string          $className The exact class name to look for (this function does not look into parent classes).
-     * @param OutputType|null $subType   An optional sub-type if the main class is an iterator that needs to be typed.
+     * @param string $className The exact class name to look for (this function does not look into parent classes).
+     * @param OutputType|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
      *
+     * @return MutableInterface
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
     {
         $typeClassName = $this->getMaps()->getTypeByObjectClass($className);
 
@@ -347,7 +350,7 @@ final class GlobTypeMapper implements TypeMapperInterface
      *
      * @param string $typeName The name of the GraphQL type
      *
-     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType)
+     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
      *
      * @throws CannotMapTypeExceptionInterface
      * @throws ReflectionException
@@ -388,8 +391,11 @@ final class GlobTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForClass(string $className, MutableObjectType $type): bool
+    public function canExtendTypeForClass(string $className, MutableInterface $type): bool
     {
         return $this->getMapClassToExtendTypeArray()->getExtendTypesByObjectClass($className) !== null;
     }
@@ -397,9 +403,11 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, MutableObjectType $type): void
+    public function extendTypeForClass(string $className, MutableInterface $type): void
     {
         $extendTypeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByObjectClass($className);
 
@@ -414,8 +422,11 @@ final class GlobTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool
+    public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
     {
         $typeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByGraphQLTypeName($typeName);
 
@@ -425,9 +436,11 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, MutableObjectType $type): void
+    public function extendTypeForName(string $typeName, MutableInterface $type): void
     {
         $extendTypeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByGraphQLTypeName($typeName);
         if ($extendTypeClassNames === null) {

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -26,8 +26,8 @@ use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeGenerator;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
-use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use Webmozart\Assert\Assert;
 use function class_exists;
@@ -295,7 +295,6 @@ final class GlobTypeMapper implements TypeMapperInterface
      * @param string $className The exact class name to look for (this function does not look into parent classes).
      * @param OutputType|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
      *
-     * @return MutableInterface
      * @throws CannotMapTypeExceptionInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
@@ -391,9 +390,8 @@ final class GlobTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
-     * @param string $className
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
     public function canExtendTypeForClass(string $className, MutableInterface $type): bool
     {
@@ -403,8 +401,8 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
-     * @param string $className
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function extendTypeForClass(string $className, MutableInterface $type): void
@@ -422,9 +420,8 @@ final class GlobTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
-     * @param string $typeName
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
     public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
     {
@@ -436,8 +433,8 @@ final class GlobTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
-     * @param string $typeName
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function extendTypeForName(string $typeName, MutableInterface $type): void

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use function interface_exists;
 use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
@@ -155,11 +156,11 @@ final class GlobTypeMapper implements TypeMapperInterface
             $explorer      = new GlobClassExplorer($this->namespace, $this->cache, $this->globTtl, ClassNameMapper::createFromComposerFile(null, null, true), $this->recursive);
             $classes       = $explorer->getClasses();
             foreach ($classes as $className) {
-                if (! class_exists($className)) {
+                if (! class_exists($className) && ! interface_exists($className)) {
                     continue;
                 }
                 $refClass = new ReflectionClass($className);
-                if (! $refClass->isInstantiable()) {
+                if (! $refClass->isInstantiable() && ! $refClass->isInterface()) {
                     continue;
                 }
                 $this->classes[$className] = $refClass;

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -7,7 +7,6 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
-use function interface_exists;
 use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
@@ -32,6 +31,7 @@ use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use Webmozart\Assert\Assert;
 use function class_exists;
+use function interface_exists;
 use function str_replace;
 
 /**

--- a/src/Mappers/PorpaginasTypeMapper.php
+++ b/src/Mappers/PorpaginasTypeMapper.php
@@ -11,9 +11,9 @@ use GraphQL\Type\Definition\Type;
 use Porpaginas\Result;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use function get_class;
 use function is_a;
 use function strpos;
@@ -48,6 +48,7 @@ class PorpaginasTypeMapper implements TypeMapperInterface
      * @param (OutputType&Type)|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
      *
      * @return MutableObjectType|MutableInterfaceType
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
@@ -64,6 +65,7 @@ class PorpaginasTypeMapper implements TypeMapperInterface
 
     /**
      * @param OutputType&Type $subType
+     *
      * @return MutableObjectType|MutableInterfaceType
      */
     private function getObjectType(OutputType $subType): MutableInterface
@@ -186,11 +188,10 @@ class PorpaginasTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
-     * @param string $className
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
-    public function canExtendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
+    public function canExtendTypeForClass(string $className, MutableInterface $type): bool
     {
         return false;
     }
@@ -198,22 +199,21 @@ class PorpaginasTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
-     * @param string $className
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
+    public function extendTypeForClass(string $className, MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendType($className, $type);
     }
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
-     * @param string $typeName
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
+    public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
     {
         return false;
     }
@@ -221,11 +221,11 @@ class PorpaginasTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
-     * @param string $typeName
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
+    public function extendTypeForName(string $typeName, MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendName($typeName, $type);
     }

--- a/src/Mappers/PorpaginasTypeMapper.php
+++ b/src/Mappers/PorpaginasTypeMapper.php
@@ -10,8 +10,10 @@ use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
 use Porpaginas\Result;
 use RuntimeException;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use function get_class;
 use function is_a;
 use function strpos;
@@ -19,7 +21,7 @@ use function substr;
 
 class PorpaginasTypeMapper implements TypeMapperInterface
 {
-    /** @var array<string, MutableObjectType> */
+    /** @var array<string, MutableInterface&(MutableObjectType|MutableInterfaceType)> */
     private $cache = [];
     /** @var RecursiveTypeMapperInterface */
     private $recursiveTypeMapper;
@@ -42,12 +44,13 @@ class PorpaginasTypeMapper implements TypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
-     * @param string          $className The exact class name to look for (this function does not look into parent classes).
-     * @param (OutputType&Type)|null $subType   An optional sub-type if the main class is an iterator that needs to be typed.
+     * @param string $className The exact class name to look for (this function does not look into parent classes).
+     * @param (OutputType&Type)|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
      *
+     * @return MutableObjectType|MutableInterfaceType
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
     {
         if (! $this->canMapClassToType($className)) {
             throw CannotMapTypeException::createForType($className);
@@ -61,8 +64,9 @@ class PorpaginasTypeMapper implements TypeMapperInterface
 
     /**
      * @param OutputType&Type $subType
+     * @return MutableObjectType|MutableInterfaceType
      */
-    private function getObjectType(OutputType $subType): MutableObjectType
+    private function getObjectType(OutputType $subType): MutableInterface
     {
         if (! isset($subType->name)) {
             throw new RuntimeException('Cannot get name property from sub type ' . get_class($subType));
@@ -128,7 +132,7 @@ class PorpaginasTypeMapper implements TypeMapperInterface
      *
      * @param string $typeName The name of the GraphQL type
      *
-     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType)
+     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
      *
      * @throws CannotMapTypeExceptionInterface
      */
@@ -182,8 +186,11 @@ class PorpaginasTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForClass(string $className, MutableObjectType $type): bool
+    public function canExtendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
     {
         return false;
     }
@@ -191,17 +198,22 @@ class PorpaginasTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, MutableObjectType $type): void
+    public function extendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendType($className, $type);
     }
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool
+    public function canExtendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
     {
         return false;
     }
@@ -209,9 +221,11 @@ class PorpaginasTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, MutableObjectType $type): void
+    public function extendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendName($typeName, $type);
     }

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -16,13 +16,13 @@ use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\InterfaceFromObjectType;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
+use Webmozart\Assert\Assert;
 use function array_flip;
 use function array_reverse;
 use function get_parent_class;
-use Webmozart\Assert\Assert;
 
 /**
  * This class wraps a TypeMapperInterface into a RecursiveTypeMapperInterface.
@@ -93,7 +93,9 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
      *
      * @param string $className The class name to look for (this function looks into parent classes if the class does not match a type)
      * @param (OutputType&Type)|null $subType
+     *
      * @return MutableInterface&(MutableObjectType|MutableInterfaceType)
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
@@ -153,9 +155,8 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
     /**
      * Extends a type using available type extenders.
      *
-     *
-     * @param string $className
      * @param MutableObjectType|MutableInterfaceType $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     private function extendType(string $className, MutableInterface $type): void

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -4,18 +4,14 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use function class_implements;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
-use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
 use Psr\SimpleCache\CacheInterface;
-use ReflectionClass;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
-use TheCodingMachine\GraphQLite\Reflection\ReflectionInterfaceUtils;
 use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\InterfaceFromObjectType;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
@@ -25,6 +21,7 @@ use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use Webmozart\Assert\Assert;
 use function array_flip;
 use function array_reverse;
+use function class_implements;
 use function get_parent_class;
 
 /**
@@ -273,21 +270,24 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
         $interfaces = [];
 
         foreach (class_implements($className) as $interface) {
-            if ($this->typeMapper->canMapClassToType($interface)) {
-                $interfaceType = $this->typeMapper->mapClassToType($interface, null);
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
-                // It might be a great idea
-                // We therefore need a ObjectFromInterface class to cast an interface returned by a TypeMapper into an object!
-                Assert::isInstanceOf($interfaceType, MutableInterfaceType::class);
-                $interfaces[] = $interfaceType;
+            if (! $this->typeMapper->canMapClassToType($interface)) {
+                continue;
             }
+
+            $interfaceType = $this->typeMapper->mapClassToType($interface, null);
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // FIXME: Should a PHP interface be mapped to a GraphQL interface AND a GraphQL implementation directly??????
+            // It might be a great idea
+            // We therefore need a ObjectFromInterface class to cast an interface returned by a TypeMapper into an object!
+            // Note: mapClassToType in the RECURSIVE type mapper should probably ALWAYS return an ObjectType
+            Assert::isInstanceOf($interfaceType, MutableInterfaceType::class);
+            $interfaces[] = $interfaceType;
         }
 
         while ($className = $this->findClosestMatchingParent($className)) {
@@ -330,12 +330,14 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
             $this->mappedClasses[$className] = $mappedClass;
             $parentClassName = $className;
             foreach (class_implements($className) as $interfaceName) {
-                if (isset($supportedClasses[$interfaceName])) {
-                    if (!isset($this->mappedClasses[$interfaceName])) {
-                        $this->mappedClasses[$interfaceName] = new MappedClass();
-                    }
-                    $this->mappedClasses[$interfaceName]->addChild($mappedClass);
+                if (! isset($supportedClasses[$interfaceName])) {
+                    continue;
                 }
+
+                if (! isset($this->mappedClasses[$interfaceName])) {
+                    $this->mappedClasses[$interfaceName] = new MappedClass();
+                }
+                $this->mappedClasses[$interfaceName]->addChild($mappedClass);
             }
             while ($parentClassName = get_parent_class($parentClassName)) {
                 if (isset($supportedClasses[$parentClassName])) {

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -132,7 +132,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
         } elseif ($type instanceof MutableInterfaceType) {
             $this->interfaces[$cacheKey] = $type;
         } else {
-            throw new RuntimeException('Unexpected type');
+            throw new RuntimeException('Unexpected type'); // @codeCoverageIgnore
         }
 
         $this->extendType($closestClassName, $type);

--- a/src/Mappers/RecursiveTypeMapperInterface.php
+++ b/src/Mappers/RecursiveTypeMapperInterface.php
@@ -32,8 +32,9 @@ interface RecursiveTypeMapperInterface
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
      * @param string $className The class name to look for (this function looks into parent classes if the class does not match a type).
-     * @param OutputType|null $subType
+     *
      * @return MutableInterface&(MutableObjectType|MutableInterfaceType)
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableInterface;

--- a/src/Mappers/RecursiveTypeMapperInterface.php
+++ b/src/Mappers/RecursiveTypeMapperInterface.php
@@ -9,6 +9,8 @@ use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 
@@ -29,12 +31,12 @@ interface RecursiveTypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
-     * @param string      $className                                          The class name to look for (this function looks into parent classes if the class does not match a type).
-     * @param (OutputType&Type)|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
-     *
+     * @param string $className The class name to look for (this function looks into parent classes if the class does not match a type).
+     * @param OutputType|null $subType
+     * @return MutableInterface&(MutableObjectType|MutableInterfaceType)
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType;
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface;
 
     /**
      * Maps a PHP fully qualified class name to a GraphQL interface (or returns null if no interface is found).

--- a/src/Mappers/RecursiveTypeMapperInterface.php
+++ b/src/Mappers/RecursiveTypeMapperInterface.php
@@ -9,7 +9,6 @@ use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
-use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
@@ -32,8 +31,6 @@ interface RecursiveTypeMapperInterface
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
      * @param string $className The class name to look for (this function looks into parent classes if the class does not match a type).
-     *
-     * @return MutableObjectType
      *
      * @throws CannotMapTypeExceptionInterface
      */

--- a/src/Mappers/RecursiveTypeMapperInterface.php
+++ b/src/Mappers/RecursiveTypeMapperInterface.php
@@ -33,11 +33,11 @@ interface RecursiveTypeMapperInterface
      *
      * @param string $className The class name to look for (this function looks into parent classes if the class does not match a type).
      *
-     * @return MutableInterface&(MutableObjectType|MutableInterfaceType)
+     * @return MutableObjectType
      *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface;
+    public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType;
 
     /**
      * Maps a PHP fully qualified class name to a GraphQL interface (or returns null if no interface is found).
@@ -100,4 +100,9 @@ interface RecursiveTypeMapperInterface
      * Returns the closest parent that can be mapped, or null if nothing can be matched.
      */
     public function findClosestMatchingParent(string $className): ?string;
+
+    /**
+     * Generates an object type from an interface type (in case no object type maps this interface)
+     */
+    public function getGeneratedObjectTypeFromInterfaceType(MutableInterfaceType $type): MutableObjectType;
 }

--- a/src/Mappers/StaticTypeMapper.php
+++ b/src/Mappers/StaticTypeMapper.php
@@ -7,8 +7,10 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use function array_keys;
 use function array_reduce;
 
@@ -19,13 +21,13 @@ use function array_reduce;
  */
 final class StaticTypeMapper implements TypeMapperInterface
 {
-    /** @var array<string,MutableObjectType> */
+    /** @var array<string,MutableInterface&(MutableObjectType|MutableInterfaceType)> */
     private $types = [];
 
     /**
      * An array mapping a fully qualified class name to the matching TypeInterface
      *
-     * @param array<string,MutableObjectType> $types
+     * @param array<string,MutableInterface&(MutableObjectType|MutableInterfaceType)> $types
      */
     public function setTypes(array $types): void
     {
@@ -45,7 +47,7 @@ final class StaticTypeMapper implements TypeMapperInterface
         $this->inputTypes = $inputTypes;
     }
 
-    /** @var array<string,Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType)> */
+    /** @var array<string,Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)> */
     private $notMappedTypes = [];
 
     /**
@@ -74,9 +76,12 @@ final class StaticTypeMapper implements TypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
+     * @param string $className
+     * @param OutputType|null $subType
+     * @return \TheCodingMachine\GraphQLite\Types\MutableInterface
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType
+    public function mapClassToType(string $className, ?OutputType $subType): \TheCodingMachine\GraphQLite\Types\MutableInterface
     {
         // TODO: add support for $subType
         if ($subType !== null) {
@@ -127,7 +132,7 @@ final class StaticTypeMapper implements TypeMapperInterface
      *
      * @param string $typeName The name of the GraphQL type
      *
-     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType)
+     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
      *
      * @throws CannotMapTypeExceptionInterface
      */
@@ -172,8 +177,11 @@ final class StaticTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForClass(string $className, MutableObjectType $type): bool
+    public function canExtendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
     {
         return false;
     }
@@ -181,17 +189,22 @@ final class StaticTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, MutableObjectType $type): void
+    public function extendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendType($className, $type);
     }
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool
+    public function canExtendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
     {
         return false;
     }
@@ -199,9 +212,11 @@ final class StaticTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, MutableObjectType $type): void
+    public function extendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendName($typeName, $type);
     }

--- a/src/Mappers/StaticTypeMapper.php
+++ b/src/Mappers/StaticTypeMapper.php
@@ -8,9 +8,9 @@ use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use function array_keys;
 use function array_reduce;
 
@@ -76,12 +76,9 @@ final class StaticTypeMapper implements TypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
-     * @param string $className
-     * @param OutputType|null $subType
-     * @return \TheCodingMachine\GraphQLite\Types\MutableInterface
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): \TheCodingMachine\GraphQLite\Types\MutableInterface
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
     {
         // TODO: add support for $subType
         if ($subType !== null) {
@@ -177,11 +174,10 @@ final class StaticTypeMapper implements TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
-     * @param string $className
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
-    public function canExtendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
+    public function canExtendTypeForClass(string $className, MutableInterface $type): bool
     {
         return false;
     }
@@ -189,22 +185,21 @@ final class StaticTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
-     * @param string $className
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
+    public function extendTypeForClass(string $className, MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendType($className, $type);
     }
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
-     * @param string $typeName
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): bool
+    public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
     {
         return false;
     }
@@ -212,11 +207,11 @@ final class StaticTypeMapper implements TypeMapperInterface
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
-     * @param string $typeName
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, \TheCodingMachine\GraphQLite\Types\MutableInterface $type): void
+    public function extendTypeForName(string $typeName, MutableInterface $type): void
     {
         throw CannotMapTypeException::createForExtendName($typeName, $type);
     }

--- a/src/Mappers/TypeMapperInterface.php
+++ b/src/Mappers/TypeMapperInterface.php
@@ -7,6 +7,8 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 
@@ -25,12 +27,13 @@ interface TypeMapperInterface
     /**
      * Maps a PHP fully qualified class name to a GraphQL type.
      *
-     * @param string          $className The exact class name to look for (this function does not look into parent classes).
-     * @param OutputType|null $subType   An optional sub-type if the main class is an iterator that needs to be typed.
+     * @param string $className The exact class name to look for (this function does not look into parent classes).
+     * @param (OutputType&Type)|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
      *
+     * @return MutableObjectType|MutableInterfaceType
      * @throws CannotMapTypeExceptionInterface
      */
-    public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType;
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface;
 
     /**
      * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
@@ -44,7 +47,7 @@ interface TypeMapperInterface
      *
      * @param string $typeName The name of the GraphQL type
      *
-     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType)
+     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
      */
     public function mapNameToType(string $typeName): Type;
 
@@ -69,27 +72,37 @@ interface TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForClass(string $className, MutableObjectType $type): bool;
+    public function canExtendTypeForClass(string $className, MutableInterface $type): bool;
 
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
+     * @param string $className
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForClass(string $className, MutableObjectType $type): void;
+    public function extendTypeForClass(string $className, MutableInterface $type): void;
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @return bool
      */
-    public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool;
+    public function canExtendTypeForName(string $typeName, MutableInterface $type): bool;
 
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
+     * @param string $typeName
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
      * @throws CannotMapTypeExceptionInterface
      */
-    public function extendTypeForName(string $typeName, MutableObjectType $type): void;
+    public function extendTypeForName(string $typeName, MutableInterface $type): void;
 
     /**
      * Returns true if this type mapper can decorate an existing input type for the $typeName GraphQL input type

--- a/src/Mappers/TypeMapperInterface.php
+++ b/src/Mappers/TypeMapperInterface.php
@@ -31,6 +31,7 @@ interface TypeMapperInterface
      * @param (OutputType&Type)|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
      *
      * @return MutableObjectType|MutableInterfaceType
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableInterface;
@@ -72,34 +73,32 @@ interface TypeMapperInterface
 
     /**
      * Returns true if this type mapper can extend an existing type for the $className FQCN
-     * @param string $className
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
     public function canExtendTypeForClass(string $className, MutableInterface $type): bool;
 
     /**
      * Extends the existing GraphQL type that is mapped to $className.
      *
-     * @param string $className
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function extendTypeForClass(string $className, MutableInterface $type): void;
 
     /**
      * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
-     * @param string $typeName
+     *
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
-     * @return bool
      */
     public function canExtendTypeForName(string $typeName, MutableInterface $type): bool;
 
     /**
      * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
      *
-     * @param string $typeName
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function extendTypeForName(string $typeName, MutableInterface $type): void;

--- a/src/NamingStrategy.php
+++ b/src/NamingStrategy.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
-use function str_replace;
 use TheCodingMachine\GraphQLite\Annotations\Factory;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 use function lcfirst;
+use function str_replace;
 use function strlen;
 use function strpos;
 use function strrpos;
@@ -30,7 +30,7 @@ class NamingStrategy implements NamingStrategyInterface
      */
     public function getConcreteNameFromInterfaceName(string $name): string
     {
-        return str_replace('Interface', '', $name).'Impl';
+        return str_replace('Interface', '', $name) . 'Impl';
     }
 
     /**

--- a/src/NamingStrategy.php
+++ b/src/NamingStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
+use function str_replace;
 use TheCodingMachine\GraphQLite\Annotations\Factory;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 use function lcfirst;
@@ -21,6 +22,15 @@ class NamingStrategy implements NamingStrategyInterface
     public function getInterfaceNameFromConcreteName(string $concreteType): string
     {
         return $concreteType . 'Interface';
+    }
+
+    /**
+     * Returns the name of the GraphQL object from a name of GraphQL interface type (when the object is created
+     * automatically from a "Type" annotated interface)
+     */
+    public function getConcreteNameFromInterfaceName(string $name): string
+    {
+        return str_replace('Interface', '', $name).'Impl';
     }
 
     /**

--- a/src/NamingStrategyInterface.php
+++ b/src/NamingStrategyInterface.php
@@ -16,6 +16,12 @@ interface NamingStrategyInterface
     public function getInterfaceNameFromConcreteName(string $concreteType): string;
 
     /**
+     * Returns the name of the GraphQL object from a name of GraphQL interface type (when the object is created
+     * automatically from a "Type" annotated interface)
+     */
+    public function getConcreteNameFromInterfaceName(string $name): string;
+
+    /**
      * Returns the GraphQL output object type name based on the type className and the Type annotation.
      */
     public function getOutputTypeName(string $typeClassName, Type $type): string;

--- a/src/Reflection/ReflectionInterfaceUtils.php
+++ b/src/Reflection/ReflectionInterfaceUtils.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Reflection;
+
+
+use function array_diff_key;
+use ReflectionClass;
+
+class ReflectionInterfaceUtils
+{
+
+    /**
+     * Returns a list of all interfaces directly implemented by this class/interface.
+     * "Super" interfaces are not returned.
+     *
+     * @param ReflectionClass $reflectionClass
+     * @return array<string, ReflectionClass> Interfaces indexed by FQCN
+     */
+    public static function getDirectlyImplementedInterfaces(ReflectionClass $reflectionClass): array
+    {
+        $interfaces = $reflectionClass->getInterfaces();
+
+        $subInterfaces = [];
+        foreach ($interfaces as $interface) {
+            $subInterfaces += $interface->getInterfaces();
+        }
+
+        return array_diff_key($interfaces, $subInterfaces);
+    }
+}

--- a/src/Reflection/ReflectionInterfaceUtils.php
+++ b/src/Reflection/ReflectionInterfaceUtils.php
@@ -13,7 +13,7 @@ class ReflectionInterfaceUtils
      * Returns a list of all interfaces directly implemented by this class/interface.
      * "Super" interfaces are not returned.
      *
-     * @return array<string, ReflectionClass> Interfaces indexed by FQCN
+     * @return array<string,ReflectionClass> Interfaces indexed by FQCN
      */
     public static function getDirectlyImplementedInterfaces(ReflectionClass $reflectionClass): array
     {

--- a/src/Reflection/ReflectionInterfaceUtils.php
+++ b/src/Reflection/ReflectionInterfaceUtils.php
@@ -1,20 +1,18 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Reflection;
 
-
-use function array_diff_key;
 use ReflectionClass;
+use function array_diff_key;
 
 class ReflectionInterfaceUtils
 {
-
     /**
      * Returns a list of all interfaces directly implemented by this class/interface.
      * "Super" interfaces are not returned.
      *
-     * @param ReflectionClass $reflectionClass
      * @return array<string, ReflectionClass> Interfaces indexed by FQCN
      */
     public static function getDirectlyImplementedInterfaces(ReflectionClass $reflectionClass): array

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -9,9 +9,9 @@ use ReflectionClass;
 use ReflectionException;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 
 /**
  * This class is in charge of creating Webonyx GraphQL types from annotated objects that do not extend the
@@ -104,6 +104,7 @@ class TypeGenerator
     /**
      * @param object $annotatedObject An object with a ExtendType annotation.
      * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
      * @throws ReflectionException
      */
     public function extendAnnotatedObject(object $annotatedObject, MutableInterface $type): void

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -53,7 +53,7 @@ class TypeGenerator
     /**
      * @param string $annotatedObjectClassName The FQCN of an object with a Type annotation.
      *
-     * @return MutableInterface&(TypeAnnotatedInterfaceType|TypeAnnotatedObjectType)
+     * @return MutableInterface&(MutableInterfaceType|MutableObjectType)
      *
      * @throws ReflectionException
      */

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -8,8 +8,10 @@ use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionException;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 
 /**
  * This class is in charge of creating Webonyx GraphQL types from annotated objects that do not extend the
@@ -101,8 +103,10 @@ class TypeGenerator
 
     /**
      * @param object $annotatedObject An object with a ExtendType annotation.
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     * @throws ReflectionException
      */
-    public function extendAnnotatedObject(object $annotatedObject, MutableObjectType $type): void
+    public function extendAnnotatedObject(object $annotatedObject, MutableInterface $type): void
     {
         $refTypeClass = new ReflectionClass($annotatedObject);
 

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -82,7 +82,7 @@ class TypeGenerator
         }
 
         if ($isInterface) {
-            return TypeAnnotatedInterfaceType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper, ! $typeField->isDefault(), $typeField->isInheritanceDisabled());
+            return TypeAnnotatedInterfaceType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper);
         }
 
         return TypeAnnotatedObjectType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper, ! $typeField->isDefault(), $typeField->isInheritanceDisabled());

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
-use function interface_exists;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionException;
@@ -14,6 +13,7 @@ use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeAnnotatedInterfaceType;
 use TheCodingMachine\GraphQLite\Types\TypeAnnotatedObjectType;
+use function interface_exists;
 
 /**
  * This class is in charge of creating Webonyx GraphQL types from annotated objects that do not extend the
@@ -52,6 +52,7 @@ class TypeGenerator
 
     /**
      * @param string $annotatedObjectClassName The FQCN of an object with a Type annotation.
+     *
      * @return MutableInterface&(TypeAnnotatedInterfaceType|TypeAnnotatedObjectType)
      *
      * @throws ReflectionException
@@ -82,9 +83,9 @@ class TypeGenerator
 
         if ($isInterface) {
             return TypeAnnotatedInterfaceType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper, ! $typeField->isDefault(), $typeField->isInheritanceDisabled());
-        } else {
-            return TypeAnnotatedObjectType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper, ! $typeField->isDefault(), $typeField->isInheritanceDisabled());
         }
+
+        return TypeAnnotatedObjectType::createFromAnnotatedClass($typeName, $typeField->getClass(), $annotatedObject, $this->fieldsBuilder, $this->recursiveTypeMapper, ! $typeField->isDefault(), $typeField->isInheritanceDisabled());
 
         /*return new ObjectType([
             'name' => $typeName,

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -10,9 +10,9 @@ use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use function get_class;
 
 /**
@@ -66,7 +66,6 @@ class TypeRegistry
     }
 
     /**
-     * @param string $typeName
      * @return MutableInterface&(MutableObjectType|MutableInterfaceType)
      */
     public function getMutableInterface(string $typeName): MutableInterface

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -9,8 +9,10 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use function get_class;
 
 /**
@@ -58,6 +60,20 @@ class TypeRegistry
         $type = $this->getType($typeName);
         if (! $type instanceof MutableObjectType) {
             throw new GraphQLException('Expected GraphQL type "' . $typeName . '" to be an MutableObjectType. Got a ' . get_class($type));
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param string $typeName
+     * @return MutableInterface&(MutableObjectType|MutableInterfaceType)
+     */
+    public function getMutableInterface(string $typeName): MutableInterface
+    {
+        $type = $this->getType($typeName);
+        if (! $type instanceof MutableInterface) {
+            throw new GraphQLException('Expected GraphQL type "' . $typeName . '" to be an MutableInterface. Got a ' . get_class($type));
         }
 
         return $type;

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -71,8 +71,8 @@ class TypeRegistry
     public function getMutableInterface(string $typeName): MutableInterface
     {
         $type = $this->getType($typeName);
-        if (! $type instanceof MutableInterface) {
-            throw new GraphQLException('Expected GraphQL type "' . $typeName . '" to be an MutableInterface. Got a ' . get_class($type));
+        if (! $type instanceof MutableInterface || (! $type instanceof MutableInterfaceType && ! $type instanceof MutableObjectType)) {
+            throw new GraphQLException('Expected GraphQL type "' . $typeName . '" to be either a MutableObjectType or a MutableInterfaceType. Got a ' . get_class($type));
         }
 
         return $type;

--- a/src/Types/MutableInterface.php
+++ b/src/Types/MutableInterface.php
@@ -3,7 +3,9 @@
 
 namespace TheCodingMachine\GraphQLite\Types;
 
-
+/**
+ * GraphQL objects or interfaces that can be muted.
+ */
 interface MutableInterface
 {
     // In pending state, we can still add fields.

--- a/src/Types/MutableInterface.php
+++ b/src/Types/MutableInterface.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
 
@@ -26,5 +27,5 @@ interface MutableInterface
      *
      * @throws InvariantViolation
      */
-    public function getFields();
+    public function getFields(): array;
 }

--- a/src/Types/MutableInterface.php
+++ b/src/Types/MutableInterface.php
@@ -3,6 +3,9 @@
 
 namespace TheCodingMachine\GraphQLite\Types;
 
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\FieldDefinition;
+
 /**
  * GraphQL objects or interfaces that can be muted.
  */
@@ -17,4 +20,11 @@ interface MutableInterface
     public function getStatus(): string;
 
     public function addFields(callable $fields): void;
+
+    /**
+     * @return FieldDefinition[]
+     *
+     * @throws InvariantViolation
+     */
+    public function getFields();
 }

--- a/src/Types/MutableInterface.php
+++ b/src/Types/MutableInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+
+interface MutableInterface
+{
+    // In pending state, we can still add fields.
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_FROZEN  = 'frozen';
+
+    public function freeze(): void;
+
+    public function getStatus(): string;
+
+    public function addFields(callable $fields): void;
+}

--- a/src/Types/MutableInterfaceType.php
+++ b/src/Types/MutableInterfaceType.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
 
-use Exception;
-use GraphQL\Error\InvariantViolation;
-use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InterfaceType;
-use GraphQL\Type\Definition\ObjectType;
-use RuntimeException;
 
 /**
  * An object type built from the Type annotation

--- a/src/Types/MutableInterfaceType.php
+++ b/src/Types/MutableInterfaceType.php
@@ -7,13 +7,14 @@ namespace TheCodingMachine\GraphQLite\Types;
 use Exception;
 use GraphQL\Error\InvariantViolation;
 use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
 use RuntimeException;
 
 /**
  * An object type built from the Type annotation
  */
-class MutableObjectType extends ObjectType implements MutableInterface
+class MutableInterfaceType extends InterfaceType implements MutableInterface
 {
     use MutableTrait;
 

--- a/src/Types/MutableObjectType.php
+++ b/src/Types/MutableObjectType.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
 
-use Exception;
-use GraphQL\Error\InvariantViolation;
-use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ObjectType;
-use RuntimeException;
 
 /**
  * An object type built from the Type annotation

--- a/src/Types/MutableTrait.php
+++ b/src/Types/MutableTrait.php
@@ -1,8 +1,8 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
-
 
 use Exception;
 use GraphQL\Error\InvariantViolation;
@@ -101,5 +101,4 @@ trait MutableTrait
     {
         return $this->className;
     }
-
 }

--- a/src/Types/MutableTrait.php
+++ b/src/Types/MutableTrait.php
@@ -1,0 +1,105 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\FieldDefinition;
+use RuntimeException;
+
+trait MutableTrait
+{
+    /** @var string */
+    private $status;
+
+    /** @var array<callable> */
+    private $fieldsCallables = [];
+
+    /** @var FieldDefinition[]|null */
+    private $finalFields;
+    /** @var string|null */
+    private $className;
+
+    public function freeze(): void
+    {
+        $this->status = self::STATUS_FROZEN;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function addFields(callable $fields): void
+    {
+        if ($this->status !== MutableInterface::STATUS_PENDING) {
+            throw new RuntimeException('Tried to add fields to a frozen MutableObjectType.');
+        }
+        $this->fieldsCallables[] = $fields;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @throws Exception
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    public function getField($name): FieldDefinition
+    {
+        if ($this->status === MutableInterface::STATUS_PENDING) {
+            throw new RuntimeException('You must freeze() a MutableObjectType before fetching its fields.');
+        }
+
+        return parent::getField($name);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    public function hasField($name): bool
+    {
+        if ($this->status === MutableInterface::STATUS_PENDING) {
+            throw new RuntimeException('You must freeze() a MutableObjectType before fetching its fields.');
+        }
+
+        return parent::hasField($name);
+    }
+
+    /**
+     * @return FieldDefinition[]
+     *
+     * @throws InvariantViolation
+     */
+    public function getFields(): array
+    {
+        if ($this->finalFields === null) {
+            if ($this->status === MutableInterface::STATUS_PENDING) {
+                throw new RuntimeException('You must freeze() a MutableObjectType before fetching its fields.');
+            }
+
+            $this->finalFields = parent::getFields();
+            foreach ($this->fieldsCallables as $fieldsCallable) {
+                $this->finalFields = FieldDefinition::defineFieldMap($this, $fieldsCallable()) + $this->finalFields;
+            }
+            if (empty($this->finalFields)) {
+                throw NoFieldsException::create($this->name);
+            }
+        }
+
+        return $this->finalFields;
+    }
+
+    /**
+     * Returns the PHP class mapping this GraphQL type (if any)
+     */
+    public function getMappedClassName(): ?string
+    {
+        return $this->className;
+    }
+
+}

--- a/src/Types/ObjectFromInterfaceType.php
+++ b/src/Types/ObjectFromInterfaceType.php
@@ -5,14 +5,6 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Types;
 
 use GraphQL\Type\Definition\InterfaceType;
-use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\OutputType;
-use GraphQL\Type\Definition\Type;
-use InvalidArgumentException;
-use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
-use function get_class;
-use function gettype;
-use function is_object;
 
 class ObjectFromInterfaceType extends MutableObjectType
 {
@@ -26,10 +18,8 @@ class ObjectFromInterfaceType extends MutableObjectType
             'fields' => static function () use ($type) {
                 return $type->getFields();
             },
-            'interfaces' => [
-                $type
-            ],
-            'description' => $type->description
+            'interfaces' => [$type],
+            'description' => $type->description,
         ]);
     }
 }

--- a/src/Types/ObjectFromInterfaceType.php
+++ b/src/Types/ObjectFromInterfaceType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type;
+use InvalidArgumentException;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use function get_class;
+use function gettype;
+use function is_object;
+
+class ObjectFromInterfaceType extends MutableObjectType
+{
+    /**
+     * @param string $name The name of the object type to create
+     */
+    public function __construct(string $name, InterfaceType $type)
+    {
+        parent::__construct([
+            'name' => $name,
+            'fields' => static function () use ($type) {
+                return $type->getFields();
+            },
+            'interfaces' => [
+                $type
+            ],
+            'description' => $type->description
+        ]);
+    }
+}

--- a/src/Types/TypeAnnotatedInterfaceType.php
+++ b/src/Types/TypeAnnotatedInterfaceType.php
@@ -21,9 +21,7 @@ use function is_object;
  */
 class TypeAnnotatedInterfaceType extends MutableInterfaceType
 {
-    /**
-     * @var RecursiveTypeMapperInterface
-     */
+    /** @var RecursiveTypeMapperInterface */
     private $recursiveTypeMapper;
 
     /**
@@ -67,43 +65,27 @@ class TypeAnnotatedInterfaceType extends MutableInterfaceType
                 $fields += $interfaceFields;
 
                 return $fields;
-            },
-            'resolveType' => function ($value) use ($recursiveTypeMapper) {
-                if (! is_object($value)) {
-                    throw new InvalidArgumentException('Expected object for resolveType. Got: "' . gettype($value) . '"');
-                }
-
-                $className = get_class($value);
-
-                if ($recursiveTypeMapper->canMapClassToType($className, null)) {
-                    return $recursiveTypeMapper->mapClassToType($className, null);
-                } else {
-                    return $recursiveTypeMapper->getGeneratedObjectTypeFromInterfaceType($this);
-                }
-            },
+            }
         ], $recursiveTypeMapper);
     }
 
     /**
      * Resolves concrete ObjectType for given object value
      *
-     * @param object  $objectValue
      * @param mixed[] $context
-     *
-     * @return Type|null
      */
     public function resolveType($objectValue, $context, ResolveInfo $info)
     {
         if (! is_object($objectValue)) {
-            throw new InvalidArgumentException('Expected object for resolveType. Got: "' . gettype($value) . '"');
+            throw new InvalidArgumentException('Expected object for resolveType. Got: "' . gettype($objectValue) . '"');
         }
 
         $className = get_class($objectValue);
 
-        if ($this->recursiveTypeMapper->canMapClassToType($className, null)) {
+        if ($this->recursiveTypeMapper->canMapClassToType($className)) {
             return $this->recursiveTypeMapper->mapClassToType($className, null);
-        } else {
-            return $this->recursiveTypeMapper->getGeneratedObjectTypeFromInterfaceType($this);
         }
+
+        return $this->recursiveTypeMapper->getGeneratedObjectTypeFromInterfaceType($this);
     }
 }

--- a/src/Types/TypeAnnotatedInterfaceType.php
+++ b/src/Types/TypeAnnotatedInterfaceType.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
 
-use function array_merge;
-use function get_class;
-use function get_declared_interfaces;
 use InvalidArgumentException;
-use function is_object;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
-use function get_parent_class;
 use TheCodingMachine\GraphQLite\Reflection\ReflectionInterfaceUtils;
+use function array_merge;
+use function get_class;
+use function gettype;
+use function is_object;
 
 /**
  * An object type built from the Type annotation
@@ -32,19 +31,20 @@ class TypeAnnotatedInterfaceType extends MutableInterfaceType
     {
         return new self($className, [
             'name' => $typeName,
-            'fields' => static function () use ($annotatedObject, $recursiveTypeMapper, $className, $fieldsBuilder, $disableInheritance) {
-
+            'fields' => static function () use ($annotatedObject, $recursiveTypeMapper, $className, $fieldsBuilder) {
                 $interfaces = ReflectionInterfaceUtils::getDirectlyImplementedInterfaces(new ReflectionClass($className));
 
                 $fieldsArray = [];
                 foreach ($interfaces as $interfaceName => $interface) {
-                    if ($recursiveTypeMapper->canMapClassToType($interfaceName)) {
-                        $interfaceType = $recursiveTypeMapper->mapClassToType($interfaceName, null);
-                        $fieldsArray[] = $interfaceType->getFields();
+                    if (! $recursiveTypeMapper->canMapClassToType($interfaceName)) {
+                        continue;
                     }
+
+                    $interfaceType = $recursiveTypeMapper->mapClassToType($interfaceName, null);
+                    $fieldsArray[] = $interfaceType->getFields();
                 }
 
-                if (!empty($fieldsArray)) {
+                if (! empty($fieldsArray)) {
                     $interfaceFields = array_merge(...$fieldsArray);
                 } else {
                     $interfaceFields = [];

--- a/src/Types/TypeAnnotatedInterfaceType.php
+++ b/src/Types/TypeAnnotatedInterfaceType.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
 
+use function array_merge;
 use function get_class;
+use function get_declared_interfaces;
 use InvalidArgumentException;
 use function is_object;
+use ReflectionClass;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use function get_parent_class;
+use TheCodingMachine\GraphQLite\Reflection\ReflectionInterfaceUtils;
 
 /**
  * An object type built from the Type annotation
@@ -30,24 +34,20 @@ class TypeAnnotatedInterfaceType extends MutableInterfaceType
             'name' => $typeName,
             'fields' => static function () use ($annotatedObject, $recursiveTypeMapper, $className, $fieldsBuilder, $disableInheritance) {
 
-                // TODO: get fields from parent interfaces
-                // TODO: get fields from parent interfaces
-                // TODO: get fields from parent interfaces
-                // TODO: get fields from parent interfaces
-                // TODO: get fields from parent interfaces
-                // TODO: get fields from parent interfaces
-                // TODO: get fields from parent interfaces
-                // TODO: get fields from parent interfaces
-                // QUESTION: DO WE NEED ANOTHER SET OF FUNCTIONS IN THE TYPEMAPPER OR DO WE USE THE CURRENT getByClassName...
-                // QUESTION: DO WE NEED ANOTHER SET OF FUNCTIONS IN THE TYPEMAPPER OR DO WE USE THE CURRENT getByClassName...
-                // QUESTION: DO WE NEED ANOTHER SET OF FUNCTIONS IN THE TYPEMAPPER OR DO WE USE THE CURRENT getByClassName... ???
+                $interfaces = ReflectionInterfaceUtils::getDirectlyImplementedInterfaces(new ReflectionClass($className));
 
-                /*$parentClass = get_parent_class($className);
-                $parentType  = null;
-                if ($parentClass !== false && $disableInheritance === false) {
-                    if ($recursiveTypeMapper->canMapClassToType($parentClass)) {
-                        $parentType = $recursiveTypeMapper->mapClassToType($parentClass, null);
+                $fieldsArray = [];
+                foreach ($interfaces as $interfaceName => $interface) {
+                    if ($recursiveTypeMapper->canMapClassToType($interfaceName)) {
+                        $interfaceType = $recursiveTypeMapper->mapClassToType($interfaceName, null);
+                        $fieldsArray[] = $interfaceType->getFields();
                     }
+                }
+
+                if (!empty($fieldsArray)) {
+                    $interfaceFields = array_merge(...$fieldsArray);
+                } else {
+                    $interfaceFields = [];
                 }
 
                 if ($annotatedObject !== null) {
@@ -55,14 +55,8 @@ class TypeAnnotatedInterfaceType extends MutableInterfaceType
                 } else {
                     $fields = $fieldsBuilder->getSelfFields($className);
                 }
-                if ($parentType !== null) {
-                    $finalFields = $parentType->getFields();
-                    foreach ($fields as $name => $field) {
-                        $finalFields[$name] = $field;
-                    }
 
-                    return $finalFields;
-                }*/
+                $fields += $interfaceFields;
 
                 return $fields;
             },

--- a/src/Types/TypeAnnotatedInterfaceType.php
+++ b/src/Types/TypeAnnotatedInterfaceType.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+use function get_class;
+use InvalidArgumentException;
+use function is_object;
+use TheCodingMachine\GraphQLite\FieldsBuilder;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use function get_parent_class;
+
+/**
+ * An object type built from the Type annotation
+ */
+class TypeAnnotatedInterfaceType extends MutableInterfaceType
+{
+    /**
+     * @param mixed[] $config
+     */
+    public function __construct(string $className, array $config)
+    {
+        parent::__construct($config, $className);
+    }
+
+    public static function createFromAnnotatedClass(string $typeName, string $className, ?object $annotatedObject, FieldsBuilder $fieldsBuilder, RecursiveTypeMapperInterface $recursiveTypeMapper, bool $doNotMapInterfaces, bool $disableInheritance): self
+    {
+        return new self($className, [
+            'name' => $typeName,
+            'fields' => static function () use ($annotatedObject, $recursiveTypeMapper, $className, $fieldsBuilder, $disableInheritance) {
+
+                // TODO: get fields from parent interfaces
+                // TODO: get fields from parent interfaces
+                // TODO: get fields from parent interfaces
+                // TODO: get fields from parent interfaces
+                // TODO: get fields from parent interfaces
+                // TODO: get fields from parent interfaces
+                // TODO: get fields from parent interfaces
+                // TODO: get fields from parent interfaces
+                // QUESTION: DO WE NEED ANOTHER SET OF FUNCTIONS IN THE TYPEMAPPER OR DO WE USE THE CURRENT getByClassName...
+                // QUESTION: DO WE NEED ANOTHER SET OF FUNCTIONS IN THE TYPEMAPPER OR DO WE USE THE CURRENT getByClassName...
+                // QUESTION: DO WE NEED ANOTHER SET OF FUNCTIONS IN THE TYPEMAPPER OR DO WE USE THE CURRENT getByClassName... ???
+
+                /*$parentClass = get_parent_class($className);
+                $parentType  = null;
+                if ($parentClass !== false && $disableInheritance === false) {
+                    if ($recursiveTypeMapper->canMapClassToType($parentClass)) {
+                        $parentType = $recursiveTypeMapper->mapClassToType($parentClass, null);
+                    }
+                }
+
+                if ($annotatedObject !== null) {
+                    $fields = $fieldsBuilder->getFields($annotatedObject);
+                } else {
+                    $fields = $fieldsBuilder->getSelfFields($className);
+                }
+                if ($parentType !== null) {
+                    $finalFields = $parentType->getFields();
+                    foreach ($fields as $name => $field) {
+                        $finalFields[$name] = $field;
+                    }
+
+                    return $finalFields;
+                }*/
+
+                return $fields;
+            },
+            'resolve' => static function ($value) use ($recursiveTypeMapper) {
+                if (! is_object($value)) {
+                    throw new InvalidArgumentException('Expected object for resolveType. Got: "' . gettype($value) . '"');
+                }
+
+                $className = get_class($value);
+
+                return $recursiveTypeMapper->mapClassToType($className, null);
+            },
+        ]);
+    }
+}

--- a/src/Types/TypeAnnotatedObjectType.php
+++ b/src/Types/TypeAnnotatedObjectType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
 
+use function class_implements;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use function get_parent_class;
@@ -45,7 +46,28 @@ class TypeAnnotatedObjectType extends MutableObjectType
                         $finalFields[$name] = $field;
                     }
 
-                    return $finalFields;
+                    $fields = $finalFields;
+                }
+
+                // FIXME: we must get interfaces in THE CORRECT ORDER!!!!
+                // FIXME: write tests for the order!!! => with 2 @ExtendType on the interface
+
+                // FIXME: add an interface with a @Type that is implemented by noone.
+                // Check that it does not trigger an exception.
+                if ($disableInheritance === false) {
+                    $interfaces = class_implements($className);
+                    foreach ($interfaces as $interface) {
+                        if ($recursiveTypeMapper->canMapClassToType($interface)) {
+                            $interfaceType = $recursiveTypeMapper->mapClassToType($interface, null);
+
+                            $interfaceFields = $interfaceType->getFields();
+                            foreach ($interfaceFields as $name => $field) {
+                                if (!isset($fields[$name])) {
+                                    $fields[$name] = $field;
+                                }
+                            }
+                        }
+                    }
                 }
 
                 return $fields;

--- a/src/Types/TypeAnnotatedObjectType.php
+++ b/src/Types/TypeAnnotatedObjectType.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Types;
 
-use function class_implements;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use function class_implements;
 use function get_parent_class;
 
 /**
@@ -57,15 +57,19 @@ class TypeAnnotatedObjectType extends MutableObjectType
                 if ($disableInheritance === false) {
                     $interfaces = class_implements($className);
                     foreach ($interfaces as $interface) {
-                        if ($recursiveTypeMapper->canMapClassToType($interface)) {
-                            $interfaceType = $recursiveTypeMapper->mapClassToType($interface, null);
+                        if (! $recursiveTypeMapper->canMapClassToType($interface)) {
+                            continue;
+                        }
 
-                            $interfaceFields = $interfaceType->getFields();
-                            foreach ($interfaceFields as $name => $field) {
-                                if (!isset($fields[$name])) {
-                                    $fields[$name] = $field;
-                                }
+                        $interfaceType = $recursiveTypeMapper->mapClassToType($interface, null);
+
+                        $interfaceFields = $interfaceType->getFields();
+                        foreach ($interfaceFields as $name => $field) {
+                            if (isset($fields[$name])) {
+                                continue;
                             }
+
+                            $fields[$name] = $field;
                         }
                     }
                 }

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -41,6 +41,7 @@ use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
@@ -133,7 +134,7 @@ abstract class AbstractQueryProviderTest extends TestCase
                     //$this->inputTestObjectType2 = $inputTestObjectType2;
                 }
 
-                public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType
+                public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
                 {
                     if ($className === TestObject::class) {
                         return $this->testObjectType;
@@ -189,22 +190,22 @@ abstract class AbstractQueryProviderTest extends TestCase
                     return $typeName === 'TestObject' || $typeName === 'TestObject2' || $typeName === 'TestObjectInput';
                 }
 
-                public function canExtendTypeForClass(string $className, MutableObjectType $type): bool
+                public function canExtendTypeForClass(string $className, MutableInterface $type): bool
                 {
                     return false;
                 }
 
-                public function extendTypeForClass(string $className, MutableObjectType $type): void
+                public function extendTypeForClass(string $className, MutableInterface $type): void
                 {
                     throw CannotMapTypeException::createForExtendType($className, $type);
                 }
 
-                public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool
+                public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
                 {
                     return false;
                 }
 
-                public function extendTypeForName(string $typeName, MutableObjectType $type): void
+                public function extendTypeForName(string $typeName, MutableInterface $type): void
                 {
                     throw CannotMapTypeException::createForExtendName($typeName, $type);
                 }

--- a/tests/Annotations/TypeTest.php
+++ b/tests/Annotations/TypeTest.php
@@ -4,6 +4,8 @@ namespace TheCodingMachine\GraphQLite\Annotations;
 
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface;
+use TheCodingMachine\GraphQLite\GraphQLException;
 
 class TypeTest extends TestCase
 {
@@ -19,5 +21,21 @@ class TypeTest extends TestCase
     {
         $type = new Type(['external'=>true]);
         $this->assertSame(false, $type->isSelfType());
+    }
+
+    public function testException2()
+    {
+        $type = new Type(['default'=>false]);
+        $this->expectException(GraphQLException::class);
+        $this->expectExceptionMessage('Problem in annotation @Type for interface "TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface": you cannot use the default="false" attribute on interfaces');
+        $type->setClass(FooInterface::class);
+    }
+
+    public function testException3()
+    {
+        $type = new Type(['disableInheritance'=>true]);
+        $this->expectException(GraphQLException::class);
+        $this->expectExceptionMessage('Problem in annotation @Type for interface "TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface": you cannot use the disableInheritance="true" attribute on interfaces');
+        $type->setClass(FooInterface::class);
     }
 }

--- a/tests/Fixtures/AnnotatedInterfaces/Controllers/AnnotatedInterfaceController.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Controllers/AnnotatedInterfaceController.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Controllers;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\BazInterface;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\ClassA;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\ClassD;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface;
+
+class AnnotatedInterfaceController
+{
+    /**
+     * @Query()
+     */
+    public function getClassA(): ClassA
+    {
+        return new ClassA();
+    }
+
+    /**
+     * @Query()
+     */
+    public function getFoo(): FooInterface
+    {
+        return new ClassD();
+    }
+
+    /**
+     * @Query() Unsupported: annotating an interface that has no @Type annotation.
+     */
+    /*public function getBaz(): BazInterface
+    {
+        return new ClassD();
+    }*/
+
+    /**
+     * @Query()
+     */
+    public function getClassD(): ClassD
+    {
+        return new ClassD();
+    }
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Controllers/AnnotatedInterfaceController.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Controllers/AnnotatedInterfaceController.php
@@ -9,6 +9,9 @@ use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\BazInterface;
 use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\ClassA;
 use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\ClassD;
 use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\NotAnnotatedQux;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\QuxInterface;
+use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\WizzInterface;
 
 class AnnotatedInterfaceController
 {
@@ -39,8 +42,16 @@ class AnnotatedInterfaceController
     /**
      * @Query()
      */
-    public function getClassD(): ClassD
+    public function getClassDAsWizInterface(): WizzInterface
     {
         return new ClassD();
+    }
+
+    /**
+     * @Query()
+     */
+    public function getQux(): QuxInterface
+    {
+        return new NotAnnotatedQux();
     }
 }

--- a/tests/Fixtures/AnnotatedInterfaces/Types/BarInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/BarInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type()
+ */
+interface BarInterface
+{
+    /**
+     * @Field()
+     */
+    public function getBar(): string;
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/BazInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/BazInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+interface BazInterface extends ParentInterface
+{
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ClassA.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ClassA.php
@@ -25,4 +25,14 @@ class ClassA implements FooInterface, BarInterface, BazInterface
     {
         return 'parent';
     }
+
+    public function grandFather(): string
+    {
+        return 'grandFather';
+    }
+
+    public function grandMother(): string
+    {
+        return 'grandMother';
+    }
 }

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ClassA.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ClassA.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type()
+ */
+class ClassA implements FooInterface, BarInterface, BazInterface
+{
+
+    public function getBar(): string
+    {
+        return 'bar';
+    }
+
+    public function getFoo(): string
+    {
+        return 'foo';
+    }
+
+    public function getParentValue(): string
+    {
+        return 'parent';
+    }
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ClassB.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ClassB.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+class ClassB extends ClassA
+{
+
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ClassC.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ClassC.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+
+class ClassC extends ClassB implements WizzInterface
+{
+    /**
+     * @Field()
+     */
+    public function getWizz(): string
+    {
+        return 'wizz';
+    }
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ClassD.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ClassD.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type()
+ */
+class ClassD extends ClassC
+{
+
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/FooInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/FooInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type()
+ */
+interface FooInterface
+{
+    /**
+     * @Field()
+     */
+    public function getFoo(): string;
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/GrandFatherInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/GrandFatherInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type()
+ */
+interface GrandFatherInterface
+{
+    /**
+     * @Field()
+     */
+    public function grandFather(): string;
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/GrandMotherInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/GrandMotherInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type()
+ */
+interface GrandMotherInterface
+{
+    /**
+     * @Field()
+     */
+    public function grandMother(): string;
+
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/NotAnnotatedQux.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/NotAnnotatedQux.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+class NotAnnotatedQux implements QuxInterface
+{
+    public function getQux(): string
+    {
+        return 'qux';
+    }
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ParentInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ParentInterface.php
@@ -3,7 +3,7 @@
 
 namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
 
-interface ParentInterface
+interface ParentInterface extends ParentParentInterface
 {
     public function getParentValue(): string;
 }

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ParentInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ParentInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+interface ParentInterface
+{
+    public function getParentValue(): string;
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ParentInterfaceType.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ParentInterfaceType.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(class=ParentInterface::class)
+ * @SourceField(name="parentValue")
+ */
+class ParentInterfaceType
+{
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/ParentParentInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/ParentParentInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+interface ParentParentInterface extends GrandFatherInterface, GrandMotherInterface
+{
+}

--- a/tests/Fixtures/AnnotatedInterfaces/Types/QuxInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/QuxInterface.php
@@ -9,13 +9,10 @@ use TheCodingMachine\GraphQLite\Annotations\Type;
 /**
  * @Type()
  */
-class ClassD extends ClassC
+interface QuxInterface
 {
     /**
      * @Field()
      */
-    public function getClassD(): string
-    {
-        return 'classD';
-    }
+    public function getQux(): string;
 }

--- a/tests/Fixtures/AnnotatedInterfaces/Types/WizzInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/WizzInterface.php
@@ -5,7 +5,11 @@ namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
 
 
 use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
 
+/**
+ * @Type()
+ */
 interface WizzInterface
 {
     /**

--- a/tests/Fixtures/AnnotatedInterfaces/Types/WizzInterface.php
+++ b/tests/Fixtures/AnnotatedInterfaces/Types/WizzInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+
+interface WizzInterface
+{
+    /**
+     * @Field()
+     */
+    public function getWizz(): string;
+}

--- a/tests/Integration/AnnotatedInterfaceTest.php
+++ b/tests/Integration/AnnotatedInterfaceTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Integration;
+
+use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use GraphQL\Error\Debug;
+use GraphQL\GraphQL;
+use GraphQL\Type\Definition\NonNull;
+use Mouf\Picotainer\Picotainer;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use stdClass;
+use Symfony\Component\Cache\Simple\ArrayCache;
+use Symfony\Component\Lock\Factory as LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
+use Symfony\Component\Lock\Store\SemaphoreStore;
+use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\FieldsBuilder;
+use TheCodingMachine\GraphQLite\GlobControllerQueryProvider;
+use TheCodingMachine\GraphQLite\InputTypeGenerator;
+use TheCodingMachine\GraphQLite\InputTypeUtils;
+use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper;
+use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\MyCLabsEnumTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
+use TheCodingMachine\GraphQLite\Middlewares\AuthorizationFieldMiddleware;
+use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewareInterface;
+use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewarePipe;
+use TheCodingMachine\GraphQLite\NamingStrategy;
+use TheCodingMachine\GraphQLite\NamingStrategyInterface;
+use TheCodingMachine\GraphQLite\QueryProviderInterface;
+use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
+use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
+use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
+use TheCodingMachine\GraphQLite\Schema;
+use TheCodingMachine\GraphQLite\SchemaFactory;
+use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
+use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
+use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
+use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
+use TheCodingMachine\GraphQLite\TypeGenerator;
+use TheCodingMachine\GraphQLite\TypeMismatchException;
+use TheCodingMachine\GraphQLite\TypeRegistry;
+use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
+use TheCodingMachine\GraphQLite\Types\TypeResolver;
+use function var_dump;
+use function var_export;
+
+class AnnotatedInterfaceTest extends TestCase
+{
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    public function setUp(): void
+    {
+        $container = new BasicAutoWiringContainer(new EmptyContainer());
+
+        $schemaFactory = new SchemaFactory(new ArrayCache(), $container);
+        $schemaFactory->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\AnnotatedInterfaces\\Controllers');
+        $schemaFactory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\AnnotatedInterfaces\\Types');
+
+        $this->schema = $schemaFactory->createSchema();
+    }
+
+    public function testClassA(): void
+    {
+        $this->schema->assertValid();
+
+        $queryString = '
+        query {
+            classA {
+                foo
+                bar
+                parentValue
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $this->schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'classA' => [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'parentValue' => 'parent',
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data'] ?? $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['errors']);
+    }
+}

--- a/tests/Integration/AnnotatedInterfaceTest.php
+++ b/tests/Integration/AnnotatedInterfaceTest.php
@@ -101,4 +101,59 @@ class AnnotatedInterfaceTest extends TestCase
             ]
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data'] ?? $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['errors']);
     }
+
+    public function testAnnotatedInterfaceWithNotAnnotatedClass(): void
+    {
+        $queryString = '
+        query {
+            qux {
+                qux
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $this->schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'qux' => [
+                'qux' => 'qux',
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data'] ?? $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['errors']);
+    }
+
+    public function testAnnotatedInterfaceWithAnnotatedClass(): void
+    {
+        $queryString = '
+        query {
+            classDAsWizInterface {
+                wizz
+                ... on ClassD {
+                    foo
+                    bar
+                    parentValue
+                    classD
+                }
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $this->schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'classDAsWizInterface' => [
+                'wizz' => 'wizz',
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'parentValue' => 'parent',
+                'classD' => 'classD',
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data'] ?? $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['errors']);
+    }
+
 }

--- a/tests/Integration/AnnotatedInterfaceTest.php
+++ b/tests/Integration/AnnotatedInterfaceTest.php
@@ -84,6 +84,8 @@ class AnnotatedInterfaceTest extends TestCase
                 foo
                 bar
                 parentValue
+                grandFather
+                grandMother
             }
         }
         ';
@@ -98,6 +100,8 @@ class AnnotatedInterfaceTest extends TestCase
                 'foo' => 'foo',
                 'bar' => 'bar',
                 'parentValue' => 'parent',
+                'grandFather' => 'grandFather',
+                'grandMother' => 'grandMother',
             ]
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data'] ?? $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['errors']);
     }

--- a/tests/Mappers/CompositeTypeMapperTest.php
+++ b/tests/Mappers/CompositeTypeMapperTest.php
@@ -12,6 +12,7 @@ use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\TypeMappingException;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
@@ -26,7 +27,7 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
     public function setUp(): void
     {
         $typeMapper1 = new class() implements TypeMapperInterface {
-            public function mapClassToType(string $className, ?OutputType $subType): MutableObjectType
+            public function mapClassToType(string $className, ?OutputType $subType): \TheCodingMachine\GraphQLite\Types\MutableInterface
             {
                 if ($className === TestObject::class) {
                     return new MutableObjectType([
@@ -106,22 +107,22 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
                 return $typeName === 'TestObject';
             }
 
-            public function canExtendTypeForClass(string $className, MutableObjectType $type): bool
+            public function canExtendTypeForClass(string $className, MutableInterface $type): bool
             {
                 return false;
             }
 
-            public function extendTypeForClass(string $className, MutableObjectType $type): void
+            public function extendTypeForClass(string $className, MutableInterface $type): void
             {
                 throw CannotMapTypeException::createForExtendType($className, $type);
             }
 
-            public function canExtendTypeForName(string $typeName, MutableObjectType $type): bool
+            public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
             {
                 return true;
             }
 
-            public function extendTypeForName(string $typeName, MutableObjectType $type): void
+            public function extendTypeForName(string $typeName, MutableInterface $type): void
             {
                 $type->addFields(function() {
                     return [

--- a/tests/Reflection/Fixtures/SomeClass.php
+++ b/tests/Reflection/Fixtures/SomeClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Reflection\Fixtures;
+
+
+class SomeClass implements SomeInterface
+{
+
+}

--- a/tests/Reflection/Fixtures/SomeInterface.php
+++ b/tests/Reflection/Fixtures/SomeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Reflection\Fixtures;
+
+
+interface SomeInterface extends SuperInterface
+{
+
+}

--- a/tests/Reflection/Fixtures/SuperInterface.php
+++ b/tests/Reflection/Fixtures/SuperInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Reflection\Fixtures;
+
+
+interface SuperInterface
+{
+
+}

--- a/tests/Reflection/ReflectionInterfaceUtilsTest.php
+++ b/tests/Reflection/ReflectionInterfaceUtilsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Reflection;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use TheCodingMachine\GraphQLite\Reflection\Fixtures\SomeClass;
+use TheCodingMachine\GraphQLite\Reflection\Fixtures\SomeInterface;
+
+class ReflectionInterfaceUtilsTest extends TestCase
+{
+    public function testGetDirectlyImplementedInterfaces()
+    {
+        $interfaces = ReflectionInterfaceUtils::getDirectlyImplementedInterfaces(new ReflectionClass(SomeClass::class));
+        $this->assertCount(1, $interfaces);
+        $this->assertSame(SomeInterface::class, $interfaces[SomeInterface::class]->getName());
+    }
+}

--- a/tests/TypeRegistryTest.php
+++ b/tests/TypeRegistryTest.php
@@ -75,4 +75,24 @@ class TypeRegistryTest extends TestCase
         $this->assertSame($type, $registry->getMutableObjectType('FooBar'));
     }
 
+    public function testGetMutableInterface(): void
+    {
+        $type = new MutableObjectType([
+            'name' => 'Foo',
+            'fields' => function() {return [];}
+        ]);
+        $type2 = new ObjectType([
+            'name' => 'FooBar',
+            'fields' => function() {return [];}
+        ]);
+
+        $registry = new TypeRegistry();
+        $registry->registerType($type);
+        $registry->registerType($type2);
+
+        $this->assertSame($type, $registry->getMutableInterface('Foo'));
+
+        $this->expectException(GraphQLException::class);
+        $this->assertSame($type, $registry->getMutableInterface('FooBar'));
+    }
 }

--- a/tests/Types/TypeAnnotatedInterfaceTypeTest.php
+++ b/tests/Types/TypeAnnotatedInterfaceTypeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use InvalidArgumentException;
+use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+
+class TypeAnnotatedInterfaceTypeTest extends AbstractQueryProviderTest
+{
+
+    public function testResolveTypeException()
+    {
+        $typeAnnotatedInterfaceType = new TypeAnnotatedInterfaceType('Foo', [], $this->getTypeMapper());
+        $resolveInfo = $this->createMock(ResolveInfo::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected object for resolveType. Got: "string"');
+
+        $typeAnnotatedInterfaceType->resolveType('foo', null, $resolveInfo);
+    }
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,7 +2,7 @@
   "docs": {
     "Introduction": ["features"],
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
-    "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance"],
+    "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance-interfaces"],
     "Performance": ["query-plan", "prefetch-method"],
     "Advanced": ["file-uploads", "pagination", "custom-types", "field-middlewares", "extend_input_type", "multiple_output_types", "symfony-bundle-advanced", "internals", "troubleshooting", "migrating"],
     "Reference": ["annotations_reference"]


### PR DESCRIPTION
It should be possible to annotate a PHP interface with the @Type annotation.
That should automatically map to a GraphQL interface.