### PR TITLE
Refactoring the wrapping of exceptions

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,6 +20,7 @@
     <rule ref="Doctrine">
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
         <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
         <exclude name="Generic.Formatting.MultipleStatementAlignment" />

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -288,7 +288,8 @@ class FieldsBuilder
                 try {
                     $type = $this->typeResolver->mapNameToOutputType($outputType);
                 } catch (CannotMapTypeExceptionInterface $e) {
-                    throw CannotMapTypeException::wrapWithReturnInfo($e, $refMethod);
+                    $e->addReturnInfo($refMethod);
+                    throw $e;
                 }
             } else {
                 $type = $this->typeMapper->mapReturnType($refMethod, $docBlockObj);
@@ -409,7 +410,8 @@ class FieldsBuilder
                 try {
                     $type = $this->typeResolver->mapNameToOutputType($outputType);
                 } catch (CannotMapTypeExceptionInterface $e) {
-                    throw CannotMapTypeException::wrapWithSourceField($e, $refClass, $sourceField);
+                    $e->addSourceFieldInfo($refClass, $sourceField);
+                    throw $e;
                 }
             } else {
                 $type = $this->typeMapper->mapReturnType($refMethod, $docBlockObj);

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -10,20 +10,14 @@ use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionParameter;
 use TheCodingMachine\GraphQLite\Annotations\ExtendType;
-use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
-use Webmozart\Assert\Assert;
 use function array_filter;
 use function array_map;
 use function implode;
-use function sprintf;
 
 class CannotMapTypeException extends Exception implements CannotMapTypeExceptionInterface
 {
-    private $locationInfoAdded = false;
+    use CannotMapTypeTrait;
 
     public static function createForType(string $className): self
     {
@@ -62,57 +56,6 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
         return new self('In GraphQL, you can only use union types between objects. These types cannot be used in union types: ' . implode(', ', $disallowedTypeNames));
     }
 
-    public function addParamInfo(ReflectionParameter $parameter): void
-    {
-        $declaringClass = $parameter->getDeclaringClass();
-        Assert::notNull($declaringClass, 'Parameter passed must be a parameter of a method, not a parameter of a function.');
-
-        if ($this->locationInfoAdded === false) {
-            $this->locationInfoAdded = true;
-            $this->message = sprintf(
-                'For parameter $%s, in %s::%s, %s',
-                $parameter->getName(),
-                $declaringClass->getName(),
-                $parameter->getDeclaringFunction()->getName(),
-                $this->message
-            );
-        }
-    }
-
-    public function addReturnInfo(ReflectionMethod $method): void
-    {
-        if ($this->locationInfoAdded === false) {
-            $this->locationInfoAdded = true;
-            $this->message = sprintf(
-                'For return type of %s::%s, %s',
-                $method->getDeclaringClass()->getName(),
-                $method->getName(),
-                $this->message
-            );
-        }
-    }
-
-    public function addSourceFieldInfo(ReflectionClass $class, SourceFieldInterface $sourceField): void
-    {
-        if ($this->locationInfoAdded === false) {
-            $this->locationInfoAdded = true;
-            $this->message = sprintf(
-                'For @SourceField "%s" declared in "%s", %s',
-                $sourceField->getName(),
-                $class->getName(),
-                $this->message
-            );
-        }
-    }
-
-    public function addExtendTypeInfo(ReflectionClass $class, ExtendType $extendType): void
-    {
-        if ($this->locationInfoAdded === false) {
-            $this->locationInfoAdded = true;
-            $this->message = 'For ' . self::extendTypeToString($extendType) . ' annotation declared in class "' . $class->getName() . '", '.$this->message;
-        }
-    }
-
     public static function mustBeOutputType(string $subTypeName): self
     {
         return new self('type "' . $subTypeName . '" must be an output type.');
@@ -141,15 +84,5 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
     public static function extendTypeWithBadTargetedClass(string $className, ExtendType $extendType): self
     {
         return new self('For ' . self::extendTypeToString($extendType) . ' annotation declared in class "' . $className . '", the pointed at GraphQL type cannot be extended. You can only target types extending the MutableObjectType (like types created with the @Type annotation).');
-    }
-
-    private static function extendTypeToString(ExtendType $extendType): string
-    {
-        $attribute = 'class="' . $extendType->getClass() . '"';
-        if ($extendType->getName() !== null) {
-            $attribute = 'name="' . $extendType->getName() . '"';
-        }
-
-        return '@ExtendType(' . $attribute . ')';
     }
 }

--- a/src/Mappers/CannotMapTypeExceptionInterface.php
+++ b/src/Mappers/CannotMapTypeExceptionInterface.php
@@ -4,8 +4,20 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
+use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
 use Throwable;
 
 interface CannotMapTypeExceptionInterface extends Throwable
 {
+    public function addParamInfo(ReflectionParameter $parameter): void;
+
+    public function addReturnInfo(ReflectionMethod $method): void;
+
+    public function addSourceFieldInfo(ReflectionClass $class, SourceFieldInterface $sourceField): void;
+
+    public function addExtendTypeInfo(ReflectionClass $class, ExtendType $extendType): void;
 }

--- a/src/Mappers/CannotMapTypeTrait.php
+++ b/src/Mappers/CannotMapTypeTrait.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
+use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
+use Webmozart\Assert\Assert;
+use function sprintf;
+
+trait CannotMapTypeTrait
+{
+    /** @var bool */
+    private $locationInfoAdded = false;
+
+    public function addParamInfo(ReflectionParameter $parameter): void
+    {
+        $declaringClass = $parameter->getDeclaringClass();
+        Assert::notNull($declaringClass, 'Parameter passed must be a parameter of a method, not a parameter of a function.');
+
+        if ($this->locationInfoAdded !== false) {
+            return;
+        }
+
+        $this->locationInfoAdded = true;
+        $this->message = sprintf(
+            'For parameter $%s, in %s::%s, %s',
+            $parameter->getName(),
+            $declaringClass->getName(),
+            $parameter->getDeclaringFunction()->getName(),
+            $this->message
+        );
+    }
+
+    public function addReturnInfo(ReflectionMethod $method): void
+    {
+        if ($this->locationInfoAdded !== false) {
+            return;
+        }
+
+        $this->locationInfoAdded = true;
+        $this->message = sprintf(
+            'For return type of %s::%s, %s',
+            $method->getDeclaringClass()->getName(),
+            $method->getName(),
+            $this->message
+        );
+    }
+
+    public function addSourceFieldInfo(ReflectionClass $class, SourceFieldInterface $sourceField): void
+    {
+        if ($this->locationInfoAdded !== false) {
+            return;
+        }
+
+        $this->locationInfoAdded = true;
+        $this->message = sprintf(
+            'For @SourceField "%s" declared in "%s", %s',
+            $sourceField->getName(),
+            $class->getName(),
+            $this->message
+        );
+    }
+
+    public function addExtendTypeInfo(ReflectionClass $class, ExtendType $extendType): void
+    {
+        if ($this->locationInfoAdded !== false) {
+            return;
+        }
+
+        $this->locationInfoAdded = true;
+        $this->message = 'For ' . self::extendTypeToString($extendType) . ' annotation declared in class "' . $class->getName() . '", ' . $this->message;
+    }
+
+    private static function extendTypeToString(ExtendType $extendType): string
+    {
+        $attribute = 'class="' . $extendType->getClass() . '"';
+        if ($extendType->getName() !== null) {
+            $attribute = 'name="' . $extendType->getName() . '"';
+        }
+
+        return '@ExtendType(' . $attribute . ')';
+    }
+}

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -243,7 +243,12 @@ final class GlobTypeMapper implements TypeMapperInterface
                 if ($extendType !== null) {
                     $extendClassName = $extendType->getClass();
                     if ($extendClassName !== null) {
-                        $targetType = $this->recursiveTypeMapper->mapClassToType($extendClassName, null);
+                        try {
+                            $targetType = $this->recursiveTypeMapper->mapClassToType($extendClassName, null);
+                        } catch (CannotMapTypeException $e) {
+                            $e->addExtendTypeInfo($refClass, $extendType);
+                            throw $e;
+                        }
                         $typeName   = $targetType->name;
                     } else {
                         $typeName = $extendType->getName();

--- a/src/Mappers/Parameters/TypeMapper.php
+++ b/src/Mappers/Parameters/TypeMapper.php
@@ -94,7 +94,8 @@ class TypeMapper implements ParameterMapperInterface
         } catch (TypeMappingException $e) {
             throw TypeMappingException::wrapWithReturnInfo($e, $refMethod);
         } catch (CannotMapTypeExceptionInterface $e) {
-            throw CannotMapTypeException::wrapWithReturnInfo($e, $refMethod);
+            $e->addReturnInfo($refMethod);
+            throw $e;
         }
 
         return $type;
@@ -132,7 +133,8 @@ class TypeMapper implements ParameterMapperInterface
             try {
                 $type = $this->typeResolver->mapNameToInputType($useInputType->getInputType());
             } catch (CannotMapTypeExceptionInterface $e) {
-                throw CannotMapTypeException::wrapWithParamInfo($e, $parameter);
+                $e->addParamInfo($parameter);
+                throw $e;
             }
         } else {
             $parameterType = $parameter->getType();
@@ -155,7 +157,8 @@ class TypeMapper implements ParameterMapperInterface
             } catch (TypeMappingException $e) {
                 throw TypeMappingException::wrapWithParamInfo($e, $parameter);
             } catch (CannotMapTypeExceptionInterface $e) {
-                throw CannotMapTypeException::wrapWithParamInfo($e, $parameter);
+                $e->addParamInfo($parameter);
+                throw $e;
             }
         }
 

--- a/src/Mappers/PorpaginasMissingParameterException.php
+++ b/src/Mappers/PorpaginasMissingParameterException.php
@@ -9,6 +9,8 @@ use GraphQL\Error\ClientAware;
 
 class PorpaginasMissingParameterException extends Exception implements ClientAware, CannotMapTypeExceptionInterface
 {
+    use CannotMapTypeTrait;
+
     public static function missingLimit(): self
     {
         return new self('In the items field of a result set, you cannot add a "offset" without also adding a "limit"');

--- a/src/Types/InvalidTypesInUnionException.php
+++ b/src/Types/InvalidTypesInUnionException.php
@@ -6,9 +6,12 @@ namespace TheCodingMachine\GraphQLite\Types;
 
 use InvalidArgumentException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeTrait;
 
 class InvalidTypesInUnionException extends InvalidArgumentException implements CannotMapTypeExceptionInterface
 {
+    use CannotMapTypeTrait;
+
     public static function notObjectType(): self
     {
         throw new self('A Union type can only contain objects. Scalars, lists, etc... are not allowed.');

--- a/tests/Fixtures/BadExtendType2/BadExtendType2.php
+++ b/tests/Fixtures/BadExtendType2/BadExtendType2.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\BadExtendType2;
+
+use TheCodingMachine\GraphQLite\Annotations\ExtendType;
+
+/**
+ * @ExtendType(class=\Exception::class)
+ */
+class BadExtendType2
+{
+}

--- a/tests/Mappers/CannotMapTypeTraitTest.php
+++ b/tests/Mappers/CannotMapTypeTraitTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use ReflectionClass;
+use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\Fixtures\TestTypeId;
+use TheCodingMachine\GraphQLite\Fixtures\Types\FooExtendType;
+
+class CannotMapTypeTraitTest extends AbstractQueryProviderTest
+{
+
+    public function testAddParamInfo()
+    {
+        $e = CannotMapTypeException::createForType('Foo');
+        $e->addParamInfo((new ReflectionClass('DateTime'))->getMethod('__construct')->getParameters()[0]);
+        $e->addParamInfo((new ReflectionClass('DateTime'))->getMethod('__construct')->getParameters()[0]);
+
+        $this->assertSame('For parameter $time, in DateTime::__construct, cannot map class "Foo" to a known GraphQL type. Check your TypeMapper configuration.', $e->getMessage());
+    }
+
+    public function testAddSourceFieldInfo()
+    {
+        $class = new ReflectionClass(TestTypeId::class);
+        $sourceFields = $this->getAnnotationReader()->getSourceFields($class);
+
+        $e = CannotMapTypeException::createForType('Foo');
+        $e->addSourceFieldInfo($class, $sourceFields[0]);
+        $e->addSourceFieldInfo($class, $sourceFields[0]);
+
+        $this->assertSame('For @SourceField "test" declared in "TheCodingMachine\GraphQLite\Fixtures\TestTypeId", cannot map class "Foo" to a known GraphQL type. Check your TypeMapper configuration.', $e->getMessage());
+    }
+
+    public function testAddExtendTypeInfo()
+    {
+        $class = new ReflectionClass(FooExtendType::class);
+        $extendType = $this->getAnnotationReader()->getExtendTypeAnnotation($class);
+
+        $e = CannotMapTypeException::createForType('Foo');
+        $e->addExtendTypeInfo($class, $extendType);
+        $e->addExtendTypeInfo($class, $extendType);
+
+        $this->assertSame('For @ExtendType(class="TheCodingMachine\GraphQLite\Fixtures\TestObject") annotation declared in class "TheCodingMachine\GraphQLite\Fixtures\Types\FooExtendType", cannot map class "Foo" to a known GraphQL type. Check your TypeMapper configuration.', $e->getMessage());
+    }
+
+    public function testAddReturnInfo()
+    {
+        $refMethod = (new ReflectionClass(__CLASS__))->getMethod('testAddReturnInfo');
+
+        $e = CannotMapTypeException::createForType('Foo');
+        $e->addReturnInfo($refMethod);
+        $e->addReturnInfo($refMethod);
+
+        $this->assertSame('For return type of TheCodingMachine\GraphQLite\Mappers\CannotMapTypeTraitTest::testAddReturnInfo, cannot map class "Foo" to a known GraphQL type. Check your TypeMapper configuration.', $e->getMessage());
+    }
+}


### PR DESCRIPTION
Instead of wrapping exceptions to add location data, they are now modified in place.
In particular, once modified to add location data, they cannot be modified again.
This way, we don't end up with a chain of exceptions where useless location data is added.

Also, this adds a location data for @ExtendType.