### PR TITLE
Allow abstract types

### DIFF
--- a/src/Containers/BasicAutoWiringContainer.php
+++ b/src/Containers/BasicAutoWiringContainer.php
@@ -88,7 +88,7 @@ class BasicAutoWiringContainer implements ContainerInterface
         if (class_exists($id)) {
             $refTypeClass = new ReflectionClass($id);
 
-            return ! ($refTypeClass->hasMethod('__construct') && $refTypeClass->getMethod('__construct')->getNumberOfRequiredParameters() > 0);
+            return $refTypeClass->isInstantiable() && ! ($refTypeClass->hasMethod('__construct') && $refTypeClass->getMethod('__construct')->getNumberOfRequiredParameters() > 0);
         }
 
         return false;

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -67,9 +67,6 @@ final class GlobTypeMapper extends AbstractTypeMapper
                     continue;
                 }
                 $refClass = new ReflectionClass($className);
-                if (! $refClass->isInstantiable() && ! $refClass->isInterface()) {
-                    continue;
-                }
                 $this->classes[$className] = $refClass;
             }
         }

--- a/src/MissingAnnotationException.php
+++ b/src/MissingAnnotationException.php
@@ -15,7 +15,7 @@ class MissingAnnotationException extends RuntimeException
 
     public static function missingTypeException(string $className): self
     {
-        return new self('GraphQL type class "'.$className.'" must provide a @Type annotation.');
+        return new self('GraphQL type class "' . $className . '" must provide a @Type annotation.');
     }
 
     public static function missingExtendTypeException(): self

--- a/src/MissingAnnotationException.php
+++ b/src/MissingAnnotationException.php
@@ -13,9 +13,9 @@ class MissingAnnotationException extends RuntimeException
         return new self('You cannot use the @SourceField annotation without also adding a @Type annotation or a @ExtendType annotation.');
     }
 
-    public static function missingTypeException(): self
+    public static function missingTypeException(string $className): self
     {
-        return new self('GraphQL type classes must provide a @Type annotation.');
+        return new self('GraphQL type class "'.$className.'" must provide a @Type annotation.');
     }
 
     public static function missingExtendTypeException(): self

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -74,6 +74,9 @@ class TypeGenerator
         }
 
         if (! $typeField->isSelfType()) {
+            if (! $refTypeClass->isInstantiable()) {
+                throw new GraphQLException('Class "' . $annotatedObjectClassName . '" annotated with @Type(class="' . $typeField->getClass() . '") must be instantiable.');
+            }
             $annotatedObject = $this->container->get($annotatedObjectClassName);
             $isInterface = interface_exists($typeField->getClass());
         } else {

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -64,7 +64,7 @@ class TypeGenerator
         $typeField = $this->annotationReader->getTypeAnnotation($refTypeClass);
 
         if ($typeField === null) {
-            throw MissingAnnotationException::missingTypeException();
+            throw MissingAnnotationException::missingTypeException($annotatedObjectClassName);
         }
 
         $typeName = $this->namingStrategy->getOutputTypeName($refTypeClass->getName(), $typeField);

--- a/tests/Fixtures/NonInstantiableType/AbstractFooType.php
+++ b/tests/Fixtures/NonInstantiableType/AbstractFooType.php
@@ -1,15 +1,18 @@
 <?php
 
 
-namespace TheCodingMachine\GraphQLite\Fixtures\Types;
+namespace TheCodingMachine\GraphQLite\Fixtures\NonInstantiableType;
 
+use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\Right;
 use TheCodingMachine\GraphQLite\Annotations\SourceField;
 use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 
 /**
  * @Type(class=TheCodingMachine\GraphQLite\Fixtures\TestObject::class)
+ * @SourceField(name="test")
  */
-class FooType extends AbstractFooType
+abstract class AbstractFooType
 {
 }

--- a/tests/Fixtures/Types/AbstractFooType.php
+++ b/tests/Fixtures/Types/AbstractFooType.php
@@ -10,7 +10,6 @@ use TheCodingMachine\GraphQLite\Annotations\Type;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 
 /**
- * @Type(class=TheCodingMachine\GraphQLite\Fixtures\TestObject::class)
  * @SourceField(name="test")
  * @SourceField(name="testBool", logged=true)
  * @SourceField(name="testRight", right=@Right(name="FOOBAR"))

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -90,9 +90,19 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $mapper = new GlobTypeMapper('TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes', $typeGenerator, $this->getInputTypeGenerator(), $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), new NullCache());
 
-        $this->expectException(DuplicateMappingException::class);
-        $this->expectExceptionMessage('The class \'TheCodingMachine\GraphQLite\Fixtures\TestObject\' should be mapped to only one GraphQL Input type. Two methods are pointing via the @Factory annotation to this class: \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory::myFactory\' and \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory2::myFactory\'');
-        $mapper->canMapClassToInputType(TestObject::class);
+        $caught = false;
+        try {
+            $mapper->canMapClassToInputType(TestObject::class);
+        } catch (DuplicateMappingException $e) {
+            // Depending on the environment, one of the messages can be returned.
+            $this->assertContains($e->getMessage(),
+                [
+                    'The class \'TheCodingMachine\GraphQLite\Fixtures\TestObject\' should be mapped to only one GraphQL Input type. Two methods are pointing via the @Factory annotation to this class: \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory::myFactory\' and \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory2::myFactory\'',
+                    'The class \'TheCodingMachine\GraphQLite\Fixtures\TestObject\' should be mapped to only one GraphQL Input type. Two methods are pointing via the @Factory annotation to this class: \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory2::myFactory\' and \'TheCodingMachine\GraphQLite\Fixtures\DuplicateInputTypes\TestFactory::myFactory\''
+                ]);
+            $caught = true;
+        }
+        $this->assertTrue($caught, 'DuplicateMappingException is thrown');
     }
 
     public function testGlobTypeMapperInheritedInputTypesException(): void


### PR DESCRIPTION
PHP abstract classes can be typed with @Type annotation (it makes sense if they are also subtyped)