### PR TITLE
Tests for DateTime input

### DIFF
--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -34,11 +34,17 @@ class DateTimeType extends ScalarType
 
     /**
      * @param mixed $value
+     * @return DateTimeImmutable|null
+     * @throws Exception
      */
     public function parseValue($value): ?DateTimeImmutable
     {
         if ($value === null) {
             return null;
+        }
+
+        if($value instanceof DateTimeImmutable) {
+            return $value;
         }
 
         return new DateTimeImmutable($value);

--- a/tests/Fixtures/Integration/Controllers/ContactController.php
+++ b/tests/Fixtures/Integration/Controllers/ContactController.php
@@ -5,7 +5,6 @@ namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Controllers;
 
 
 use Porpaginas\Arrays\ArrayResult;
-use Psr\Http\Message\UploadedFileInterface;
 use TheCodingMachine\GraphQLite\Annotations\Mutation;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
@@ -32,6 +31,18 @@ class ContactController
      */
     public function saveContact(Contact $contact): Contact
     {
+        return $contact;
+    }
+
+    /**
+     * @Mutation()
+     * @param \DateTimeInterface $birthDate
+     * @return Contact
+     */
+    public function saveBirthDate(\DateTimeInterface $birthDate): Contact {
+        $contact = new Contact('Bill');
+        $contact->setBirthDate($birthDate);
+
         return $contact;
     }
 

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -284,6 +284,67 @@ class EndToEndTest extends TestCase
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
 
+    public function testEndToEndInputTypeDate()
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+        $queryString = '
+        mutation {
+          saveBirthDate(birthDate: "1942-12-24 00:00:00")  {
+            name
+            birthDate
+          }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'saveBirthDate' => [
+                'name' => 'Bill',
+                'birthDate' => '1942-12-24T00:00:00+00:00',
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
+
+    public function testEndToEndInputTypeDateAsParam()
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+        $queryString = '
+        mutation($birthDate: DateTime!) {
+          saveBirthDate(birthDate: $birthDate) {
+            name
+            birthDate
+          }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString,
+            null,
+            null,
+            [
+                "birthDate" => "1942-12-24 00:00:00"
+            ]
+        );
+
+        $this->assertSame([
+            'saveBirthDate' => [
+                'name' => 'Bill',
+                'birthDate' => '1942-12-24T00:00:00+00:00',
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
+
     public function testEndToEndInputType()
     {
         /**


### PR DESCRIPTION
Passing DateTime as  variable causes an exception:
```
TypeError: DateTimeImmutable::__construct() expects parameter 1 to be string, object given
/Users/admin/Projects/graphqlite/src/Types/DateTimeType.php:44
/Users/admin/Projects/graphqlite/src/Types/ArgumentResolver.php:54
```
Passing the same value inline works good.
Tests in this pull request show the problem but do not solve it. 
The simplest way to fix it would be something like this, but I am not sure it`s a good idea:
```
    public function parseValue($value): ?DateTimeImmutable
    {
        if ($value === null) {
            return null;
        }
       if($value instanceof DateTimeImmutable) {
           return $value;
       }
        return new DateTimeImmutable($value);
    }
```
 Thanks!
