### PR TITLE
Adding a StaticClassListTypeMapper

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,5 +10,6 @@ parameters:
         - "#Method TheCodingMachine\\\\GraphQLite\\\\Types\\\\MutableObjectType::getFields() should return array<GraphQL\\\\Type\\\\Definition\\\\FieldDefinition> but returns array|float|int.#"
         - "#Parameter \\#2 \\$inputTypeNode of static method GraphQL\\\\Utils\\\\AST::typeFromAST() expects GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode, GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NameNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode given.#"
         - "#PHPDoc tag @throws with type Psr\\\\SimpleCache\\\\InvalidArgumentException is not subtype of Throwable#"
+        - '#Variable \$context might not be defined.#'
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/AggregateControllerQueryProviderFactory.php
+++ b/src/AggregateControllerQueryProviderFactory.php
@@ -26,8 +26,8 @@ class AggregateControllerQueryProviderFactory implements QueryProviderFactoryInt
         $this->controllersContainer = $controllersContainer;
     }
 
-    public function create(FieldsBuilder $fieldsBuilder): QueryProviderInterface
+    public function create(FactoryContext $context): QueryProviderInterface
     {
-        return new AggregateControllerQueryProvider($this->controllers, $fieldsBuilder, $this->controllersContainer);
+        return new AggregateControllerQueryProvider($this->controllers, $context->getFieldsBuilder(), $this->controllersContainer);
     }
 }

--- a/src/FactoryContext.php
+++ b/src/FactoryContext.php
@@ -36,6 +36,10 @@ class FactoryContext
     private $container;
     /** @var CacheInterface */
     private $cache;
+    /** @var int|null */
+    private $globTtl;
+    /** @var int|null */
+    private $mapTtl;
 
     public function __construct(
         AnnotationReader $annotationReader,
@@ -47,7 +51,9 @@ class FactoryContext
         InputTypeGenerator $inputTypeGenerator,
         RecursiveTypeMapperInterface $recursiveTypeMapper,
         ContainerInterface $container,
-        CacheInterface $cache
+        CacheInterface $cache,
+        ?int $globTtl = 2,
+        ?int $mapTtl = null
     ) {
         $this->annotationReader = $annotationReader;
         $this->typeResolver = $typeResolver;
@@ -59,6 +65,8 @@ class FactoryContext
         $this->recursiveTypeMapper = $recursiveTypeMapper;
         $this->container = $container;
         $this->cache = $cache;
+        $this->globTtl = $globTtl;
+        $this->mapTtl = $mapTtl;
     }
 
     public function getAnnotationReader(): AnnotationReader
@@ -109,5 +117,15 @@ class FactoryContext
     public function getCache(): CacheInterface
     {
         return $this->cache;
+    }
+
+    public function getGlobTtl(): ?int
+    {
+        return $this->globTtl;
+    }
+
+    public function getMapTtl(): ?int
+    {
+        return $this->mapTtl;
     }
 }

--- a/src/FactoryContext.php
+++ b/src/FactoryContext.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite;
+
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\Types\TypeResolver;
+
+/**
+ * A context class containing a number of classes created on the fly by SchemaFactory.
+ * Those classes are made available to factories implementing QueryProviderFactoryInterface
+ * or TypeMapperFactoryInterface
+ */
+class FactoryContext
+{
+    /** @var AnnotationReader */
+    private $annotationReader;
+    /** @var TypeResolver */
+    private $typeResolver;
+    /** @var NamingStrategyInterface */
+    private $namingStrategy;
+    /** @var TypeRegistry */
+    private $typeRegistry;
+    /** @var FieldsBuilder */
+    private $fieldsBuilder;
+    /** @var TypeGenerator */
+    private $typeGenerator;
+    /** @var InputTypeGenerator */
+    private $inputTypeGenerator;
+    /** @var RecursiveTypeMapperInterface */
+    private $recursiveTypeMapper;
+    /** @var ContainerInterface */
+    private $container;
+    /** @var CacheInterface */
+    private $cache;
+
+    public function __construct(
+        AnnotationReader $annotationReader,
+        TypeResolver $typeResolver,
+        NamingStrategyInterface $namingStrategy,
+        TypeRegistry $typeRegistry,
+        FieldsBuilder $fieldsBuilder,
+        TypeGenerator $typeGenerator,
+        InputTypeGenerator $inputTypeGenerator,
+        RecursiveTypeMapperInterface $recursiveTypeMapper,
+        ContainerInterface $container,
+        CacheInterface $cache
+    ) {
+        $this->annotationReader = $annotationReader;
+        $this->typeResolver = $typeResolver;
+        $this->namingStrategy = $namingStrategy;
+        $this->typeRegistry = $typeRegistry;
+        $this->fieldsBuilder = $fieldsBuilder;
+        $this->typeGenerator = $typeGenerator;
+        $this->inputTypeGenerator = $inputTypeGenerator;
+        $this->recursiveTypeMapper = $recursiveTypeMapper;
+        $this->container = $container;
+        $this->cache = $cache;
+    }
+
+    public function getAnnotationReader(): AnnotationReader
+    {
+        return $this->annotationReader;
+    }
+
+    public function getTypeResolver(): TypeResolver
+    {
+        return $this->typeResolver;
+    }
+
+    public function getNamingStrategy(): NamingStrategyInterface
+    {
+        return $this->namingStrategy;
+    }
+
+    public function getTypeRegistry(): TypeRegistry
+    {
+        return $this->typeRegistry;
+    }
+
+    public function getFieldsBuilder(): FieldsBuilder
+    {
+        return $this->fieldsBuilder;
+    }
+
+    public function getTypeGenerator(): TypeGenerator
+    {
+        return $this->typeGenerator;
+    }
+
+    public function getInputTypeGenerator(): InputTypeGenerator
+    {
+        return $this->inputTypeGenerator;
+    }
+
+    public function getRecursiveTypeMapper(): RecursiveTypeMapperInterface
+    {
+        return $this->recursiveTypeMapper;
+    }
+
+    public function getContainer(): ContainerInterface
+    {
+        return $this->container;
+    }
+
+    public function getCache(): CacheInterface
+    {
+        return $this->cache;
+    }
+}

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -1,0 +1,445 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type;
+use Mouf\Composer\ClassNameMapper;
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+use ReflectionClass;
+use ReflectionException;
+use Symfony\Component\Cache\Adapter\Psr16Adapter;
+use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
+use TheCodingMachine\CacheUtils\ClassBoundCache;
+use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
+use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
+use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
+use TheCodingMachine\CacheUtils\FileBoundCache;
+use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
+use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\InputTypeGenerator;
+use TheCodingMachine\GraphQLite\InputTypeUtils;
+use TheCodingMachine\GraphQLite\NamingStrategyInterface;
+use TheCodingMachine\GraphQLite\TypeGenerator;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
+use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use Webmozart\Assert\Assert;
+use function class_exists;
+use function interface_exists;
+use function str_replace;
+
+/**
+ * Analyzes classes and uses the @Type annotation to find the types automatically.
+ *
+ * Assumes that the container contains a class whose identifier is the same as the class name.
+ */
+abstract class AbstractTypeMapper implements TypeMapperInterface
+{
+    /** @var AnnotationReader */
+    private $annotationReader;
+    /** @var CacheInterface */
+    protected $cache;
+    /** @var int|null */
+    protected $globTtl;
+
+    /**
+     * Cache storing the GlobAnnotationsCache objects linked to a given ReflectionClass.
+     *
+     * @var ClassBoundCacheContractInterface
+     */
+    private $mapClassToAnnotationsCache;
+    /**
+     * Cache storing the GlobAnnotationsCache objects linked to a given ReflectionClass.
+     *
+     * @var ClassBoundCacheContractInterface
+     */
+    private $mapClassToExtendAnnotationsCache;
+
+    /** @var ContainerInterface */
+    private $container;
+    /** @var TypeGenerator */
+    private $typeGenerator;
+    /** @var int|null */
+    private $mapTtl;
+    /** @var NamingStrategyInterface */
+    private $namingStrategy;
+    /** @var InputTypeGenerator */
+    private $inputTypeGenerator;
+    /** @var InputTypeUtils */
+    private $inputTypeUtils;
+    /** @var RecursiveTypeMapperInterface */
+    private $recursiveTypeMapper;
+    /** @var CacheContractInterface */
+    private $cacheContract;
+    /** @var GlobTypeMapperCache */
+    private $globTypeMapperCache;
+    /** @var GlobExtendTypeMapperCache */
+    private $globExtendTypeMapperCache;
+
+    /**
+     * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
+     */
+    public function __construct(string $cachePrefix, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null)
+    {
+        $this->typeGenerator       = $typeGenerator;
+        $this->container           = $container;
+        $this->annotationReader    = $annotationReader;
+        $this->namingStrategy      = $namingStrategy;
+        $this->cache               = $cache;
+        $this->globTtl             = $globTtl;
+        $this->cacheContract       = new Psr16Adapter($this->cache, $cachePrefix, $this->globTtl ?? 0);
+        $this->mapTtl              = $mapTtl;
+        $this->inputTypeGenerator  = $inputTypeGenerator;
+        $this->inputTypeUtils      = $inputTypeUtils;
+        $this->recursiveTypeMapper = $recursiveTypeMapper;
+        $this->mapClassToAnnotationsCache = new ClassBoundCacheContract(new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'classToAnnotations_' . $cachePrefix))));
+        $this->mapClassToExtendAnnotationsCache = new ClassBoundCacheContract(new ClassBoundMemoryAdapter(new ClassBoundCache(new FileBoundCache($this->cache, 'classToExtendAnnotations_' . $cachePrefix))));
+    }
+
+    /**
+     * Returns an object mapping all types.
+     */
+    private function getMaps(): GlobTypeMapperCache
+    {
+        if ($this->globTypeMapperCache === null) {
+            $this->globTypeMapperCache = $this->cacheContract->get('fullMapComputed', function () {
+                return $this->buildMap();
+            });
+        }
+
+        return $this->globTypeMapperCache;
+    }
+
+    private function getMapClassToExtendTypeArray(): GlobExtendTypeMapperCache
+    {
+        if ($this->globExtendTypeMapperCache === null) {
+            $this->globExtendTypeMapperCache = $this->cacheContract->get('fullExtendMapComputed', function () {
+                return $this->buildMapClassToExtendTypeArray();
+            });
+        }
+
+        return $this->globExtendTypeMapperCache;
+    }
+
+    /**
+     * Returns the array of globbed classes.
+     * Only instantiable classes are returned.
+     *
+     * @return array<string,ReflectionClass> Key: fully qualified class name
+     */
+    abstract protected function getClassList(): array;
+
+    private function buildMap(): GlobTypeMapperCache
+    {
+        $globTypeMapperCache = new GlobTypeMapperCache();
+
+        /** @var ReflectionClass[] $classes */
+        $classes = $this->getClassList();
+        foreach ($classes as $className => $refClass) {
+            $annotationsCache = $this->mapClassToAnnotationsCache->get($refClass, function () use ($refClass, $className) {
+                $annotationsCache = new GlobAnnotationsCache();
+
+                $containsAnnotations = false;
+
+                $type = $this->annotationReader->getTypeAnnotation($refClass);
+                if ($type !== null) {
+                    $typeName = $this->namingStrategy->getOutputTypeName($className, $type);
+                    $annotationsCache->setType($type->getClass(), $typeName, $type->isDefault());
+                    $containsAnnotations = true;
+                }
+
+                $isAbstract = $refClass->isAbstract();
+
+                foreach ($refClass->getMethods() as $method) {
+                    if (! $method->isPublic() || ($isAbstract && ! $method->isStatic())) {
+                        continue;
+                    }
+                    $factory = $this->annotationReader->getFactoryAnnotation($method);
+
+                    if ($factory !== null) {
+                        [$inputName, $className] = $this->inputTypeUtils->getInputTypeNameAndClassName($method);
+
+                        $annotationsCache->registerFactory($method->getName(), $inputName, $className, $factory->isDefault(), $refClass->getName());
+                        $containsAnnotations = true;
+                    }
+
+                    $decorator = $this->annotationReader->getDecorateAnnotation($method);
+
+                    if ($decorator === null) {
+                        continue;
+                    }
+
+                    $annotationsCache->registerDecorator($method->getName(), $decorator->getInputTypeName(), $refClass->getName());
+                    $containsAnnotations = true;
+                }
+
+                if (! $containsAnnotations) {
+                    return 'nothing';
+                }
+
+                return $annotationsCache;
+            }, '', $this->mapTtl);
+
+            if ($annotationsCache === 'nothing') {
+                continue;
+            }
+
+            $globTypeMapperCache->registerAnnotations($refClass, $annotationsCache);
+        }
+
+        return $globTypeMapperCache;
+    }
+
+    private function buildMapClassToExtendTypeArray(): GlobExtendTypeMapperCache
+    {
+        $globExtendTypeMapperCache = new GlobExtendTypeMapperCache();
+
+        /** @var ReflectionClass[] $classes */
+        $classes = $this->getClassList();
+        foreach ($classes as $className => $refClass) {
+            $annotationsCache = $this->mapClassToExtendAnnotationsCache->get($refClass, function () use ($refClass) {
+                $extendAnnotationsCache = new GlobExtendAnnotationsCache();
+
+                $extendType = $this->annotationReader->getExtendTypeAnnotation($refClass);
+
+                if ($extendType !== null) {
+                    $extendClassName = $extendType->getClass();
+                    if ($extendClassName !== null) {
+                        try {
+                            $targetType = $this->recursiveTypeMapper->mapClassToType($extendClassName, null);
+                        } catch (CannotMapTypeException $e) {
+                            $e->addExtendTypeInfo($refClass, $extendType);
+                            throw $e;
+                        }
+                        $typeName   = $targetType->name;
+                    } else {
+                        $typeName = $extendType->getName();
+                        Assert::notNull($typeName);
+                        $targetType = $this->recursiveTypeMapper->mapNameToType($typeName);
+                        if (! $targetType instanceof MutableObjectType) {
+                            throw CannotMapTypeException::extendTypeWithBadTargetedClass($refClass->getName(), $extendType);
+                        }
+                        $extendClassName = $targetType->getMappedClassName();
+                    }
+
+                    // FIXME: $extendClassName === NULL!!!!!!
+                    $extendAnnotationsCache->setExtendType($extendClassName, $typeName);
+
+                    return $extendAnnotationsCache;
+                }
+
+                return 'nothing';
+            }, '', $this->mapTtl);
+
+            if ($annotationsCache === 'nothing') {
+                continue;
+            }
+
+            $globExtendTypeMapperCache->registerAnnotations($refClass, $annotationsCache);
+        }
+
+        return $globExtendTypeMapperCache;
+    }
+
+    /**
+     * Returns true if this type mapper can map the $className FQCN to a GraphQL type.
+     */
+    public function canMapClassToType(string $className): bool
+    {
+        return $this->getMaps()->getTypeByObjectClass($className) !== null;
+    }
+
+    /**
+     * Maps a PHP fully qualified class name to a GraphQL type.
+     *
+     * @param string $className The exact class name to look for (this function does not look into parent classes).
+     * @param OutputType|null $subType An optional sub-type if the main class is an iterator that needs to be typed.
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
+    {
+        $typeClassName = $this->getMaps()->getTypeByObjectClass($className);
+
+        if ($typeClassName === null) {
+            throw CannotMapTypeException::createForType($className);
+        }
+
+        return $this->typeGenerator->mapAnnotatedObject($typeClassName);
+    }
+
+    /**
+     * Returns the list of classes that have matching input GraphQL types.
+     *
+     * @return string[]
+     */
+    public function getSupportedClasses(): array
+    {
+        return $this->getMaps()->getSupportedClasses();
+    }
+
+    /**
+     * Returns true if this type mapper can map the $className FQCN to a GraphQL input type.
+     */
+    public function canMapClassToInputType(string $className): bool
+    {
+        return $this->getMaps()->getFactoryByObjectClass($className) !== null;
+    }
+
+    /**
+     * Maps a PHP fully qualified class name to a GraphQL input type.
+     *
+     * @return ResolvableMutableInputInterface&InputObjectType
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function mapClassToInputType(string $className): ResolvableMutableInputInterface
+    {
+        $factory = $this->getMaps()->getFactoryByObjectClass($className);
+
+        if ($factory === null) {
+            throw CannotMapTypeException::createForInputType($className);
+        }
+
+        return $this->inputTypeGenerator->mapFactoryMethod($factory[0], $factory[1], $this->container);
+    }
+
+    /**
+     * Returns a GraphQL type by name (can be either an input or output type)
+     *
+     * @param string $typeName The name of the GraphQL type
+     *
+     * @return Type&((ResolvableMutableInputInterface&InputObjectType)|MutableObjectType|MutableInterfaceType)
+     *
+     * @throws CannotMapTypeExceptionInterface
+     * @throws ReflectionException
+     */
+    public function mapNameToType(string $typeName): Type
+    {
+        $typeClassName = $this->getMaps()->getTypeByGraphQLTypeName($typeName);
+
+        if ($typeClassName !== null) {
+            return $this->typeGenerator->mapAnnotatedObject($typeClassName);
+        }
+
+        $factory = $this->getMaps()->getFactoryByGraphQLInputTypeName($typeName);
+        if ($factory !== null) {
+            return $this->inputTypeGenerator->mapFactoryMethod($factory[0], $factory[1], $this->container);
+        }
+
+        throw CannotMapTypeException::createForName($typeName);
+    }
+
+    /**
+     * Returns true if this type mapper can map the $typeName GraphQL name to a GraphQL type.
+     *
+     * @param string $typeName The name of the GraphQL type
+     */
+    public function canMapNameToType(string $typeName): bool
+    {
+        $typeClassName = $this->getMaps()->getTypeByGraphQLTypeName($typeName);
+
+        if ($typeClassName !== null) {
+            return true;
+        }
+
+        $factory = $this->getMaps()->getFactoryByGraphQLInputTypeName($typeName);
+
+        return $factory !== null;
+    }
+
+    /**
+     * Returns true if this type mapper can extend an existing type for the $className FQCN
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     */
+    public function canExtendTypeForClass(string $className, MutableInterface $type): bool
+    {
+        return $this->getMapClassToExtendTypeArray()->getExtendTypesByObjectClass($className) !== null;
+    }
+
+    /**
+     * Extends the existing GraphQL type that is mapped to $className.
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function extendTypeForClass(string $className, MutableInterface $type): void
+    {
+        $extendTypeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByObjectClass($className);
+
+        if ($extendTypeClassNames === null) {
+            throw CannotMapTypeException::createForExtendType($className, $type);
+        }
+
+        foreach ($extendTypeClassNames as $extendedTypeClass) {
+            $this->typeGenerator->extendAnnotatedObject($this->container->get($extendedTypeClass), $type);
+        }
+    }
+
+    /**
+     * Returns true if this type mapper can extend an existing type for the $typeName GraphQL type
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     */
+    public function canExtendTypeForName(string $typeName, MutableInterface $type): bool
+    {
+        $typeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByGraphQLTypeName($typeName);
+
+        return $typeClassNames !== null;
+    }
+
+    /**
+     * Extends the existing GraphQL type that is mapped to the $typeName GraphQL type.
+     *
+     * @param MutableInterface&(MutableObjectType|MutableInterfaceType) $type
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function extendTypeForName(string $typeName, MutableInterface $type): void
+    {
+        $extendTypeClassNames = $this->getMapClassToExtendTypeArray()->getExtendTypesByGraphQLTypeName($typeName);
+        if ($extendTypeClassNames === null) {
+            throw CannotMapTypeException::createForExtendName($typeName, $type);
+        }
+
+        foreach ($extendTypeClassNames as $extendedTypeClass) {
+            $this->typeGenerator->extendAnnotatedObject($this->container->get($extendedTypeClass), $type);
+        }
+    }
+
+    /**
+     * Returns true if this type mapper can decorate an existing input type for the $typeName GraphQL input type
+     */
+    public function canDecorateInputTypeForName(string $typeName, ResolvableMutableInputInterface $type): bool
+    {
+        return ! empty($this->getMaps()->getDecorateByGraphQLInputTypeName($typeName));
+    }
+
+    /**
+     * Decorates the existing GraphQL input type that is mapped to the $typeName GraphQL input type.
+     *
+     * @param ResolvableMutableInputInterface &InputObjectType $type
+     *
+     * @throws CannotMapTypeExceptionInterface
+     */
+    public function decorateInputTypeForName(string $typeName, ResolvableMutableInputInterface $type): void
+    {
+        $decorators = $this->getMaps()->getDecorateByGraphQLInputTypeName($typeName);
+
+        if (empty($decorators)) {
+            throw CannotMapTypeException::createForDecorateName($typeName, $type);
+        }
+
+        foreach ($decorators as $decorator) {
+            $this->inputTypeGenerator->decorateInputType($decorator[0], $decorator[1], $type, $this->container);
+        }
+    }
+}

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -7,7 +7,6 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
-use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
@@ -19,7 +18,6 @@ use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
 use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
 use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
 use TheCodingMachine\CacheUtils\FileBoundCache;
-use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
 use TheCodingMachine\GraphQLite\AnnotationReader;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
@@ -30,9 +28,6 @@ use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use Webmozart\Assert\Assert;
-use function class_exists;
-use function interface_exists;
-use function str_replace;
 
 /**
  * Analyzes classes and uses the @Type annotation to find the types automatically.
@@ -82,9 +77,6 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
     /** @var GlobExtendTypeMapperCache */
     private $globExtendTypeMapperCache;
 
-    /**
-     * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
-     */
     public function __construct(string $cachePrefix, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null)
     {
         $this->typeGenerator       = $typeGenerator;

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -4,32 +4,16 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\OutputType;
-use GraphQL\Type\Definition\Type;
 use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
-use ReflectionException;
-use Symfony\Component\Cache\Adapter\Psr16Adapter;
-use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundCache;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
-use TheCodingMachine\CacheUtils\FileBoundCache;
 use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
 use TheCodingMachine\GraphQLite\AnnotationReader;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeGenerator;
-use TheCodingMachine\GraphQLite\Types\MutableInterface;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
-use TheCodingMachine\GraphQLite\Types\MutableObjectType;
-use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use Webmozart\Assert\Assert;
 use function class_exists;
 use function interface_exists;
 use function str_replace;
@@ -65,7 +49,7 @@ final class GlobTypeMapper extends AbstractTypeMapper
         $cachePrefix = str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $namespace);
         parent::__construct($cachePrefix, $typeGenerator, $inputTypeGenerator, $inputTypeUtils, $container, $annotationReader, $namingStrategy, $recursiveTypeMapper, $cache, $globTtl, $mapTtl);
     }
-    
+
     /**
      * Returns the array of globbed classes.
      * Only instantiable classes are returned.
@@ -92,5 +76,4 @@ final class GlobTypeMapper extends AbstractTypeMapper
 
         return $this->classes;
     }
-
 }

--- a/src/Mappers/StaticClassListTypeMapper.php
+++ b/src/Mappers/StaticClassListTypeMapper.php
@@ -57,11 +57,7 @@ final class StaticClassListTypeMapper extends AbstractTypeMapper
                 if (! class_exists($className) && ! interface_exists($className)) {
                     throw new GraphQLException('Could not find class "' . $className . '"');
                 }
-                $refClass = new ReflectionClass($className);
-                if (! $refClass->isInstantiable() && ! $refClass->isInterface()) {
-                    throw new GraphQLException('Class "' . $className . '" must be instantiable or be an interface.');
-                }
-                $this->classes[$className] = $refClass;
+                $this->classes[$className] = new ReflectionClass($className);
             }
         }
 

--- a/src/Mappers/StaticClassListTypeMapper.php
+++ b/src/Mappers/StaticClassListTypeMapper.php
@@ -4,35 +4,17 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\OutputType;
-use GraphQL\Type\Definition\Type;
-use function implode;
-use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
-use ReflectionException;
-use Symfony\Component\Cache\Adapter\Psr16Adapter;
-use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundCache;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
-use TheCodingMachine\CacheUtils\FileBoundCache;
-use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
 use TheCodingMachine\GraphQLite\AnnotationReader;
 use TheCodingMachine\GraphQLite\GraphQLException;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeGenerator;
-use TheCodingMachine\GraphQLite\Types\MutableInterface;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
-use TheCodingMachine\GraphQLite\Types\MutableObjectType;
-use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use Webmozart\Assert\Assert;
 use function class_exists;
+use function implode;
 use function interface_exists;
 use function str_replace;
 
@@ -41,9 +23,7 @@ use function str_replace;
  */
 final class StaticClassListTypeMapper extends AbstractTypeMapper
 {
-    /**
-     * @var array<int, string> The list of classes to be scanned.
-     */
+    /** @var array<int, string> The list of classes to be scanned. */
     private $classList;
     /**
      * The array of classes.
@@ -54,7 +34,7 @@ final class StaticClassListTypeMapper extends AbstractTypeMapper
     private $classes;
 
     /**
-     * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
+     * @param array<int, string> $classList The list of classes to analyze.
      */
     public function __construct(array $classList, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null)
     {
@@ -75,11 +55,11 @@ final class StaticClassListTypeMapper extends AbstractTypeMapper
             $this->classes = [];
             foreach ($this->classList as $className) {
                 if (! class_exists($className) && ! interface_exists($className)) {
-                    throw new GraphQLException('Could not find class "'.$className.'"');
+                    throw new GraphQLException('Could not find class "' . $className . '"');
                 }
                 $refClass = new ReflectionClass($className);
                 if (! $refClass->isInstantiable() && ! $refClass->isInterface()) {
-                    throw new GraphQLException('Class "'.$className.'" must be instantiable or be an interface.');
+                    throw new GraphQLException('Class "' . $className . '" must be instantiable or be an interface.');
                 }
                 $this->classes[$className] = $refClass;
             }

--- a/src/Mappers/StaticClassListTypeMapperFactory.php
+++ b/src/Mappers/StaticClassListTypeMapperFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use Psr\SimpleCache\CacheInterface;
 use TheCodingMachine\GraphQLite\FactoryContext;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 
@@ -15,8 +14,6 @@ final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterfa
 {
     /** @var array<int, string> The list of classes to be scanned. */
     private $classList;
-    /** @var CacheInterface */
-    private $cache;
     /** @var int|null */
     private $globTtl;
     /** @var int|null */

--- a/src/Mappers/StaticClassListTypeMapperFactory.php
+++ b/src/Mappers/StaticClassListTypeMapperFactory.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type;
+use function implode;
+use Mouf\Composer\ClassNameMapper;
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+use ReflectionClass;
+use ReflectionException;
+use Symfony\Component\Cache\Adapter\Psr16Adapter;
+use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
+use TheCodingMachine\CacheUtils\ClassBoundCache;
+use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
+use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
+use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
+use TheCodingMachine\CacheUtils\FileBoundCache;
+use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
+use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\InputTypeGenerator;
+use TheCodingMachine\GraphQLite\InputTypeUtils;
+use TheCodingMachine\GraphQLite\NamingStrategyInterface;
+use TheCodingMachine\GraphQLite\TypeGenerator;
+use TheCodingMachine\GraphQLite\TypeRegistry;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
+use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use Webmozart\Assert\Assert;
+use function class_exists;
+use function interface_exists;
+use function str_replace;
+
+/**
+ * A type mapper that is passed the list of classes that it must scan (unlike the GlobTypeMapper that find those automatically).
+ */
+final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterface
+{
+    /**
+     * @var array<int, string> The list of classes to be scanned.
+     */
+    private $classList;
+    /** @var AnnotationReader */
+    private $annotationReader;
+    /** @var CacheInterface */
+    protected $cache;
+    /** @var int|null */
+    protected $globTtl;
+
+    /** @var ContainerInterface */
+    private $container;
+    /** @var TypeGenerator */
+    private $typeGenerator;
+    /** @var int|null */
+    private $mapTtl;
+    /** @var NamingStrategyInterface */
+    private $namingStrategy;
+    /** @var InputTypeGenerator */
+    private $inputTypeGenerator;
+    /** @var InputTypeUtils */
+    private $inputTypeUtils;
+    /** @var RecursiveTypeMapperInterface */
+    private $recursiveTypeMapper;
+    /** @var GlobTypeMapperCache */
+    private $globTypeMapperCache;
+    /** @var GlobExtendTypeMapperCache */
+    private $globExtendTypeMapperCache;
+
+    /**
+     * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
+     */
+    public function __construct(array $classList,
+                                TypeGenerator $typeGenerator,
+                                InputTypeGenerator $inputTypeGenerator,
+                                InputTypeUtils $inputTypeUtils,
+                                ContainerInterface $container,
+                                AnnotationReader $annotationReader,
+                                NamingStrategyInterface $namingStrategy,
+                                CacheInterface $cache,
+                                ?int $globTtl = 2,
+                                ?int $mapTtl = null)
+    {
+        $this->classList           = $classList;
+        $this->typeGenerator       = $typeGenerator;
+        $this->container           = $container;
+        $this->annotationReader    = $annotationReader;
+        $this->namingStrategy      = $namingStrategy;
+        $this->cache               = $cache;
+        $this->globTtl             = $globTtl;
+        $this->mapTtl              = $mapTtl;
+        $this->inputTypeGenerator  = $inputTypeGenerator;
+        $this->inputTypeUtils      = $inputTypeUtils;
+        $this->recursiveTypeMapper = $recursiveTypeMapper;
+    }
+
+    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper, TypeRegistry $typeRegistry): TypeMapperInterface
+    {
+        $typeGenerator      = new TypeGenerator($this->annotationReader, $this->namingStrategy, $typeRegistry, $this->container, $recursiveTypeMapper, $this->fieldsBuilder);
+
+        return new StaticClassListTypeMapper(
+            $this->classList,
+            $this->typeGenerator,
+            $this->inputTypeGenerator,
+            $this->inputTypeUtils,
+            $this->container,
+            $this->annotationReader,
+            $this->namingStrategy,
+            $recursiveTypeMapper,
+            $this->cache,
+            $this->globTtl,
+            $this->mapTtl
+        );
+    }
+}

--- a/src/Mappers/StaticClassListTypeMapperFactory.php
+++ b/src/Mappers/StaticClassListTypeMapperFactory.php
@@ -4,115 +4,53 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\OutputType;
-use GraphQL\Type\Definition\Type;
-use function implode;
-use Mouf\Composer\ClassNameMapper;
-use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
-use ReflectionClass;
-use ReflectionException;
-use Symfony\Component\Cache\Adapter\Psr16Adapter;
-use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundCache;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
-use TheCodingMachine\CacheUtils\FileBoundCache;
-use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
-use TheCodingMachine\GraphQLite\AnnotationReader;
-use TheCodingMachine\GraphQLite\GraphQLException;
-use TheCodingMachine\GraphQLite\InputTypeGenerator;
+use TheCodingMachine\GraphQLite\FactoryContext;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
-use TheCodingMachine\GraphQLite\NamingStrategyInterface;
-use TheCodingMachine\GraphQLite\TypeGenerator;
-use TheCodingMachine\GraphQLite\TypeRegistry;
-use TheCodingMachine\GraphQLite\Types\MutableInterface;
-use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
-use TheCodingMachine\GraphQLite\Types\MutableObjectType;
-use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
-use Webmozart\Assert\Assert;
-use function class_exists;
-use function interface_exists;
-use function str_replace;
 
 /**
  * A type mapper that is passed the list of classes that it must scan (unlike the GlobTypeMapper that find those automatically).
  */
 final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterface
 {
-    /**
-     * @var array<int, string> The list of classes to be scanned.
-     */
+    /** @var array<int, string> The list of classes to be scanned. */
     private $classList;
-    /** @var AnnotationReader */
-    private $annotationReader;
     /** @var CacheInterface */
-    protected $cache;
+    private $cache;
     /** @var int|null */
-    protected $globTtl;
-
-    /** @var ContainerInterface */
-    private $container;
-    /** @var TypeGenerator */
-    private $typeGenerator;
+    private $globTtl;
     /** @var int|null */
     private $mapTtl;
-    /** @var NamingStrategyInterface */
-    private $namingStrategy;
-    /** @var InputTypeGenerator */
-    private $inputTypeGenerator;
-    /** @var InputTypeUtils */
-    private $inputTypeUtils;
-    /** @var RecursiveTypeMapperInterface */
-    private $recursiveTypeMapper;
-    /** @var GlobTypeMapperCache */
-    private $globTypeMapperCache;
-    /** @var GlobExtendTypeMapperCache */
-    private $globExtendTypeMapperCache;
 
     /**
-     * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
+     * StaticClassListTypeMapperFactory constructor.
+     *
+     * @param array<int, string> $classList
      */
-    public function __construct(array $classList,
-                                TypeGenerator $typeGenerator,
-                                InputTypeGenerator $inputTypeGenerator,
-                                InputTypeUtils $inputTypeUtils,
-                                ContainerInterface $container,
-                                AnnotationReader $annotationReader,
-                                NamingStrategyInterface $namingStrategy,
-                                CacheInterface $cache,
-                                ?int $globTtl = 2,
-                                ?int $mapTtl = null)
-    {
+    public function __construct(
+        array $classList,
+        ?int $globTtl = 2,
+        ?int $mapTtl = null
+    ) {
         $this->classList           = $classList;
-        $this->typeGenerator       = $typeGenerator;
-        $this->container           = $container;
-        $this->annotationReader    = $annotationReader;
-        $this->namingStrategy      = $namingStrategy;
-        $this->cache               = $cache;
         $this->globTtl             = $globTtl;
         $this->mapTtl              = $mapTtl;
-        $this->inputTypeGenerator  = $inputTypeGenerator;
-        $this->inputTypeUtils      = $inputTypeUtils;
-        $this->recursiveTypeMapper = $recursiveTypeMapper;
     }
 
-    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper, TypeRegistry $typeRegistry): TypeMapperInterface
+    public function create(FactoryContext $context): TypeMapperInterface
     {
-        $typeGenerator      = new TypeGenerator($this->annotationReader, $this->namingStrategy, $typeRegistry, $this->container, $recursiveTypeMapper, $this->fieldsBuilder);
+        $inputTypeUtils = new InputTypeUtils($context->getAnnotationReader(), $context->getNamingStrategy());
 
         return new StaticClassListTypeMapper(
             $this->classList,
-            $this->typeGenerator,
-            $this->inputTypeGenerator,
-            $this->inputTypeUtils,
-            $this->container,
-            $this->annotationReader,
-            $this->namingStrategy,
-            $recursiveTypeMapper,
-            $this->cache,
+            $context->getTypeGenerator(),
+            $context->getInputTypeGenerator(),
+            $inputTypeUtils,
+            $context->getContainer(),
+            $context->getAnnotationReader(),
+            $context->getNamingStrategy(),
+            $context->getRecursiveTypeMapper(),
+            $context->getCache(),
             $this->globTtl,
             $this->mapTtl
         );

--- a/src/Mappers/StaticClassListTypeMapperFactory.php
+++ b/src/Mappers/StaticClassListTypeMapperFactory.php
@@ -14,10 +14,6 @@ final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterfa
 {
     /** @var array<int, string> The list of classes to be scanned. */
     private $classList;
-    /** @var int|null */
-    private $globTtl;
-    /** @var int|null */
-    private $mapTtl;
 
     /**
      * StaticClassListTypeMapperFactory constructor.
@@ -25,13 +21,9 @@ final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterfa
      * @param array<int, string> $classList
      */
     public function __construct(
-        array $classList,
-        ?int $globTtl = 2,
-        ?int $mapTtl = null
+        array $classList
     ) {
         $this->classList           = $classList;
-        $this->globTtl             = $globTtl;
-        $this->mapTtl              = $mapTtl;
     }
 
     public function create(FactoryContext $context): TypeMapperInterface
@@ -48,8 +40,8 @@ final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterfa
             $context->getNamingStrategy(),
             $context->getRecursiveTypeMapper(),
             $context->getCache(),
-            $this->globTtl,
-            $this->mapTtl
+            $context->getGlobTtl(),
+            $context->getMapTtl()
         );
     }
 }

--- a/src/Mappers/TypeMapperFactoryInterface.php
+++ b/src/Mappers/TypeMapperFactoryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use TheCodingMachine\GraphQLite\TypeRegistry;
+use TheCodingMachine\GraphQLite\FactoryContext;
 
 /**
  * Class in charge of creating a type mapper.
@@ -13,5 +13,5 @@ use TheCodingMachine\GraphQLite\TypeRegistry;
  */
 interface TypeMapperFactoryInterface
 {
-    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper, TypeRegistry $typeRegistry): TypeMapperInterface;
+    public function create(FactoryContext $context): TypeMapperInterface;
 }

--- a/src/Mappers/TypeMapperFactoryInterface.php
+++ b/src/Mappers/TypeMapperFactoryInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
+use TheCodingMachine\GraphQLite\TypeRegistry;
+
 /**
  * Class in charge of creating a type mapper.
  * You can pass a type mapper factory to the SchemaFactory instead of a type mapper if the type mapper you want to
@@ -11,5 +13,5 @@ namespace TheCodingMachine\GraphQLite\Mappers;
  */
 interface TypeMapperFactoryInterface
 {
-    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper): TypeMapperInterface;
+    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper, TypeRegistry $typeRegistry): TypeMapperInterface;
 }

--- a/src/QueryProviderFactoryInterface.php
+++ b/src/QueryProviderFactoryInterface.php
@@ -11,5 +11,5 @@ namespace TheCodingMachine\GraphQLite;
  */
 interface QueryProviderFactoryInterface
 {
-    public function create(FieldsBuilder $fieldsBuilder): QueryProviderInterface;
+    public function create(FactoryContext $context): QueryProviderInterface;
 }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -343,8 +343,23 @@ class SchemaFactory
             $compositeTypeMapper->addTypeMapper($typeMapper);
         }
 
+        if (! empty($this->typeMapperFactories) || ! empty($this->queryProviders)) {
+            $context = new FactoryContext(
+                $annotationReader,
+                $typeResolver,
+                $namingStrategy,
+                $typeRegistry,
+                $fieldsBuilder,
+                $typeGenerator,
+                $inputTypeGenerator,
+                $recursiveTypeMapper,
+                $this->container,
+                $this->cache
+            );
+        }
+
         foreach ($this->typeMapperFactories as $typeMapperFactory) {
-            $compositeTypeMapper->addTypeMapper($typeMapperFactory->create($recursiveTypeMapper, $typeRegistry));
+            $compositeTypeMapper->addTypeMapper($typeMapperFactory->create($context));
         }
 
         $compositeTypeMapper->addTypeMapper(new PorpaginasTypeMapper($recursiveTypeMapper));
@@ -365,7 +380,7 @@ class SchemaFactory
         }
 
         foreach ($this->queryProviderFactories as $queryProviderFactory) {
-            $queryProviders[] = $queryProviderFactory->create($fieldsBuilder);
+            $queryProviders[] = $queryProviderFactory->create($context);
         }
 
         if ($queryProviders === []) {

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -344,7 +344,7 @@ class SchemaFactory
         }
 
         foreach ($this->typeMapperFactories as $typeMapperFactory) {
-            $compositeTypeMapper->addTypeMapper($typeMapperFactory->create($recursiveTypeMapper));
+            $compositeTypeMapper->addTypeMapper($typeMapperFactory->create($recursiveTypeMapper, $typeRegistry));
         }
 
         $compositeTypeMapper->addTypeMapper(new PorpaginasTypeMapper($recursiveTypeMapper));

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -343,7 +343,7 @@ class SchemaFactory
             $compositeTypeMapper->addTypeMapper($typeMapper);
         }
 
-        if (! empty($this->typeMapperFactories) || ! empty($this->queryProviders)) {
+        if (! empty($this->typeMapperFactories) || ! empty($this->queryProviderFactories)) {
             $context = new FactoryContext(
                 $annotationReader,
                 $typeResolver,

--- a/tests/FactoryContextTest.php
+++ b/tests/FactoryContextTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Simple\ArrayCache;
+use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
+
+class FactoryContextTest extends AbstractQueryProviderTest
+{
+    public function testContext(): void
+    {
+        $namingStrategy = new NamingStrategy();
+        $container = new EmptyContainer();
+        $arrayCache = new ArrayCache();
+
+        $context = new FactoryContext(
+            $this->getAnnotationReader(),
+            $this->getTypeResolver(),
+            $namingStrategy,
+            $this->getTypeRegistry(),
+            $this->getFieldsBuilder(),
+            $this->getTypeGenerator(),
+            $this->getInputTypeGenerator(),
+            $this->getTypeMapper(),
+            $container,
+            $arrayCache
+        );
+
+        $this->assertSame($this->getAnnotationReader(), $context->getAnnotationReader());
+        $this->assertSame($this->getTypeResolver(), $context->getTypeResolver());
+        $this->assertSame($namingStrategy, $context->getNamingStrategy());
+        $this->assertSame($this->getTypeRegistry(), $context->getTypeRegistry());
+        $this->assertSame($this->getFieldsBuilder(), $context->getFieldsBuilder());
+        $this->assertSame($this->getTypeGenerator(), $context->getTypeGenerator());
+        $this->assertSame($this->getInputTypeGenerator(), $context->getInputTypeGenerator());
+        $this->assertSame($this->getTypeMapper(), $context->getRecursiveTypeMapper());
+        $this->assertSame($container, $context->getContainer());
+        $this->assertSame($arrayCache, $context->getCache());
+        $this->assertSame(2, $context->getGlobTtl());
+        $this->assertNull($context->getMapTtl());
+    }
+}

--- a/tests/Mappers/StaticClassListTypeMapperTest.php
+++ b/tests/Mappers/StaticClassListTypeMapperTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\Cache\Simple\ArrayCache;
+use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
+use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\NamingStrategy;
+
+class StaticClassListTypeMapperTest extends AbstractQueryProviderTest
+{
+    public function testClassListException(): void
+    {
+        $container = new EmptyContainer();
+
+        $typeGenerator = $this->getTypeGenerator();
+        $inputTypeGenerator = $this->getInputTypeGenerator();
+
+        $cache = new ArrayCache();
+
+        $mapper = new StaticClassListTypeMapper(['NotExistsClass'], $typeGenerator, $inputTypeGenerator, $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), $cache);
+
+        $this->expectException(GraphQLException::class);
+        $this->expectExceptionMessage('Could not find class "NotExistsClass"');
+
+        $mapper->getSupportedClasses();
+    }
+}

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -59,7 +59,7 @@ class SchemaFactoryTest extends TestCase
                 ->setNamingStrategy(new NamingStrategy())
                 ->addTypeMapper(new CompositeTypeMapper())
                 ->addTypeMapperFactory(new class implements TypeMapperFactoryInterface {
-                    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper): TypeMapperInterface
+                    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper, TypeRegistry $typeRegistry): TypeMapperInterface
                     {
                         return new CompositeTypeMapper();
                     }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -59,7 +59,7 @@ class SchemaFactoryTest extends TestCase
                 ->setNamingStrategy(new NamingStrategy())
                 ->addTypeMapper(new CompositeTypeMapper())
                 ->addTypeMapperFactory(new class implements TypeMapperFactoryInterface {
-                    public function create(RecursiveTypeMapperInterface $recursiveTypeMapper, TypeRegistry $typeRegistry): TypeMapperInterface
+                    public function create(FactoryContext $context): TypeMapperInterface
                     {
                         return new CompositeTypeMapper();
                     }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -16,11 +16,13 @@ use TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\TypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\StaticClassListTypeMapperFactory;
 use TheCodingMachine\GraphQLite\Mappers\TypeMapperFactoryInterface;
 use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
 use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
+use TheCodingMachine\GraphQLite\Fixtures\TestSelfType;
 
 class SchemaFactoryTest extends TestCase
 {
@@ -58,12 +60,7 @@ class SchemaFactoryTest extends TestCase
                 ->setAuthorizationService(new VoidAuthorizationService())
                 ->setNamingStrategy(new NamingStrategy())
                 ->addTypeMapper(new CompositeTypeMapper())
-                ->addTypeMapperFactory(new class implements TypeMapperFactoryInterface {
-                    public function create(FactoryContext $context): TypeMapperInterface
-                    {
-                        return new CompositeTypeMapper();
-                    }
-                })
+                ->addTypeMapperFactory(new StaticClassListTypeMapperFactory([TestSelfType::class]))
                 ->addRootTypeMapper(new CompositeRootTypeMapper([]))
                 ->addParameterMapper(new CompositeParameterMapper([]))
                 ->addQueryProviderFactory(new AggregateControllerQueryProviderFactory([], $container))


### PR DESCRIPTION
This is a variant of the GlobTypeMapper that is not performing any glob.
Instead it is being passed a list of classes that are looked into for annotations.
This is useful because the GlobTypeMapper is not looking into packages (only the root package)
and therefore it is important to have a way for packages to provide types too.