### PR TITLE
Adding @Security annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "webmozart/assert": "^1.4",
         "symfony/cache": "^4.3",
         "thecodingmachine/cache-utils": "^1",
-        "ocramius/package-versions": "^1.4"
+        "ocramius/package-versions": "^1.4",
+        "symfony/expression-language": "^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2.4",

--- a/docs/authentication_authorization.md
+++ b/docs/authentication_authorization.md
@@ -7,13 +7,16 @@ sidebar_label: Authentication and authorization
 You might not want to expose your GraphQL API to anyone. Or you might want to keep some queries/mutations or fields
 reserved to some users.
 
-GraphQLite offers some control over what a user can do with your API based on authentication (whether the user
-is logged or not) or authorization (what rights the user have).
+GraphQLite offers some control over what a user can do with your API. You can restrict access to resources:
+ 
+- based on authentication using the [`@Logged` annotation](#logged-and-right-annotations) (restrict access to logged users)
+- based on authorization using the [`@Right` annotation](#logged-and-right-annotations) (restrict access to logged users with certain rights).
+- based on fine-grained authorization using the [`@Security` annotation](fine-grained-security.md) (restrict access for some given resources to some users).
 
 <div class="alert alert-info">
 GraphQLite does not have its own security mechanism.
-Unless you're using our Symfony Bundle, it is up to you to connect this feature to your framework's security mechanism.<br>
-See <a href="#connecting-graphqlite-to-your-framework-s-security-module">Connecting GraphQLite to your framework's security module</a>.
+Unless you're using our Symfony Bundle or our Laravel package, it is up to you to connect this feature to your framework's security mechanism.<br>
+See <a href="implementing-security.md">Connecting GraphQLite to your framework's security module</a>.
 </div>
 
 ## `@Logged` and `@Right` annotations
@@ -112,55 +115,3 @@ While this is the most secured mode, it can have drawbacks when working with dev
 (you need to be logged as admin to fetch the complete schema).
 
 <div class="alert alert-info">The "HideIfUnauthorized" mode was the default mode in GraphQLite 3 and is optionnal from GraphQLite 4+.</div>
-
-## Connecting GraphQLite to your framework's security module
-
-<div class="alert alert-info">
-    This step is NOT necessary for user using GraphQLite through the Symfony Bundle
-</div>
-
-GraphQLite needs to know if a user is logged or not, and what rights it has.
-But this is specific of the framework you use.
-
-To plug GraphQLite to your framework's security mechanism, you will have to provide two classes implementing: 
-
-* `TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface`
-* `TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface`
-
-Those two interfaces act as adapters between GraphQLite and your framework:
-
-```php
-interface AuthenticationServiceInterface
-{
-    /**
-     * Returns true if the "current" user is logged.
-     *
-     * @return bool
-     */
-    public function isLogged(): bool;
-}
-``` 
-
-```php
-interface AuthorizationServiceInterface
-{
-    /**
-     * Returns true if the "current" user has access to the right "$right".
-     *
-     * @param string $right
-     * @return bool
-     */
-    public function isAllowed(string $right): bool;
-}
-```
-
-You need to write classes that implement these interfaces. Then, you must register those classes with GraphQLite.
-It you are [using the `SchemaFactory`](other-frameworks.md), you can register your classes using:
-
-```php
-// Configure an authentication service (to resolve the @Logged annotations).
-$schemaFactory->setAuthenticationService($myAuthenticationService);
-// Configure an authorization service (to resolve the @Right annotations).
-$schemaFactory->setAuthorizationService($myAuthorizationService);
-```
-

--- a/docs/fine-grained-security.md
+++ b/docs/fine-grained-security.md
@@ -1,0 +1,170 @@
+---
+id: fine-grained-security
+title: Fine grained security
+sidebar_label: Fine grained security
+---
+
+If the [`@Logged` and `@Right` annotations](authentication_authorization.md#logged-and-right-annotations) are not 
+granular enough for your needs, you can use the advanced `@Security` annotation.
+
+Using the `@Security` annotation, you can write an *expression* that can contain custom logic. For instance:
+
+- Check that a user can access a given resource
+- Check that a user has one right or another right
+- ...
+
+## Using the @Security annotation
+
+The `@Security` annotation is very flexible: it allows you to pass an expression that can contains custom logic:
+
+```php
+use TheCodingMachine\GraphQLite\Annotations\Security;
+
+// ...
+
+/**
+ * @Query
+ * @Security("is_granted('ROLE_ADMIN') or is_granted('POST_SHOW', post)")
+ */
+public function getPost(Post $post): array
+{
+    // ...
+}
+```
+
+The *expression* defined in the `@Security` annotation must conform to [Symfony's Expression Language syntax](https://symfony.com/doc/4.4/components/expression_language/syntax.html)
+
+<div class="alert alert-info">
+    If you are a Symfony user, you might already be used to the <code>@Security</code> annotation. Most of the inspiration
+    of this annotation comes from Symfony. Warning though! GraphQLite's <code>@Security</code> annotation and 
+    Symfony's <code>@Security</code> annotation are slightly different. Especially, the two annotations do not live
+    in the same namespace!
+</div>
+
+## The `is_granted` function
+
+Use the `is_granted` function to check if a user has a special right.
+
+```php
+@Security("is_granted('ROLE_ADMIN')")
+```
+
+is similar to
+
+```php
+@Right("ROLE_ADMIN")
+```
+
+In addition, the `is_granted` function accepts a second optional parameter: the "scope" of the right.
+
+```php
+/**
+ * @Query
+ * @Security("is_granted('POST_SHOW', post)")
+ */
+public function getPost(Post $post): array
+{
+    // ...
+}
+```
+
+In the example above, the `getPost` method can be called only if the logged user has the 'POST_SHOW' permission on the
+`$post` object. You can notice that the `$post` object comes from the parameters.
+
+## Accessing method parameters
+
+All parameters passed to the method can be accessed in the `@Security` expression.
+
+```php
+/**
+ * @Query
+ * @Security("startDate < endDate", statusCode=400, message="End date must be after start date")
+ */
+public function getPosts(DateTimeImmutable $startDate, DateTimeImmutable $endDate): array
+{
+    // ...
+}
+```
+
+In the example above, we tweak a bit the Security annotation purpose to do simple input validation.
+
+## Setting HTTP code and error message
+
+You can use the `statusCode` and `message` attributes to set the HTTP code and GraphQL error message.
+
+```php
+/**
+ * @Query
+ * @Security("is_granted('POST_SHOW', post)", statusCode=404, message="Post not found (let's pretend the post does not exists!)")
+ */
+public function getPost(Post $post): array
+{
+    // ...
+}
+```
+
+Note: since a single GraphQL call contain many errors, 2 errors might have conflicting HTTP status code.
+The resulting status code is up to the GraphQL middleware you use. Most of the time, the status code with the 
+higher error code will be returned.
+
+## Accessing the user
+
+You can use the `user` variable to access the currently logged user.
+You can use the `is_logged()` function to check if a user is logged or not.
+
+```php
+/**
+ * @Query
+ * @Security("is_logged() && user.age > 18")
+ */
+public function getNSFWImages(): array
+{
+    // ...
+}
+```
+
+## Accessing the current object
+
+You can use the `this` variable to access any (public) property / method of the current class.
+
+```php
+class Post {
+    /**
+     * @Query
+     * @Security("this.canAccess(post, user)")
+     */
+    public function getPost(Post $post): array
+    {
+        // ...
+    }
+   
+    public function canAccess(Post $post, User $user): bool
+    {
+        // Some custom logic here
+    }
+}
+```
+
+## Available scope
+
+The `@Security` annotation can be used in any query, mutation or field, so anywhere you have a `@Query`, `@Mutation`
+or `@Field` annotation.
+
+## How to restrict access to a given resource
+
+The `is_granted` method can be used to restrict access to a specific resource.
+
+```php
+@Security("is_granted('POST_SHOW', post)")
+```
+
+If you are wondering how to configure these fine-grained permissions, this is not something that GraphQLite handles 
+itself. Instead, this depends on the framework you are using.
+
+If you are using Symfony, you will [create a custom voter](https://symfony.com/doc/current/security/voters.html).
+
+If you are using Laravel, you will [create a Gate or a Policy](https://laravel.com/docs/6.x/authorization).
+
+If you are using another framework, you need to know that the `is_granted` function simply forwards the call to 
+the `isAllowed` method of the configured `AuthorizationSerice`. See [Connecting GraphQLite to your framework's security module
+](implementing-security.md) for more details

--- a/docs/implementing-security.md
+++ b/docs/implementing-security.md
@@ -1,0 +1,58 @@
+---
+id: implementing-security
+title: Connecting GraphQLite to your framework's security module
+sidebar_label: Connecting security to your framework
+---
+
+<div class="alert alert-info">
+    This step is NOT necessary for users using GraphQLite through the Symfony Bundle or the Laravel package
+</div>
+
+GraphQLite needs to know if a user is logged or not, and what rights it has.
+But this is specific of the framework you use.
+
+To plug GraphQLite to your framework's security mechanism, you will have to provide two classes implementing: 
+
+* `TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface`
+* `TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface`
+
+Those two interfaces act as adapters between GraphQLite and your framework:
+
+```php
+interface AuthenticationServiceInterface
+{
+    /**
+     * Returns true if the "current" user is logged
+     */
+    public function isLogged(): bool;
+
+    /**
+     * Returns an object representing the current logged user.
+     * Can return null if the user is not logged.
+     */
+    public function getUser(): ?object;
+}
+``` 
+
+```php
+interface AuthorizationServiceInterface
+{
+    /**
+     * Returns true if the "current" user has access to the right "$right"
+     *
+     * @param mixed $subject The scope this right applies on. $subject is typically an object or a FQCN. Set $subject to "null" if the right is global.
+     */
+    public function isAllowed(string $right, $subject = null): bool;
+}
+```
+
+You need to write classes that implement these interfaces. Then, you must register those classes with GraphQLite.
+It you are [using the `SchemaFactory`](other_frameworks.md), you can register your classes using:
+
+```php
+// Configure an authentication service (to resolve the @Logged annotations).
+$schemaFactory->setAuthenticationService($myAuthenticationService);
+// Configure an authorization service (to resolve the @Right annotations).
+$schemaFactory->setAuthorizationService($myAuthorizationService);
+```
+

--- a/docs/laravel-package.md
+++ b/docs/laravel-package.md
@@ -53,8 +53,55 @@ return [
 The debug parameters are detailed in the [documentation of the Webonyx GraphQL library](https://webonyx.github.io/graphql-php/error-handling/)
 which is used internally by GraphQLite.
 
-<div class="alert alert-warning">By default `/graphql` route is placed under `web` middleware group which requires a CSRF token. If you need to add your own middleware you can edit them in the config file above, or add `graphql` to `$except` in `app/Http/Middleware/VerifyCsrfToken.php`.</div>
+## Passing the XSRF token
 
+<div class="alert alert-warning">By default `/graphql` route is placed under `web` middleware group which requires a CSRF token.</div>
+
+You have 2 options:
+
+- Configure your GraphQL client to pass the `X-CSRF-TOKEN` with every GraphQL query
+- or disable CSRF for GraphQL routes (not recommended)
+
+### Configuring your GraphQL client
+
+This step depends on the Javascript GraphQL client you are using.
+
+Assuming you are using [Apollo](https://www.apollographql.com/docs/link/links/http/), you need to be sure that Apollo passes the token
+back to Laravel on every request.
+
+**Sample Apollo client setup with CSRF support**
+```js
+import { ApolloClient, ApolloLink, InMemoryCache, HttpLink } from 'apollo-boost';
+
+const httpLink = new HttpLink({ uri: 'https://api.example.com/graphql' });
+
+const authLink = new ApolloLink((operation, forward) => {
+  // Retrieve the authorization token from local storage.
+  const token = localStorage.getItem('auth_token');
+  
+  // Get the XSRF-TOKEN that is set by Laravel on each request
+  var cookieValue = document.cookie.replace(/(?:(?:^|.*;\s*)XSRF-TOKEN\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+
+  // Use the setContext method to set the X-CSRF-TOKEN header back.
+  operation.setContext({
+    headers: {
+      'X-CSRF-TOKEN': cookieValue
+    }
+  });
+
+  // Call the next link in the middleware chain.
+  return forward(operation);
+});
+
+const client = new ApolloClient({
+  link: authLink.concat(httpLink), // Chain it with the HttpLink
+  cache: new InMemoryCache()
+});
+```
+
+### Alternative: disable CSRF for the /graphql route 
+
+Alternatively, you can add `graphql` to `$except` in `app/Http/Middleware/VerifyCsrfToken.php`.
 
 ## Adding GraphQL DevTools
 

--- a/docs/laravel-package.md
+++ b/docs/laravel-package.md
@@ -4,7 +4,7 @@ title: Getting started with Laravel
 sidebar_label: Laravel package
 ---
 
-The GraphQLite-Laravel package is compatible with **Laravel 5.x**.
+The GraphQLite-Laravel package is compatible with **Laravel 5.7+** and **Laravel 6.x**.
 
 ## Installation
 
@@ -47,24 +47,51 @@ return [
     'debug' => Debug::RETHROW_UNSAFE_EXCEPTIONS,
     'uri' => env('GRAPHQLITE_URI', '/graphql'),
     'middleware' => ['web'],
+    'guard' => ['web'],
 ];
 ```
 
 The debug parameters are detailed in the [documentation of the Webonyx GraphQL library](https://webonyx.github.io/graphql-php/error-handling/)
 which is used internally by GraphQLite.
 
-## Passing the XSRF token
+## Configuring CSRF protection
 
-<div class="alert alert-warning">By default `/graphql` route is placed under `web` middleware group which requires a CSRF token.</div>
+<div class="alert alert-warning">By default, the `/graphql` route is placed under `web` middleware group which requires a 
+<a href="https://laravel.com/docs/6.x/csrf">CSRF token</a>.</div>
 
-You have 2 options:
+You have 3 options:
 
-- Configure your GraphQL client to pass the `X-CSRF-TOKEN` with every GraphQL query
-- or disable CSRF for GraphQL routes (not recommended)
+- Use the `api` middleware
+- Disable CSRF for GraphQL routes
+- or configure your GraphQL client to pass the `X-CSRF-TOKEN` with every GraphQL query
+
+### Use the `api` middleware
+
+If you plan to use graphql for server-to-server connection only, you should probably configure GraphQLite to use the 
+`api` middleware instead of the `web` middleware:
+
+**config/graphqlite.php**
+```php
+<?php
+return [
+    'middleware' => ['api'],
+    'guard' => ['api'],
+];
+```
+
+### Disable CSRF for the /graphql route 
+
+If you plan to use graphql from web browsers and if you want to explicitly allow access from external applications 
+(through CORS headers), you need to disable the CSRF token.
+
+Simply add `graphql` to `$except` in `app/Http/Middleware/VerifyCsrfToken.php`.
 
 ### Configuring your GraphQL client
 
-This step depends on the Javascript GraphQL client you are using.
+If you are planning to use `graphql` only from your website domain, then the safest way is to keep CSRF enabled and
+configure your GraphQL JS client to pass the CSRF headers on any graphql request.
+
+The way you do this depends on the Javascript GraphQL client you are using.
 
 Assuming you are using [Apollo](https://www.apollographql.com/docs/link/links/http/), you need to be sure that Apollo passes the token
 back to Laravel on every request.
@@ -99,10 +126,6 @@ const client = new ApolloClient({
 });
 ```
 
-### Alternative: disable CSRF for the /graphql route 
-
-Alternatively, you can add `graphql` to `$except` in `app/Http/Middleware/VerifyCsrfToken.php`.
-
 ## Adding GraphQL DevTools
 
 GraphQLite does not include additional GraphQL tooling, such as the GraphiQL editor.
@@ -116,3 +139,8 @@ $ composer require mll-lab/laravel-graphql-playground
 By default, the playground will be available at `/graphql-playground`.
 
 You can also use any external client with GraphQLite, make sure to point it to the URL defined in the config (`'/graphql'` by default).
+
+## Troubleshooting HTTP 419 errors
+
+If HTTP requests to GraphQL endpoint generate responses with the HTTP 419 status code, you have an issue with the configuration of your
+CSRF token. Please check again [the paragraph dedicated to CSRF configuration](#configuring-csrf-protection).

--- a/docs/other_frameworks.md
+++ b/docs/other_frameworks.md
@@ -281,4 +281,4 @@ return new Picotainer([
 
 And we are done! You can now test your query using your favorite GraphQL client.
 
-![](../img/query1.png)
+![](assets/query1.png)

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -56,7 +56,7 @@ The easiest way to test a GraphQL endpoint is to use [GraphiQL](https://github.c
 
 Here a query using our simple *Hello World* example:
 
-![](../img/query1.png)
+![](/img/query1.png)
 
 ## Query with a type
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,5 +11,8 @@ parameters:
         - "#Parameter \\#2 \\$inputTypeNode of static method GraphQL\\\\Utils\\\\AST::typeFromAST() expects GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode, GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NameNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode given.#"
         - "#PHPDoc tag @throws with type Psr\\\\SimpleCache\\\\InvalidArgumentException is not subtype of Throwable#"
         - '#Variable \$context might not be defined.#'
+        -
+          message: '#If condition is always true#'
+          path: src/Middlewares/SecurityFieldMiddleware.php
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,8 +11,8 @@ parameters:
         - "#Parameter \\#2 \\$inputTypeNode of static method GraphQL\\\\Utils\\\\AST::typeFromAST() expects GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode, GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NameNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode given.#"
         - "#PHPDoc tag @throws with type Psr\\\\SimpleCache\\\\InvalidArgumentException is not subtype of Throwable#"
         - '#Variable \$context might not be defined.#'
-        -
-          message: '#If condition is always true#'
-          path: src/Middlewares/SecurityFieldMiddleware.php
+        #-
+        #  message: '#If condition is always true#'
+        #  path: src/Middlewares/SecurityFieldMiddleware.php
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/Annotations/Security.php
+++ b/src/Annotations/Security.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use BadMethodCallException;
-use TheCodingMachine\GraphQLite\GraphQLException;
 use function array_key_exists;
 
 /**

--- a/src/Annotations/Security.php
+++ b/src/Annotations/Security.php
@@ -39,9 +39,9 @@ class Security implements MiddlewareAnnotationInterface
     public function __construct(array $values)
     {
         if (! isset($values['value']) && ! isset($values['expression'])) {
-            throw new BadMethodCallException('The @Security annotation must be passed an expression. For instance: "@Security("hasRight(\'CAN_EDIT_STUFF\')")"');
+            throw new BadMethodCallException('The @Security annotation must be passed an expression. For instance: "@Security("is_granted(\'CAN_EDIT_STUFF\')")"');
         }
-        $this->expression = $values['value'] ?? $values['name'];
+        $this->expression = $values['value'] ?? $values['expression'];
         if (array_key_exists('failWith', $values)) {
             $this->failWith = $values['failWith'];
             $this->failWithIsSet = true;
@@ -49,7 +49,7 @@ class Security implements MiddlewareAnnotationInterface
         $this->message = $values['message'] ?? 'Access denied.';
         $this->statusCode = $values['statusCode'] ?? 403;
         if ($this->failWithIsSet === true && (isset($values['message']) || isset($values['statusCode']))) {
-            throw new GraphQLException('A @Security annotation that has "failWith" attribute set cannot have a message or a statusCode attribute.');
+            throw new BadMethodCallException('A @Security annotation that has "failWith" attribute set cannot have a message or a statusCode attribute.');
         }
     }
 

--- a/src/Annotations/Security.php
+++ b/src/Annotations/Security.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Annotations;
+
+use BadMethodCallException;
+use TheCodingMachine\GraphQLite\GraphQLException;
+use function array_key_exists;
+
+/**
+ * @Annotation
+ * @Target({"ANNOTATION", "METHOD"})
+ * @Attributes({
+ *   @Attribute("expression", type = "string"),
+ *   @Attribute("failWith", type = "mixed"),
+ *   @Attribute("statusCode", type = "int"),
+ *   @Attribute("message", type = "string"),
+ * })
+ */
+class Security implements MiddlewareAnnotationInterface
+{
+    /** @var string */
+    private $expression;
+    /** @var mixed */
+    private $failWith;
+    /** @var bool */
+    private $failWithIsSet = false;
+    /** @var int|null */
+    private $statusCode;
+    /** @var string */
+    private $message;
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @throws BadMethodCallException
+     */
+    public function __construct(array $values)
+    {
+        if (! isset($values['value']) && ! isset($values['expression'])) {
+            throw new BadMethodCallException('The @Security annotation must be passed an expression. For instance: "@Security("hasRight(\'CAN_EDIT_STUFF\')")"');
+        }
+        $this->expression = $values['value'] ?? $values['name'];
+        if (array_key_exists('failWith', $values)) {
+            $this->failWith = $values['failWith'];
+            $this->failWithIsSet = true;
+        }
+        $this->message = $values['message'] ?? 'Access denied.';
+        $this->statusCode = $values['statusCode'] ?? 403;
+        if ($this->failWithIsSet === true && (isset($values['message']) || isset($values['statusCode']))) {
+            throw new GraphQLException('A @Security annotation that has "failWith" attribute set cannot have a message or a statusCode attribute.');
+        }
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function isFailWithSet(): bool
+    {
+        return $this->failWithIsSet;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFailWith()
+    {
+        return $this->failWith;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -234,6 +234,7 @@ class FieldsBuilder
             }
 
             $fieldDescriptor = new QueryFieldDescriptor();
+            $fieldDescriptor->setRefMethod($refMethod);
 
             $docBlockObj     = $this->cachedDocBlockFactory->getDocBlock($refMethod);
             $docBlockComment = $docBlockObj->getSummary() . "\n" . $docBlockObj->getDescription()->render();
@@ -390,6 +391,7 @@ class FieldsBuilder
             }
 
             $fieldDescriptor = new QueryFieldDescriptor();
+            $fieldDescriptor->setRefMethod($refMethod);
             $fieldDescriptor->setName($sourceField->getName());
 
             $methodName = $refMethod->getName();

--- a/src/Middlewares/BadExpressionInSecurityException.php
+++ b/src/Middlewares/BadExpressionInSecurityException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Middlewares;
+
+use Exception;
+use TheCodingMachine\GraphQLite\QueryFieldDescriptor;
+use Throwable;
+
+/**
+ * Exception wrapping exceptions occurring when the Security annotation is evaluated
+ */
+class BadExpressionInSecurityException extends Exception
+{
+    public static function wrapException(Throwable $e, QueryFieldDescriptor $fieldDescriptor): self
+    {
+        $refMethod = $fieldDescriptor->getRefMethod();
+        $message = 'An error occurred while evaluating expression in @Security annotation of method "' . $refMethod->getDeclaringClass()->getName() . '::' . $refMethod->getName() . '": ' . $e->getMessage();
+
+        return new self($message, $e->getCode(), $e);
+    }
+}

--- a/src/Middlewares/SecurityFieldMiddleware.php
+++ b/src/Middlewares/SecurityFieldMiddleware.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Middlewares;
 
+use Closure;
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\OutputType;
 use Psr\Log\LoggerInterface;
 use ReflectionFunction;
-use stdClass;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use TheCodingMachine\GraphQLite\Annotations\FailWith;
 use TheCodingMachine\GraphQLite\Annotations\Security;
@@ -19,14 +19,10 @@ use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
 use Webmozart\Assert\Assert;
 use function array_combine;
-use function array_intersect;
 use function array_keys;
 use function array_merge;
-use function count;
-use function implode;
 use function is_array;
 use function is_object;
-use function sprintf;
 
 /**
  * A field middleware that reads "Security" Symfony annotations.
@@ -39,9 +35,7 @@ class SecurityFieldMiddleware implements FieldMiddlewareInterface
     private $authenticationService;
     /** @var LoggerInterface|null */
     private $logger;
-    /**
-     * @var AuthorizationServiceInterface
-     */
+    /** @var AuthorizationServiceInterface */
     private $authorizationService;
 
     public function __construct(ExpressionLanguage $language, AuthenticationServiceInterface $authenticationService, AuthorizationServiceInterface $authorizationService, ?LoggerInterface $logger = null)
@@ -161,7 +155,12 @@ class SecurityFieldMiddleware implements FieldMiddlewareInterface
         if (is_array($callable) && is_object($callable[0])) {
             return $callable[0];
         }
-        $reflectionFunction = new ReflectionFunction($callable);
-        return $reflectionFunction->getClosureThis();
+        if ($callable instanceof Closure) {
+            $reflectionFunction = new ReflectionFunction($callable);
+
+            return $reflectionFunction->getClosureThis();
+        }
+
+        return null;
     }
 }

--- a/src/Middlewares/SecurityFieldMiddleware.php
+++ b/src/Middlewares/SecurityFieldMiddleware.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Middlewares;
+
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\OutputType;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use TheCodingMachine\GraphQLite\Annotations\FailWith;
+use TheCodingMachine\GraphQLite\Annotations\Security;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+use TheCodingMachine\GraphQLite\QueryFieldDescriptor;
+use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
+use Webmozart\Assert\Assert;
+use function array_combine;
+use function array_intersect;
+use function array_keys;
+use function array_merge;
+use function count;
+use function implode;
+use function sprintf;
+
+/**
+ * A field middleware that reads "Security" Symfony annotations.
+ */
+class SecurityFieldMiddleware implements FieldMiddlewareInterface
+{
+    /** @var ExpressionLanguage */
+    private $language;
+    /** @var AuthenticationServiceInterface */
+    private $authenticationService;
+    /** @var LoggerInterface|null */
+    private $logger;
+
+    public function __construct(ExpressionLanguage $language, AuthenticationServiceInterface $authenticationService, ?LoggerInterface $logger = null)
+    {
+        $this->language = $language;
+        $this->authenticationService = $authenticationService;
+        $this->logger = $logger;
+    }
+
+    public function process(QueryFieldDescriptor $queryFieldDescriptor, FieldHandlerInterface $fieldHandler): ?FieldDefinition
+    {
+        $annotations = $queryFieldDescriptor->getMiddlewareAnnotations();
+        /** @var Security[] $securityAnnotations */
+        $securityAnnotations = $annotations->getAnnotationsByType(Security::class);
+
+        if (empty($securityAnnotations)) {
+            return $fieldHandler->handle($queryFieldDescriptor);
+        }
+
+        /**
+         * @var FailWith|null $failWith
+         */
+        $failWith = $annotations->getAnnotationByType(FailWith::class);
+
+        // If the failWith value is null and the return type is non nullable, we must set it to nullable.
+        $makeReturnTypeNullable = false;
+        $type = $queryFieldDescriptor->getType();
+        if ($type instanceof NonNull) {
+            if ($failWith !== null && $failWith->getValue() === null) {
+                $makeReturnTypeNullable = true;
+            } else {
+                foreach ($securityAnnotations as $annotation) {
+                    if (! $annotation->isFailWithSet() || $annotation->getFailWith() !== null) {
+                        continue;
+                    }
+
+                    $makeReturnTypeNullable = true;
+                }
+            }
+            if ($makeReturnTypeNullable) {
+                $type = $type->getWrappedType();
+                Assert::isInstanceOf($type, OutputType::class);
+                $queryFieldDescriptor->setType($type);
+            }
+        }
+
+        $callable = $queryFieldDescriptor->getCallable();
+        Assert::notNull($callable);
+
+        $parameters = $queryFieldDescriptor->getParameters();
+
+        $queryFieldDescriptor->setCallable(function (...$args) use ($securityAnnotations, $callable, $failWith, $parameters) {
+            $variables = $this->getVariables($args, $parameters);
+
+            foreach ($securityAnnotations as $annotation) {
+                if (! $this->language->evaluate($annotation->getExpression(), $variables)) {
+                    if ($annotation->isFailWithSet()) {
+                        return $annotation->getFailWith();
+                    }
+                    if ($failWith !== null) {
+                        return $failWith->getValue();
+                    }
+
+                    throw new MissingAuthorizationException($annotation->getMessage(), $annotation->getStatusCode());
+                }
+            }
+
+            return $callable(...$args);
+        });
+
+        return $fieldHandler->handle($queryFieldDescriptor);
+    }
+
+    /**
+     * @param array<int, mixed> $args
+     * @param array<string, ParameterInterface> $parameters
+     *
+     * @return array<string, mixed>
+     */
+    private function getVariables(array $args, array $parameters): array
+    {
+        $variables = [
+            'user' => $this->authenticationService->getUser(),
+            // TODO: see if we can get this in closure context or array first elem
+            //'this' => $source,
+        ];
+
+        $argsName = array_keys($parameters);
+        $argsByName = array_combine($argsName, $args);
+        Assert::isArray($argsByName);
+
+        if ($diff = array_intersect(array_keys($variables), array_keys($argsName))) {
+            foreach ($diff as $key => $variableName) {
+                if ($variables[$variableName] !== $argsByName[$variableName]) {
+                    continue;
+                }
+
+                unset($diff[$key]);
+            }
+
+            if ($diff) {
+                $singular = count($diff) === 1;
+                if ($this->logger !== null) {
+                    $this->logger->warning(sprintf('Controller argument%s "%s" collided with the built-in security expression variables. The built-in value%s are being used for the @Security expression.', $singular ? '' : 's', implode('", "', $diff), $singular ? 's' : ''));
+                }
+            }
+        }
+
+        return array_merge($argsByName, $variables);
+    }
+}

--- a/src/Middlewares/SecurityFieldMiddleware.php
+++ b/src/Middlewares/SecurityFieldMiddleware.php
@@ -34,16 +34,16 @@ class SecurityFieldMiddleware implements FieldMiddlewareInterface
     /** @var AuthenticationServiceInterface */
     private $authenticationService;
     /** @var LoggerInterface|null */
-    private $logger;
+    /*private $logger;*/
     /** @var AuthorizationServiceInterface */
     private $authorizationService;
 
-    public function __construct(ExpressionLanguage $language, AuthenticationServiceInterface $authenticationService, AuthorizationServiceInterface $authorizationService, ?LoggerInterface $logger = null)
+    public function __construct(ExpressionLanguage $language, AuthenticationServiceInterface $authenticationService, AuthorizationServiceInterface $authorizationService/*, ?LoggerInterface $logger = null*/)
     {
         $this->language = $language;
         $this->authenticationService = $authenticationService;
         $this->authorizationService = $authorizationService;
-        $this->logger = $logger;
+        /*$this->logger = $logger;*/
     }
 
     public function process(QueryFieldDescriptor $queryFieldDescriptor, FieldHandlerInterface $fieldHandler): ?FieldDefinition

--- a/src/QueryFieldDescriptor.php
+++ b/src/QueryFieldDescriptor.php
@@ -6,6 +6,7 @@ namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use ReflectionMethod;
 use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotations;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 
@@ -40,6 +41,8 @@ class QueryFieldDescriptor
     private $comment;
     /** @var MiddlewareAnnotations */
     private $middlewareAnnotations;
+    /** @var ReflectionMethod */
+    private $refMethod;
 
     public function getName(): string
     {
@@ -159,5 +162,15 @@ class QueryFieldDescriptor
     public function setMiddlewareAnnotations(MiddlewareAnnotations $middlewareAnnotations): void
     {
         $this->middlewareAnnotations = $middlewareAnnotations;
+    }
+
+    public function getRefMethod(): ReflectionMethod
+    {
+        return $this->refMethod;
+    }
+
+    public function setRefMethod(ReflectionMethod $refMethod): void
+    {
+        $this->refMethod = $refMethod;
     }
 }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -14,6 +14,8 @@ use GraphQL\Type\SchemaConfig;
 use PackageVersions\Versions;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\Psr16Adapter;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper;
@@ -31,6 +33,7 @@ use TheCodingMachine\GraphQLite\Mappers\TypeMapperInterface;
 use TheCodingMachine\GraphQLite\Middlewares\AuthorizationFieldMiddleware;
 use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewareInterface;
 use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewarePipe;
+use TheCodingMachine\GraphQLite\Middlewares\SecurityFieldMiddleware;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
@@ -85,6 +88,8 @@ class SchemaFactory
     private $globTtl = 2;
     /** @var array<int, FieldMiddlewareInterface> */
     private $fieldMiddlewares = [];
+    /** @var ExpressionLanguage|null */
+    private $expressionLanguage;
 
     public function __construct(CacheInterface $cache, ContainerInterface $container)
     {
@@ -272,6 +277,17 @@ class SchemaFactory
         return $this;
     }
 
+    /**
+     * Sets a custom expression language to use.
+     * ExpressionLanguage is used to evaluate expressions in the "Security" tag.
+     */
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage): self
+    {
+        $this->expressionLanguage = $expressionLanguage;
+
+        return $this;
+    }
+
     public function createSchema(): Schema
     {
         $annotationReader      = new AnnotationReader($this->getDoctrineAnnotationReader(), AnnotationReader::LAX_MODE);
@@ -282,10 +298,15 @@ class SchemaFactory
         $namingStrategy        = $this->namingStrategy ?: new NamingStrategy();
         $typeRegistry          = new TypeRegistry();
 
+        $psr6Cache = new Psr16Adapter($this->cache);
+        $expressionLanguage = $this->expressionLanguage ?: new ExpressionLanguage($psr6Cache);
+
         $fieldMiddlewarePipe = new FieldMiddlewarePipe();
         foreach ($this->fieldMiddlewares as $fieldMiddleware) {
             $fieldMiddlewarePipe->pipe($fieldMiddleware);
         }
+        // TODO: add a logger to the SchemaFactory and make use of it everywhere (and most particularly in SecurityFieldMiddleware)
+        $fieldMiddlewarePipe->pipe(new SecurityFieldMiddleware($expressionLanguage, $authenticationService));
         $fieldMiddlewarePipe->pipe(new AuthorizationFieldMiddleware($authenticationService, $authorizationService));
 
         $compositeTypeMapper = new CompositeTypeMapper();

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -39,6 +39,7 @@ use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\FailAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\FailAuthorizationService;
+use TheCodingMachine\GraphQLite\Security\SecurityExpressionLanguageProvider;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use TheCodingMachine\GraphQLite\Utils\NamespacedCache;
@@ -300,13 +301,14 @@ class SchemaFactory
 
         $psr6Cache = new Psr16Adapter($this->cache);
         $expressionLanguage = $this->expressionLanguage ?: new ExpressionLanguage($psr6Cache);
+        $expressionLanguage->registerProvider(new SecurityExpressionLanguageProvider());
 
         $fieldMiddlewarePipe = new FieldMiddlewarePipe();
         foreach ($this->fieldMiddlewares as $fieldMiddleware) {
             $fieldMiddlewarePipe->pipe($fieldMiddleware);
         }
         // TODO: add a logger to the SchemaFactory and make use of it everywhere (and most particularly in SecurityFieldMiddleware)
-        $fieldMiddlewarePipe->pipe(new SecurityFieldMiddleware($expressionLanguage, $authenticationService));
+        $fieldMiddlewarePipe->pipe(new SecurityFieldMiddleware($expressionLanguage, $authenticationService, $authorizationService));
         $fieldMiddlewarePipe->pipe(new AuthorizationFieldMiddleware($authenticationService, $authorizationService));
 
         $compositeTypeMapper = new CompositeTypeMapper();

--- a/src/Security/AuthenticationServiceInterface.php
+++ b/src/Security/AuthenticationServiceInterface.php
@@ -10,4 +10,10 @@ interface AuthenticationServiceInterface
      * Returns true if the "current" user is logged
      */
     public function isLogged(): bool;
+
+    /**
+     * Returns an object representing the current logged user.
+     * Can return null if the user is not logged.
+     */
+    public function getUser(): ?object;
 }

--- a/src/Security/AuthorizationServiceInterface.php
+++ b/src/Security/AuthorizationServiceInterface.php
@@ -8,6 +8,8 @@ interface AuthorizationServiceInterface
 {
     /**
      * Returns true if the "current" user has access to the right "$right"
+     *
+     * @param mixed $subject The scope this right applies on. $subject is typically an object or a FQCN. Set $subject to "null" if the right is global.
      */
-    public function isAllowed(string $right): bool;
+    public function isAllowed(string $right, $subject = null): bool;
 }

--- a/src/Security/FailAuthenticationService.php
+++ b/src/Security/FailAuthenticationService.php
@@ -16,4 +16,13 @@ class FailAuthenticationService implements AuthenticationServiceInterface
     {
         throw SecurityNotImplementedException::createNoAuthenticationException();
     }
+
+    /**
+     * Returns an object representing the current logged user.
+     * Can return null if the user is not logged.
+     */
+    public function getUser(): ?object
+    {
+        throw SecurityNotImplementedException::createNoAuthenticationException();
+    }
 }

--- a/src/Security/FailAuthorizationService.php
+++ b/src/Security/FailAuthorizationService.php
@@ -11,8 +11,10 @@ class FailAuthorizationService implements AuthorizationServiceInterface
 {
     /**
      * Returns true if the "current" user has access to the right "$right"
+     *
+     * @param mixed $subject The scope this right applies on. $subject is typically an object or a FQCN. Set $subject to "null" if the right is global.
      */
-    public function isAllowed(string $right): bool
+    public function isAllowed(string $right, $subject = null): bool
     {
         throw SecurityNotImplementedException::createNoAuthorizationException();
     }

--- a/src/Security/SecurityExpressionLanguageProvider.php
+++ b/src/Security/SecurityExpressionLanguageProvider.php
@@ -1,8 +1,8 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Security;
-
 
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
@@ -16,7 +16,7 @@ class SecurityExpressionLanguageProvider implements ExpressionFunctionProviderIn
     /**
      * @return ExpressionFunction[] An array of Function instances
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new ExpressionFunction('is_granted', static function (string $rightName, $object = 'null'): string {

--- a/src/Security/SecurityExpressionLanguageProvider.php
+++ b/src/Security/SecurityExpressionLanguageProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Security;
+
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use function sprintf;
+
+/**
+ * An expression language provider that adds functions used in the context of the "Security" annotation.
+ */
+class SecurityExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    /**
+     * @return ExpressionFunction[] An array of Function instances
+     */
+    public function getFunctions()
+    {
+        return [
+            new ExpressionFunction('is_granted', static function (string $rightName, $object = 'null'): string {
+                return sprintf('$authorizationService->isAllowed(%s, %s)', $rightName, $object);
+            }, static function (array $variables, string $rightName, $object = null): bool {
+                return $variables['authorizationService']->isAllowed($rightName, $object);
+            }),
+
+            new ExpressionFunction('is_logged', static function (): string {
+                return sprintf('$authenticationService->isLogged()');
+            }, static function (array $variables): bool {
+                return $variables['authenticationService']->isLogged();
+            }),
+        ];
+    }
+}

--- a/src/Security/VoidAuthenticationService.php
+++ b/src/Security/VoidAuthenticationService.php
@@ -16,4 +16,13 @@ class VoidAuthenticationService implements AuthenticationServiceInterface
     {
         return false;
     }
+
+    /**
+     * Returns an object representing the current logged user.
+     * Can return null if the user is not logged.
+     */
+    public function getUser(): ?object
+    {
+        return null;
+    }
 }

--- a/src/Security/VoidAuthorizationService.php
+++ b/src/Security/VoidAuthorizationService.php
@@ -11,8 +11,10 @@ class VoidAuthorizationService implements AuthorizationServiceInterface
 {
     /**
      * Returns true if the "current" user has access to the right "$right"
+     *
+     * @param mixed $subject The scope this right applies on. $subject is typically an object or a FQCN. Set $subject to "null" if the right is global.
      */
-    public function isAllowed(string $right): bool
+    public function isAllowed(string $right, $subject = null): bool
     {
         return false;
     }

--- a/tests/Annotations/SecurityTest.php
+++ b/tests/Annotations/SecurityTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Annotations;
+
+use BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+
+class SecurityTest extends TestCase
+{
+
+    public function testBadParams(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('The @Security annotation must be passed an expression. For instance: "@Security("is_granted(\'CAN_EDIT_STUFF\')")"');
+        new Security([]);
+    }
+
+    public function testIncompatibleParams(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('A @Security annotation that has "failWith" attribute set cannot have a message or a statusCode attribute.');
+        new Security(['expression'=>'foo', 'failWith'=>null, 'statusCode'=>500]);
+    }
+}

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -23,6 +23,7 @@ use TheCodingMachine\GraphQLite\Fixtures\TestController;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerNoReturnType;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithArrayParam;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithArrayReturnType;
+use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithBadSecurity;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithFailWith;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithInputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithInvalidInputType;
@@ -57,6 +58,7 @@ use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Middlewares\AuthorizationFieldMiddleware;
+use TheCodingMachine\GraphQLite\Middlewares\BadExpressionInSecurityException;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
@@ -664,5 +666,24 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertCount(2, $testField->args);
         $this->assertSame('string', $testField->args[0]->name);
         $this->assertSame('int', $testField->args[1]->name);
+    }
+
+    public function testSecurityBadQuery(): void
+    {
+        $controller = new TestControllerWithBadSecurity();
+
+        $queryProvider = $this->buildFieldsBuilder();
+
+        $queries = $queryProvider->getQueries($controller);
+
+        $this->assertCount(1, $queries);
+        $query = $queries[0];
+        $this->assertSame('testBadSecurity', $query->name);
+
+        $resolve = $query->resolveFn;
+
+        $this->expectException(BadExpressionInSecurityException::class);
+        $this->expectExceptionMessage('An error occurred while evaluating expression in @Security annotation of method "TheCodingMachine\GraphQLite\Fixtures\TestControllerWithBadSecurity::testBadSecurity": Unexpected token "name" of value "is" around position 6 for expression `this is not valid expression language`.');
+        $result = $resolve(new stdClass(), [], null, $this->createMock(ResolveInfo::class));
     }
 }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -274,6 +274,11 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             {
                 return true;
             }
+
+            public function getUser(): ?object
+            {
+                return new stdClass();
+            }
         };
         $queryProvider = new FieldsBuilder(
             $this->getAnnotationReader(),

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -305,7 +305,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
     public function testRightInSourceField(): void
     {
         $authorizationService = new class implements AuthorizationServiceInterface {
-            public function isAllowed(string $right): bool
+            public function isAllowed(string $right, $subject = null): bool
             {
                 return true;
             }

--- a/tests/Fixtures/Integration/Controllers/ContactController.php
+++ b/tests/Fixtures/Integration/Controllers/ContactController.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Controllers;
 use Porpaginas\Arrays\ArrayResult;
 use TheCodingMachine\GraphQLite\Annotations\Mutation;
 use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Annotations\Security;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\User;
 

--- a/tests/Fixtures/Integration/Controllers/SecurityController.php
+++ b/tests/Fixtures/Integration/Controllers/SecurityController.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Controllers;
+
+
+use Porpaginas\Arrays\ArrayResult;
+use TheCodingMachine\GraphQLite\Annotations\FailWith;
+use TheCodingMachine\GraphQLite\Annotations\Mutation;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Annotations\Security;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\User;
+
+class SecurityController
+{
+    /**
+     * @Query()
+     * @Security("secret=='foo'", message="Wrong secret passed")
+     */
+    public function getSecretPhrase(string $secret): string
+    {
+        return 'you can see this secret only if passed parameter is "foo"';
+    }
+
+    /**
+     * @Query()
+     * @Security("secret=='foo'", failWith=null)
+     */
+    public function getNullableSecretPhrase(string $secret): string
+    {
+        return 'you can see this secret only if passed parameter is "foo"';
+    }
+
+    /**
+     * @Query()
+     * @Security("secret=='foo'")
+     * @FailWith(null)
+     */
+    public function getNullableSecretPhrase2(string $secret): string
+    {
+        return 'you can see this secret only if passed parameter is "foo"';
+    }
+}

--- a/tests/Fixtures/Integration/Controllers/SecurityController.php
+++ b/tests/Fixtures/Integration/Controllers/SecurityController.php
@@ -41,4 +41,36 @@ class SecurityController
     {
         return 'you can see this secret only if passed parameter is "foo"';
     }
+
+    /**
+     * @Query()
+     * @Security("user && user.bar == 42")
+     */
+    public function getSecretUsingUser(): string
+    {
+        return 'you can see this secret only if user.bar is set to 42';
+    }
+
+    /**
+     * @Query()
+     * @Security("is_granted('CAN_EDIT', user) && is_logged()")
+     */
+    public function getSecretUsingIsGranted(): string
+    {
+        return 'you can see this secret only if user has right "CAN_EDIT"';
+    }
+
+    /**
+     * @Query()
+     * @Security("this.isAllowed(secret)")
+     */
+    public function getSecretUsingThis(string $secret): string
+    {
+        return 'you can see this secret only if isAllowed() returns true';
+    }
+
+    public function isAllowed(string $secret): bool
+    {
+        return $secret === '42';
+    }
 }

--- a/tests/Fixtures/TestControllerWithBadSecurity.php
+++ b/tests/Fixtures/TestControllerWithBadSecurity.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use ArrayObject;
+use TheCodingMachine\GraphQLite\Annotations\FailWith;
+use TheCodingMachine\GraphQLite\Annotations\Logged;
+use TheCodingMachine\GraphQLite\Annotations\Mutation;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Annotations\Right;
+use TheCodingMachine\GraphQLite\Annotations\Security;
+
+class TestControllerWithBadSecurity
+{
+    /**
+     * @Query
+     * @Security("this is not valid expression language")
+     */
+    public function testBadSecurity(): TestObject
+    {
+        return new TestObject('foo');
+    }
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -50,6 +50,7 @@ use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Schema;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
+use TheCodingMachine\GraphQLite\Security\SecurityExpressionLanguageProvider;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQLite\TypeGenerator;
@@ -69,7 +70,15 @@ class EndToEndTest extends TestCase
 
     public function setUp(): void
     {
-        $this->mainContainer = new Picotainer([
+        $this->mainContainer = $this->createContainer();
+    }
+
+    /**
+     * @param array<string, callable> $overloadedServices
+     */
+    public function createContainer(array $overloadedServices = []): ContainerInterface
+    {
+        $services = [
             Schema::class => function(ContainerInterface $container) {
                 return new Schema($container->get(QueryProviderInterface::class), $container->get(RecursiveTypeMapperInterface::class), $container->get(TypeResolver::class), null, $container->get(RootTypeMapperInterface::class));
             },
@@ -104,8 +113,9 @@ class EndToEndTest extends TestCase
             },
             SecurityFieldMiddleware::class => function(ContainerInterface $container) {
                 return new SecurityFieldMiddleware(
-                    new ExpressionLanguage(new Psr16Adapter(new ArrayCache())),
-                    $container->get(AuthenticationServiceInterface::class)
+                    new ExpressionLanguage(new Psr16Adapter(new ArrayCache()), [new SecurityExpressionLanguageProvider()]),
+                    $container->get(AuthenticationServiceInterface::class),
+                    $container->get(AuthorizationServiceInterface::class)
                 );
             },
             ArgumentResolver::class => function(ContainerInterface $container) {
@@ -144,7 +154,7 @@ class EndToEndTest extends TestCase
                     $container->get(NamingStrategyInterface::class),
                     $container->get(RecursiveTypeMapperInterface::class),
                     new ArrayCache()
-                    );
+                );
             },
             GlobTypeMapper::class.'2' => function(ContainerInterface $container) {
                 return new GlobTypeMapper('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Models',
@@ -217,11 +227,13 @@ class EndToEndTest extends TestCase
                     $container->get(ContainerParameterMapper::class)
                 ]);
             }
-        ]);
-        $this->mainContainer->get(TypeResolver::class)->registerSchema($this->mainContainer->get(Schema::class));
-        $this->mainContainer->get(TypeMapperInterface::class)->addTypeMapper($this->mainContainer->get(GlobTypeMapper::class));
-        $this->mainContainer->get(TypeMapperInterface::class)->addTypeMapper($this->mainContainer->get(GlobTypeMapper::class.'2'));
-        $this->mainContainer->get(TypeMapperInterface::class)->addTypeMapper($this->mainContainer->get(PorpaginasTypeMapper::class));
+        ];
+        $container = new Picotainer($overloadedServices + $services);
+        $container->get(TypeResolver::class)->registerSchema($container->get(Schema::class));
+        $container->get(TypeMapperInterface::class)->addTypeMapper($container->get(GlobTypeMapper::class));
+        $container->get(TypeMapperInterface::class)->addTypeMapper($container->get(GlobTypeMapper::class.'2'));
+        $container->get(TypeMapperInterface::class)->addTypeMapper($container->get(PorpaginasTypeMapper::class));
+        return $container;
     }
 
     public function testEndToEnd(): void
@@ -974,4 +986,129 @@ class EndToEndTest extends TestCase
             'nullableSecretPhrase2' => null
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
+
+    public function testEndToEndSecurityWithUser(): void
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        // Test with failWith attribute
+        $queryString = '
+        query {
+            secretUsingUser
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame('Access denied.', $result->toArray(Debug::RETHROW_UNSAFE_EXCEPTIONS)['errors'][0]['message']);
+    }
+
+    public function testEndToEndSecurityWithUserConnected(): void
+    {
+        $container = $this->createContainer([
+            AuthenticationServiceInterface::class => static function() {
+                return new class implements AuthenticationServiceInterface {
+                    public function isLogged(): bool
+                    {
+                        return true;
+                    }
+
+                    public function getUser(): ?object
+                    {
+                        $user = new stdClass();
+                        $user->bar = 42;
+                        return $user;
+                    }
+                };
+            },
+            AuthorizationServiceInterface::class => static function() {
+                return new class implements AuthorizationServiceInterface {
+                    public function isAllowed(string $right, $subject = null): bool
+                    {
+                        if ($right === 'CAN_EDIT' && $subject->bar == 42) {
+                            return true;
+                        }
+                        return false;
+                    }
+                };
+            },
+
+
+        ]);
+
+        /**
+         * @var Schema $schema
+         */
+        $schema = $container->get(Schema::class);
+
+        // Test with failWith attribute
+        $queryString = '
+        query {
+            secretUsingUser
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame('you can see this secret only if user.bar is set to 42', $result->toArray(Debug::RETHROW_UNSAFE_EXCEPTIONS)['data']['secretUsingUser']);
+
+
+        // Test with failWith attribute
+        $queryString = '
+        query {
+            secretUsingIsGranted
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame('you can see this secret only if user has right "CAN_EDIT"', $result->toArray(Debug::RETHROW_UNSAFE_EXCEPTIONS)['data']['secretUsingIsGranted']);
+    }
+
+    public function testEndToEndSecurityWithThis(): void
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            secretUsingThis(secret:"41")
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame('Access denied.', $result->toArray(Debug::RETHROW_UNSAFE_EXCEPTIONS)['errors'][0]['message']);
+
+        $queryString = '
+        query {
+            secretUsingThis(secret:"42")
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame('you can see this secret only if isAllowed() returns true', $result->toArray(Debug::RETHROW_UNSAFE_EXCEPTIONS)['data']['secretUsingThis']);
+    }
+
 }

--- a/tests/Middlewares/SecurityFieldMiddlewareTest.php
+++ b/tests/Middlewares/SecurityFieldMiddlewareTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Middlewares;
+
+use PHPUnit\Framework\TestCase;
+
+class SecurityFieldMiddlewareTest extends TestCase
+{
+
+    public function testGetThisFromCallable()
+    {
+        $callable = function() {
+
+        };
+        $object = SecurityFieldMiddleware::getThisFromCallable($callable);
+
+        $this->assertSame($this, $object);
+    }
+}

--- a/tests/Middlewares/SecurityFieldMiddlewareTest.php
+++ b/tests/Middlewares/SecurityFieldMiddlewareTest.php
@@ -15,5 +15,9 @@ class SecurityFieldMiddlewareTest extends TestCase
         $object = SecurityFieldMiddleware::getThisFromCallable($callable);
 
         $this->assertSame($this, $object);
+
+        $object = SecurityFieldMiddleware::getThisFromCallable('strpos');
+
+        $this->assertNull($object);
     }
 }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -6,8 +6,10 @@ use GraphQL\Error\Debug;
 use GraphQL\GraphQL;
 use GraphQL\Type\SchemaConfig;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\PhpFilesCache;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
@@ -65,6 +67,7 @@ class SchemaFactoryTest extends TestCase
                 ->addParameterMapper(new CompositeParameterMapper([]))
                 ->addQueryProviderFactory(new AggregateControllerQueryProviderFactory([], $container))
                 ->setSchemaConfig(new SchemaConfig())
+                ->setExpressionLanguage(new ExpressionLanguage(new Psr16Adapter(new ArrayCache())))
                 ->devMode()
                 ->prodMode();
 

--- a/tests/Security/FailAuthenticationServiceTest.php
+++ b/tests/Security/FailAuthenticationServiceTest.php
@@ -13,4 +13,11 @@ class FailAuthenticationServiceTest extends TestCase
         $this->expectException(SecurityNotImplementedException::class);
         $service->isLogged();
     }
+
+    public function testGetUser(): void
+    {
+        $service = new FailAuthenticationService();
+        $this->expectException(SecurityNotImplementedException::class);
+        $service->getUser();
+    }
 }

--- a/tests/Security/SecurityExpressionLanguageProviderTest.php
+++ b/tests/Security/SecurityExpressionLanguageProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\Psr16Adapter;
+use Symfony\Component\Cache\Simple\NullCache;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+class SecurityExpressionLanguageProviderTest extends TestCase
+{
+    public function testIsGranted(): void
+    {
+        $expressionLanguage = new ExpressionLanguage(new Psr16Adapter(new NullCache()), [new SecurityExpressionLanguageProvider()]);
+        $php = $expressionLanguage->compile('is_granted("Foo")');
+        $this->assertSame('$authorizationService->isAllowed("Foo", null)', $php);
+    }
+
+    public function testIsLogged(): void
+    {
+        $expressionLanguage = new ExpressionLanguage(new Psr16Adapter(new NullCache()), [new SecurityExpressionLanguageProvider()]);
+        $php = $expressionLanguage->compile('is_logged()');
+        $this->assertSame('$authenticationService->isLogged()', $php);
+    }
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,7 +2,8 @@
   "docs": {
     "Introduction": ["features"],
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
-    "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "authentication_authorization", "external_type_declaration", "input-types", "inheritance-interfaces"],
+    "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "external_type_declaration", "input-types", "inheritance-interfaces"],
+    "Security": ["authentication_authorization", "fine-grained-security", "implementing-security"],
     "Performance": ["query-plan", "prefetch-method"],
     "Advanced": ["file-uploads", "pagination", "custom-types", "field-middlewares", "extend_input_type", "multiple_output_types", "symfony-bundle-advanced", "internals", "troubleshooting", "migrating"],
     "Reference": ["annotations_reference"]


### PR DESCRIPTION
The @Security annotation is meant to handle complex right cases not covered by @Logged or @Right.

```php
    /**
     * @Query()
     * @Security("secret=='foo'", message="Wrong secret passed")
     */
    public function getSecretPhrase(string $secret): string
    {
        return 'you can see this secret only if passed parameter is "foo"';
    }
```

TODO list:

- [x] Make arguments of the method accessible
- [x] Make current user accessible
- [x] Add functions to check rights (is_allowed?)
- [x] Think about a mechanism similar to Symfony voters
- [x] Proper documentation
- [x] Test / improve exception messages (if Security annotation fails to compile / execute)