### PR TITLE
Adding a specific GraphQLException and GraphQLAggregateException to ease exception handling

### DIFF
--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -1,0 +1,184 @@
+---
+id: error-handling
+title: Error handling
+sidebar_label: Error handling
+---
+
+In GraphQL, when an error occurs, the server must add an "error" entry in the response.
+
+```json
+{
+  "errors": [
+    {
+      "message": "Name for character with ID 1002 could not be fetched.",
+      "locations": [ { "line": 6, "column": 7 } ],
+      "path": [ "hero", "heroFriends", 1, "name" ],
+      "extensions": {
+        "category": "Exception"
+      }
+    }
+  ]
+}
+```
+
+You can generate such errors with GraphQLite by throwing a `GraphQLException`.
+
+```php
+use TheCodingMachine\GraphQLite\Exceptions\GraphQLException;
+
+throw new GraphQLException("Exception message");
+```
+
+## HTTP response code
+
+By default, when you throw a `GraphQLException`, the HTTP status code will be 500.
+
+If your exception code is in the 4xx - 5xx range, the exception code will be used as an HTTP status code.
+
+```php
+// This exception will generate a HTTP 404 status code
+throw new GraphQLException("Not found", 404);
+```
+
+<div class="alert alert-info">GraphQL allows to have several errors for one request. If you have several 
+<code>GraphQLException</code> thrown for the same request, the HTTP status code used will be the highest one.</div>
+
+## Customizing the category
+
+By default, GraphQLite adds a "category" entry in the "extensions section". You can customize the category with the 
+4th parameter of the constructor:
+
+```php
+throw new GraphQLException("Not found", 404, null, "NOT_FOUND");
+```
+
+will generate:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Not found",
+      "extensions": {
+        "category": "NOT_FOUND"
+      }
+    }
+  ]
+}
+```
+
+## Customizing the extensions section
+
+You can customize the whole "extensions" section with the 5th parameter of the constructor:
+
+```php
+throw new GraphQLException("Field required", 400, null, "VALIDATION", ['field' => 'name']);
+```
+
+will generate:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Field required",
+      "extensions": {
+        "category": "VALIDATION",
+        "field": "name"
+      }
+    }
+  ]
+}
+```
+
+## Writing your own exceptions
+
+Rather that throwing the base `GraphQLException`, you should consider writing your own exception.
+
+Any exception that implements interface `TheCodingMachine\GraphQLite\Exceptions\GraphQLExceptionInterface` will be displayed
+in the GraphQL "errors" section.
+
+```php
+class ValidationException extends Exception implements GraphQLExceptionInterface
+{
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     */
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     */
+    public function getCategory(): string
+    {
+        return 'VALIDATION';
+    }
+
+    /**
+     * Returns the "extensions" object attached to the GraphQL error.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensions(): array
+    {
+        return [];
+    }
+}
+```
+
+## Many errors for one exception
+
+Sometimes, you need to display several errors in the response. But of course, at any given point in your code, you can
+throw only one exception.
+
+If you want to display several exceptions, you can bundle these exceptions in a `GraphQLAggregateException` that you can
+throw.
+
+```php
+use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;
+
+/**
+ * @Query
+ */
+public function createProduct(string $name, float $price): Product
+{
+    $exceptions = new GraphQLAggregateException();
+
+    if ($name === '') {
+        $exceptions->add(new GraphQLException('Name cannot be empty', 400, null, 'VALIDATION));
+    }
+    if ($price <= 0) {
+        $exceptions->add(new GraphQLException('Price must be positive', 400, null, 'VALIDATION));
+    }
+
+    if ($exceptions->hasExceptions()) {
+        throw $exceptions;
+    }
+}
+```
+
+## Webonyx exceptions
+
+GraphQLite is based on the wonderful webonyx/GraphQL-PHP library. Therefore, the Webonyx exception mechanism can
+also be used in GraphQLite. This means you can throw a `GraphQL\Error\Error` exception or any exception implementing
+[`GraphQL\Error\ClientAware` interface](http://webonyx.github.io/graphql-php/error-handling/#errors-in-graphql)
+
+Actually, the `TheCodingMachine\GraphQLite\Exceptions\GraphQLExceptionInterface` extends Webonyx's `ClientAware` interface.
+
+## Behaviour of exceptions that do not implement ClientAware
+
+If an exception that does not implement `ClientAware` is thrown, by default, GraphQLite will not catch it.
+
+The exception will propagate to your framework error handler/middleware that is in charge of displaying the classical error page.
+
+You can [change the underlying behaviour of Webonyx to catch any exception and turn them into GraphQL errors](http://webonyx.github.io/graphql-php/error-handling/#debugging-tools).
+The way you adjust the error settings depends on the framework you are using ([Symfony](symfony-bundle.md), [Laravel](laravel-package.md)).
+
+<div class="alert alert-info">To be clear: we strongly discourage changing this setting. We strongly believe that the
+default "RETHROW_UNSAFE_EXCEPTIONS" setting of Webonyx is the only sane setting (only putting in "errors" section exceptions 
+designed for GraphQL).</div>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,9 @@ parameters:
         - "#Parameter \\#2 \\$inputTypeNode of static method GraphQL\\\\Utils\\\\AST::typeFromAST() expects GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode, GraphQL\\\\Language\\\\AST\\\\ListTypeNode|GraphQL\\\\Language\\\\AST\\\\NameNode|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode given.#"
         - "#PHPDoc tag @throws with type Psr\\\\SimpleCache\\\\InvalidArgumentException is not subtype of Throwable#"
         - '#Variable \$context might not be defined.#'
+        -
+           message: '#Parameter .* of class GraphQL\\Error\\Error constructor expects#'
+           path: src/Exceptions/WebonyxErrorHandler.php
         #-
         #  message: '#If condition is always true#'
         #  path: src/Middlewares/SecurityFieldMiddleware.php

--- a/src/Annotations/Factory.php
+++ b/src/Annotations/Factory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Annotations;
 
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 
 /**
  * Factories are methods used to declare GraphQL input types.
@@ -33,7 +33,7 @@ class Factory
         $this->default = $attributes['default'] ?? ! isset($attributes['name']);
 
         if ($this->name === null && $this->default === false) {
-            throw new GraphQLException('A @Factory that has "default=false" attribute must be given a name (i.e. add a name="FooBarInput" attribute).');
+            throw new GraphQLRuntimeException('A @Factory that has "default=false" attribute must be given a name (i.e. add a name="FooBarInput" attribute).');
         }
     }
 

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -6,7 +6,7 @@ namespace TheCodingMachine\GraphQLite\Annotations;
 
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use function class_exists;
 use function interface_exists;
 use function ltrim;
@@ -97,10 +97,10 @@ class Type
         }
 
         if ($this->default === false) {
-            throw new GraphQLException('Problem in annotation @Type for interface "' . $class . '": you cannot use the default="false" attribute on interfaces');
+            throw new GraphQLRuntimeException('Problem in annotation @Type for interface "' . $class . '": you cannot use the default="false" attribute on interfaces');
         }
         if ($this->disableInheritance === true) {
-            throw new GraphQLException('Problem in annotation @Type for interface "' . $class . '": you cannot use the disableInheritance="true" attribute on interfaces');
+            throw new GraphQLRuntimeException('Problem in annotation @Type for interface "' . $class . '": you cannot use the disableInheritance="true" attribute on interfaces');
         }
     }
 

--- a/src/Exceptions/GraphQLAggregateException.php
+++ b/src/Exceptions/GraphQLAggregateException.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Exceptions;
+
+use Exception;
+use GraphQL\Error\ClientAware;
+use Throwable;
+
+class GraphQLAggregateException extends Exception implements GraphQLAggregateExceptionInterface
+{
+    /** @var (ClientAware&Throwable)[] */
+    private $exceptions = [];
+
+    /**
+     * @param (ClientAware&Throwable)[] $exceptions
+     */
+    public function __construct(iterable $exceptions = [])
+    {
+        parent::__construct('Many exceptions have be thrown:');
+        foreach ($exceptions as $exception) {
+            $this->add($exception);
+        }
+    }
+
+    /**
+     * @param ClientAware&Throwable $exception
+     */
+    public function add(ClientAware $exception): void
+    {
+        $this->exceptions[] = $exception;
+        $this->message .= "\n" . $exception->getMessage();
+    }
+
+    /**
+     * @return (ClientAware&Throwable)[]
+     */
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+
+    public function hasExceptions(): bool
+    {
+        return ! empty($this->exceptions);
+    }
+}

--- a/src/Exceptions/GraphQLAggregateExceptionInterface.php
+++ b/src/Exceptions/GraphQLAggregateExceptionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Exceptions;
+
+use GraphQL\Error\ClientAware;
+use Throwable;
+
+/**
+ * Exceptions implementing this interface can aggregate many GraphQL exceptions together.
+ * Use this is you want to return more than one GraphQL error by throwing only one exception.
+ */
+interface GraphQLAggregateExceptionInterface extends Throwable
+{
+    /**
+     * @return (ClientAware&Throwable)[]
+     */
+    public function getExceptions(): array;
+}

--- a/src/Exceptions/GraphQLException.php
+++ b/src/Exceptions/GraphQLException.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Exceptions;
+
+use Exception;
+use Throwable;
+
+class GraphQLException extends Exception implements GraphQLExceptionInterface
+{
+    /** @var string */
+    private $category;
+    /** @var array<string, mixed> */
+    private $extensions;
+
+    /**
+     * @param array<string, mixed> $extensions
+     */
+    public function __construct(string $message, int $code = 0, ?Throwable $previous = null, string $category = 'Exception', array $extensions = [])
+    {
+        parent::__construct($message, $code, $previous);
+        $this->category = $category;
+        $this->extensions = $extensions;
+    }
+
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     */
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     */
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    /**
+     * Returns the "extensions" object attached to the GraphQL error.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensions(): array
+    {
+        return $this->extensions;
+    }
+}

--- a/src/Exceptions/GraphQLExceptionInterface.php
+++ b/src/Exceptions/GraphQLExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Exceptions;
+
+use GraphQL\Error\ClientAware;
+use Throwable;
+
+/**
+ * Exceptions implementing this interface are caught by GraphQLite and displayed as "errors" in the GraphQL response.
+ */
+interface GraphQLExceptionInterface extends ClientAware, Throwable
+{
+    /**
+     * Returns the "extensions" object attached to the GraphQL error.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExtensions(): array;
+}

--- a/src/Exceptions/WebonyxErrorHandler.php
+++ b/src/Exceptions/WebonyxErrorHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Exceptions;
+
+use GraphQL\Error\ClientAware;
+use GraphQL\Error\Error;
+use GraphQL\Error\FormattedError;
+use function array_map;
+use function array_merge;
+
+/**
+ * A custom error handler and error formatter for Webonyx that can read the GraphQLAggregateExceptionInterface
+ * and the GraphQLExceptionInterface.
+ */
+final class WebonyxErrorHandler
+{
+    /**
+     * @return mixed[]
+     */
+    public static function errorFormatter(Error $error): array
+    {
+        $formattedError = FormattedError::createFromException($error);
+        $previous = $error->getPrevious();
+        if ($previous instanceof GraphQLExceptionInterface && ! empty($previous->getExtensions())) {
+            $formattedError['extensions'] += $previous->getExtensions();
+        }
+
+        return $formattedError;
+    }
+
+    /**
+     * @param Error[] $errors
+     *
+     * @return mixed[]
+     */
+    public static function errorHandler(array $errors, callable $formatter): array
+    {
+        $formattedErrors = [];
+        foreach ($errors as $error) {
+            $previous = $error->getPrevious();
+            if ($previous instanceof GraphQLAggregateExceptionInterface) {
+                $exceptions = $previous->getExceptions();
+                $innerErrors = array_map(static function (ClientAware $clientAware) use ($error) {
+                    // Let's build a new error at the same spot than the aggregated one, but for the wrapped exception.
+                    $extensions = $clientAware instanceof GraphQLExceptionInterface ? $clientAware->getExtensions() : [];
+
+                    return new Error($error->getMessage(), $error->getNodes(), $error->getSource(), $error->getPositions(), $error->getPath(), $clientAware, $extensions);
+                }, $exceptions);
+
+                $formattedInnerErrors = self::errorHandler($innerErrors, $formatter);
+
+                $formattedErrors = array_merge($formattedErrors, $formattedInnerErrors);
+            } else {
+                $formattedErrors[] = self::errorFormatter($error);
+            }
+        }
+
+        return $formattedErrors;
+    }
+}

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -255,7 +255,7 @@ class FieldsBuilder
                     try {
                         $prefetchRefMethod = $refClass->getMethod($prefetchMethodName);
                     } catch (ReflectionException $e) {
-                        throw InvalidPrefetchMethodException::methodNotFound($refMethod, $refClass, $prefetchMethodName, $e);
+                        throw InvalidPrefetchMethodRuntimeException::methodNotFound($refMethod, $refClass, $prefetchMethodName, $e);
                     }
 
                     $prefetchParameters = $prefetchRefMethod->getParameters();
@@ -276,7 +276,7 @@ class FieldsBuilder
             if ($prefetchMethodName !== null) {
                 $secondParameter = array_shift($parameters);
                 if ($secondParameter === null) {
-                    throw InvalidPrefetchMethodException::prefetchDataIgnored($prefetchRefMethod, $injectSource);
+                    throw InvalidPrefetchMethodRuntimeException::prefetchDataIgnored($prefetchRefMethod, $injectSource);
                 }
             }
 
@@ -462,7 +462,7 @@ class FieldsBuilder
      *
      * @return array<string, ParameterInterface>
      *
-     * @throws MissingTypeHintException
+     * @throws MissingTypeHintRuntimeException
      */
     private function mapParameters(array $refParameters, DocBlock $docBlock): array
     {

--- a/src/GraphQLRuntimeException.php
+++ b/src/GraphQLRuntimeException.php
@@ -6,6 +6,6 @@ namespace TheCodingMachine\GraphQLite;
 
 use RuntimeException;
 
-class GraphQLException extends RuntimeException
+class GraphQLRuntimeException extends RuntimeException
 {
 }

--- a/src/InputTypeUtils.php
+++ b/src/InputTypeUtils.php
@@ -55,11 +55,11 @@ class InputTypeUtils
     {
         $returnType = $refMethod->getReturnType();
         if ($returnType === null) {
-            throw MissingTypeHintException::missingReturnType($refMethod);
+            throw MissingTypeHintRuntimeException::missingReturnType($refMethod);
         }
 
         if ($returnType->allowsNull()) {
-            throw MissingTypeHintException::nullableReturnType($refMethod);
+            throw MissingTypeHintRuntimeException::nullableReturnType($refMethod);
         }
 
         $type = (string) $returnType;
@@ -70,7 +70,7 @@ class InputTypeUtils
         Assert::notNull($phpdocType);
         $phpdocType = $this->resolveSelf($phpdocType, $refMethod->getDeclaringClass());
         if (! $phpdocType instanceof Object_) {
-            throw MissingTypeHintException::invalidReturnType($refMethod);
+            throw MissingTypeHintRuntimeException::invalidReturnType($refMethod);
         }
 
         $fqsen = $phpdocType->getFqsen();

--- a/src/InvalidDocBlockRuntimeException.php
+++ b/src/InvalidDocBlockRuntimeException.php
@@ -6,7 +6,7 @@ namespace TheCodingMachine\GraphQLite;
 
 use ReflectionMethod;
 
-class InvalidDocBlockException extends GraphQLException
+class InvalidDocBlockRuntimeException extends GraphQLRuntimeException
 {
     public static function tooManyReturnTags(ReflectionMethod $refMethod): self
     {

--- a/src/InvalidPrefetchMethodRuntimeException.php
+++ b/src/InvalidPrefetchMethodRuntimeException.php
@@ -8,7 +8,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 
-class InvalidPrefetchMethodException extends GraphQLException
+class InvalidPrefetchMethodRuntimeException extends GraphQLRuntimeException
 {
     public static function methodNotFound(ReflectionMethod $annotationMethod, ReflectionClass $reflectionClass, string $methodName, ReflectionException $previous): self
     {

--- a/src/Mappers/Parameters/CannotHideParameterRuntimeException.php
+++ b/src/Mappers/Parameters/CannotHideParameterRuntimeException.php
@@ -6,10 +6,10 @@ namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
 
 use ReflectionMethod;
 use ReflectionParameter;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use Webmozart\Assert\Assert;
 
-class CannotHideParameterException extends GraphQLException
+class CannotHideParameterRuntimeException extends GraphQLRuntimeException
 {
     public static function needDefaultValue(ReflectionParameter $parameter): self
     {

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -30,7 +30,7 @@ use ReflectionType;
 use TheCodingMachine\GraphQLite\Annotations\HideParameter;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotations;
 use TheCodingMachine\GraphQLite\Annotations\UseInputType;
-use TheCodingMachine\GraphQLite\InvalidDocBlockException;
+use TheCodingMachine\GraphQLite\InvalidDocBlockRuntimeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
@@ -38,7 +38,7 @@ use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Parameters\DefaultValueParameter;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
-use TheCodingMachine\GraphQLite\TypeMappingException;
+use TheCodingMachine\GraphQLite\TypeMappingRuntimeException;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
@@ -91,8 +91,8 @@ class TypeHandler implements ParameterHandlerInterface
         try {
             /** @var GraphQLType&OutputType $type */
             $type = $this->mapType($phpdocType, $docBlockReturnType, $returnType ? $returnType->allowsNull() : false, false, $refMethod, $docBlockObj);
-        } catch (TypeMappingException $e) {
-            throw TypeMappingException::wrapWithReturnInfo($e, $refMethod);
+        } catch (TypeMappingRuntimeException $e) {
+            throw TypeMappingRuntimeException::wrapWithReturnInfo($e, $refMethod);
         } catch (CannotMapTypeExceptionInterface $e) {
             $e->addReturnInfo($refMethod);
             throw $e;
@@ -106,7 +106,7 @@ class TypeHandler implements ParameterHandlerInterface
         /** @var Return_[] $returnTypeTags */
         $returnTypeTags = $docBlock->getTagsByName('return');
         if (count($returnTypeTags) > 1) {
-            throw InvalidDocBlockException::tooManyReturnTags($refMethod);
+            throw InvalidDocBlockRuntimeException::tooManyReturnTags($refMethod);
         }
         $docBlockReturnType = null;
         if (isset($returnTypeTags[0])) {
@@ -121,7 +121,7 @@ class TypeHandler implements ParameterHandlerInterface
         $hideParameter = $parameterAnnotations->getAnnotationByType(HideParameter::class);
         if ($hideParameter) {
             if ($parameter->isDefaultValueAvailable() === false) {
-                throw CannotHideParameterException::needDefaultValue($parameter);
+                throw CannotHideParameterRuntimeException::needDefaultValue($parameter);
             }
 
             return new DefaultValueParameter($parameter->getDefaultValue());
@@ -154,8 +154,8 @@ class TypeHandler implements ParameterHandlerInterface
                 $declaringFunction = $parameter->getDeclaringFunction();
                 Assert::isInstanceOf($declaringFunction, ReflectionMethod::class, 'Parameter of a function passed. Only parameters of methods are supported.');
                 $type = $this->mapType($phpdocType, $paramTagType, $allowsNull || $parameter->isDefaultValueAvailable(), true, $declaringFunction, $docBlock, $parameter->getName());
-            } catch (TypeMappingException $e) {
-                throw TypeMappingException::wrapWithParamInfo($e, $parameter);
+            } catch (TypeMappingRuntimeException $e) {
+                throw TypeMappingRuntimeException::wrapWithParamInfo($e, $parameter);
             } catch (CannotMapTypeExceptionInterface $e) {
                 $e->addParamInfo($parameter);
                 throw $e;
@@ -190,7 +190,7 @@ class TypeHandler implements ParameterHandlerInterface
                 if (! $isNullable && (! $graphQlType instanceof ResolvableMutableInputObjectType || $graphQlType->isInstantiableWithoutParameters() === false)) {
                     $graphQlType = GraphQLType::nonNull($graphQlType);
                 }
-            } catch (TypeMappingException | CannotMapTypeExceptionInterface $e) {
+            } catch (TypeMappingRuntimeException | CannotMapTypeExceptionInterface $e) {
                 // Is the type iterable? If yes, let's analyze the docblock
                 // TODO: it would be better not to go through an exception for this.
                 if (! ($type instanceof Object_)) {
@@ -214,7 +214,7 @@ class TypeHandler implements ParameterHandlerInterface
     private function mapDocBlockType(Type $type, ?Type $docBlockType, bool $isNullable, bool $mapToInputType, ReflectionMethod $refMethod, DocBlock $docBlockObj, ?string $argumentName = null): GraphQLType
     {
         if ($docBlockType === null) {
-            throw TypeMappingException::createFromType($type);
+            throw TypeMappingRuntimeException::createFromType($type);
         }
         if (! $isNullable) {
             // Let's check a "null" value in the docblock
@@ -223,7 +223,7 @@ class TypeHandler implements ParameterHandlerInterface
 
         $filteredDocBlockTypes = $this->typesWithoutNullable($docBlockType);
         if (empty($filteredDocBlockTypes)) {
-            throw TypeMappingException::createFromType($type);
+            throw TypeMappingRuntimeException::createFromType($type);
         }
 
         $unionTypes    = [];
@@ -231,7 +231,7 @@ class TypeHandler implements ParameterHandlerInterface
         foreach ($filteredDocBlockTypes as $singleDocBlockType) {
             try {
                 $unionTypes[] = $this->toGraphQlType($this->dropNullableType($singleDocBlockType), null, $mapToInputType, $refMethod, $docBlockObj, $argumentName);
-            } catch (TypeMappingException | CannotMapTypeExceptionInterface $e) {
+            } catch (TypeMappingRuntimeException | CannotMapTypeExceptionInterface $e) {
                 // We have several types. It is ok not to be able to match one.
                 $lastException = $e;
             }
@@ -280,7 +280,7 @@ class TypeHandler implements ParameterHandlerInterface
     private function mapIteratorDocBlockType(Type $type, ?Type $docBlockType, bool $isNullable, ReflectionMethod $refMethod, DocBlock $docBlockObj, ?string $argumentName = null): GraphQLType
     {
         if ($docBlockType === null) {
-            throw TypeMappingException::createFromType($type);
+            throw TypeMappingRuntimeException::createFromType($type);
         }
         if (! $isNullable) {
             // Let's check a "null" value in the docblock
@@ -289,7 +289,7 @@ class TypeHandler implements ParameterHandlerInterface
 
         $filteredDocBlockTypes = $this->typesWithoutNullable($docBlockType);
         if (empty($filteredDocBlockTypes)) {
-            throw TypeMappingException::createFromType($type);
+            throw TypeMappingRuntimeException::createFromType($type);
         }
 
         $unionTypes    = [];
@@ -308,7 +308,7 @@ class TypeHandler implements ParameterHandlerInterface
                 // TODO: add here a scan of the $type variable and do stuff if it is iterable.
                 // TODO: remove the iterator type if specified in the docblock (@return Iterator|User[])
                 // TODO: check there is at least one array (User[])
-            } catch (TypeMappingException | CannotMapTypeExceptionInterface $e) {
+            } catch (TypeMappingRuntimeException | CannotMapTypeExceptionInterface $e) {
                 // We have several types. It is ok not to be able to match one.
                 $lastException = $e;
             }
@@ -351,7 +351,7 @@ class TypeHandler implements ParameterHandlerInterface
             $mappedType = $this->rootTypeMapper->toGraphQLOutputType($type, $subType, $refMethod, $docBlockObj);
         }
         if ($mappedType === null) {
-            throw TypeMappingException::createFromType($type);
+            throw TypeMappingRuntimeException::createFromType($type);
         }
 
         return $mappedType;

--- a/src/Mappers/Root/BaseTypeMapper.php
+++ b/src/Mappers/Root/BaseTypeMapper.php
@@ -25,7 +25,7 @@ use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
 use Psr\Http\Message\UploadedFileInterface;
 use ReflectionMethod;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Types\DateTimeType;
@@ -142,7 +142,7 @@ class BaseTypeMapper implements RootTypeMapperInterface
                 case '\\' . UploadedFileInterface::class:
                     return self::getUploadType();
                 case '\\DateTime':
-                    throw new GraphQLException('Type-hinting a parameter against DateTime is not allowed. Please use the DateTimeImmutable type instead.');
+                    throw new GraphQLRuntimeException('Type-hinting a parameter against DateTime is not allowed. Please use the DateTimeImmutable type instead.');
                 case '\\' . ID::class:
                     return GraphQLType::id();
                 default:

--- a/src/Mappers/StaticClassListTypeMapper.php
+++ b/src/Mappers/StaticClassListTypeMapper.php
@@ -8,7 +8,7 @@ use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\AnnotationReader;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
@@ -55,7 +55,7 @@ final class StaticClassListTypeMapper extends AbstractTypeMapper
             $this->classes = [];
             foreach ($this->classList as $className) {
                 if (! class_exists($className) && ! interface_exists($className)) {
-                    throw new GraphQLException('Could not find class "' . $className . '"');
+                    throw new GraphQLRuntimeException('Could not find class "' . $className . '"');
                 }
                 $this->classes[$className] = new ReflectionClass($className);
             }

--- a/src/MissingTypeHintRuntimeException.php
+++ b/src/MissingTypeHintRuntimeException.php
@@ -7,7 +7,7 @@ namespace TheCodingMachine\GraphQLite;
 use ReflectionMethod;
 use function sprintf;
 
-class MissingTypeHintException extends GraphQLException
+class MissingTypeHintRuntimeException extends GraphQLRuntimeException
 {
     public static function missingReturnType(ReflectionMethod $method): self
     {

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -66,7 +66,7 @@ class QueryField extends FieldDefinition
 
             try {
                 $this->assertReturnType($result);
-            } catch (TypeMismatchException $e) {
+            } catch (TypeMismatchRuntimeException $e) {
                 $class = $method[0];
                 if (is_object($class)) {
                     $class = get_class($class);

--- a/src/ResolveUtils.php
+++ b/src/ResolveUtils.php
@@ -25,7 +25,7 @@ class ResolveUtils
     public static function assertInnerReturnType($result, Type $type): void
     {
         if ($type instanceof NonNull && $result === null) {
-            throw TypeMismatchException::unexpectedNullValue();
+            throw TypeMismatchRuntimeException::unexpectedNullValue();
         }
         if ($result === null) {
             return;
@@ -33,7 +33,7 @@ class ResolveUtils
         $type = self::removeNonNull($type);
         if ($type instanceof ListOfType) {
             if (! is_iterable($result)) {
-                throw TypeMismatchException::expectedIterable($result);
+                throw TypeMismatchRuntimeException::expectedIterable($result);
             }
             // If this is an array, we can scan it and check the types.
             if (is_array($result)) {
@@ -49,7 +49,7 @@ class ResolveUtils
         }
 
         if (! is_object($result)) {
-            throw TypeMismatchException::expectedObject($result);
+            throw TypeMismatchRuntimeException::expectedObject($result);
         }
         // TODO: it would be great to check if this is the actual object type we were expecting
     }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -346,7 +346,7 @@ class SchemaFactory
         $inputTypeGenerator = new InputTypeGenerator($inputTypeUtils, $fieldsBuilder);
 
         if (empty($this->typeNamespaces) && empty($this->typeMappers) && empty($this->typeMapperFactories)) {
-            throw new GraphQLException('Cannot create schema: no namespace for types found (You must call the SchemaFactory::addTypeNamespace() at least once).');
+            throw new GraphQLRuntimeException('Cannot create schema: no namespace for types found (You must call the SchemaFactory::addTypeNamespace() at least once).');
         }
 
         foreach ($this->typeNamespaces as $typeNamespace) {
@@ -409,7 +409,7 @@ class SchemaFactory
         }
 
         if ($queryProviders === []) {
-            throw new GraphQLException('Cannot create schema: no namespace for controllers found (You must call the SchemaFactory::addControllerNamespace() at least once).');
+            throw new GraphQLRuntimeException('Cannot create schema: no namespace for controllers found (You must call the SchemaFactory::addControllerNamespace() at least once).');
         }
 
         $aggregateQueryProvider = new AggregateQueryProvider($queryProviders);

--- a/src/TypeGenerator.php
+++ b/src/TypeGenerator.php
@@ -75,7 +75,7 @@ class TypeGenerator
 
         if (! $typeField->isSelfType()) {
             if (! $refTypeClass->isInstantiable()) {
-                throw new GraphQLException('Class "' . $annotatedObjectClassName . '" annotated with @Type(class="' . $typeField->getClass() . '") must be instantiable.');
+                throw new GraphQLRuntimeException('Class "' . $annotatedObjectClassName . '" annotated with @Type(class="' . $typeField->getClass() . '") must be instantiable.');
             }
             $annotatedObject = $this->container->get($annotatedObjectClassName);
             $isInterface = interface_exists($typeField->getClass());

--- a/src/TypeMappingRuntimeException.php
+++ b/src/TypeMappingRuntimeException.php
@@ -18,7 +18,7 @@ use Webmozart\Assert\Assert;
 use function get_class;
 use function sprintf;
 
-class TypeMappingException extends GraphQLException
+class TypeMappingRuntimeException extends GraphQLRuntimeException
 {
     /** @var Type */
     private $type;
@@ -31,7 +31,7 @@ class TypeMappingException extends GraphQLException
         return $e;
     }
 
-    public static function wrapWithParamInfo(TypeMappingException $previous, ReflectionParameter $parameter): TypeMappingException
+    public static function wrapWithParamInfo(TypeMappingRuntimeException $previous, ReflectionParameter $parameter): TypeMappingRuntimeException
     {
         $declaringClass = $parameter->getDeclaringClass();
         Assert::notNull($declaringClass, 'Parameter passed must be a parameter of a method, not a parameter of a function.');
@@ -56,14 +56,14 @@ class TypeMappingException extends GraphQLException
             );
         } else {
             if (! ($previous->type instanceof Object_)) {
-                throw new GraphQLException("Unexpected type in TypeMappingException. Got '" . get_class($previous->type) . '"');
+                throw new GraphQLRuntimeException("Unexpected type in TypeMappingException. Got '" . get_class($previous->type) . '"');
             }
 
             $fqcn     = (string) $previous->type->getFqsen();
             $refClass = new ReflectionClass($fqcn);
             // Note : $refClass->isIterable() is only accessible in PHP 7.2
             if (! $refClass->implementsInterface(Iterator::class) && ! $refClass->implementsInterface(IteratorAggregate::class)) {
-                throw new GraphQLException("Unexpected type in TypeMappingException. Got a non iterable '" . $fqcn . '"');
+                throw new GraphQLRuntimeException("Unexpected type in TypeMappingException. Got a non iterable '" . $fqcn . '"');
             }
 
             $message = sprintf(
@@ -83,7 +83,7 @@ class TypeMappingException extends GraphQLException
         return $e;
     }
 
-    public static function wrapWithReturnInfo(TypeMappingException $previous, ReflectionMethod $method): TypeMappingException
+    public static function wrapWithReturnInfo(TypeMappingRuntimeException $previous, ReflectionMethod $method): TypeMappingRuntimeException
     {
         if ($previous->type instanceof Array_ || $previous->type instanceof Iterable_) {
             $typeStr = $previous->type instanceof Array_ ? 'array' : 'iterable';
@@ -101,14 +101,14 @@ class TypeMappingException extends GraphQLException
             );
         } else {
             if (! ($previous->type instanceof Object_)) {
-                throw new GraphQLException("Unexpected type in TypeMappingException. Got '" . get_class($previous->type) . '"');
+                throw new GraphQLRuntimeException("Unexpected type in TypeMappingException. Got '" . get_class($previous->type) . '"');
             }
 
             $fqcn     = (string) $previous->type->getFqsen();
             $refClass = new ReflectionClass($fqcn);
             // Note : $refClass->isIterable() is only accessible in PHP 7.2
             if (! $refClass->implementsInterface(Iterator::class) && ! $refClass->implementsInterface(IteratorAggregate::class)) {
-                throw new GraphQLException("Unexpected type in TypeMappingException. Got a non iterable '" . $fqcn . '"');
+                throw new GraphQLRuntimeException("Unexpected type in TypeMappingException. Got a non iterable '" . $fqcn . '"');
             }
 
             $message = sprintf(

--- a/src/TypeMismatchRuntimeException.php
+++ b/src/TypeMismatchRuntimeException.php
@@ -9,7 +9,7 @@ use function gettype;
 /**
  * An exception thrown when a resolver returns a value that is not compatible with the GraphQL type.
  */
-class TypeMismatchException extends GraphQLException
+class TypeMismatchRuntimeException extends GraphQLRuntimeException
 {
     public static function unexpectedNullValue(): self
     {

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -33,7 +33,7 @@ class TypeRegistry
     public function registerType(NamedType $type): void
     {
         if (isset($this->outputTypes[$type->name])) {
-            throw new GraphQLException('Type "' . $type->name . '" is already registered');
+            throw new GraphQLRuntimeException('Type "' . $type->name . '" is already registered');
         }
         $this->outputTypes[$type->name] = $type;
     }
@@ -49,7 +49,7 @@ class TypeRegistry
     public function getType(string $typeName): NamedType
     {
         if (! isset($this->outputTypes[$typeName])) {
-            throw new GraphQLException('Could not find type "' . $typeName . '" in registry');
+            throw new GraphQLRuntimeException('Could not find type "' . $typeName . '" in registry');
         }
 
         return $this->outputTypes[$typeName];
@@ -59,7 +59,7 @@ class TypeRegistry
     {
         $type = $this->getType($typeName);
         if (! $type instanceof MutableObjectType) {
-            throw new GraphQLException('Expected GraphQL type "' . $typeName . '" to be an MutableObjectType. Got a ' . get_class($type));
+            throw new GraphQLRuntimeException('Expected GraphQL type "' . $typeName . '" to be an MutableObjectType. Got a ' . get_class($type));
         }
 
         return $type;
@@ -72,7 +72,7 @@ class TypeRegistry
     {
         $type = $this->getType($typeName);
         if (! $type instanceof MutableInterface || (! $type instanceof MutableInterfaceType && ! $type instanceof MutableObjectType)) {
-            throw new GraphQLException('Expected GraphQL type "' . $typeName . '" to be either a MutableObjectType or a MutableInterfaceType. Got a ' . get_class($type));
+            throw new GraphQLRuntimeException('Expected GraphQL type "' . $typeName . '" to be either a MutableObjectType or a MutableInterfaceType. Got a ' . get_class($type));
         }
 
         return $type;

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -11,7 +11,7 @@ use GraphQL\Error\InvariantViolation;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\Utils;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 
 class DateTimeType extends ScalarType
 {
@@ -69,6 +69,6 @@ class DateTimeType extends ScalarType
         }
 
         // Intentionally without message, as all information already in wrapped Exception
-        throw new GraphQLException();
+        throw new GraphQLRuntimeException();
     }
 }

--- a/src/Types/TypeAnnotatedInterfaceType.php
+++ b/src/Types/TypeAnnotatedInterfaceType.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Reflection\ReflectionInterfaceUtils;
 use function array_merge;

--- a/tests/Annotations/FactoryTest.php
+++ b/tests/Annotations/FactoryTest.php
@@ -3,14 +3,14 @@
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use PHPUnit\Framework\TestCase;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 
 class FactoryTest extends TestCase
 {
 
     public function testExceptionInConstruct(): void
     {
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         new Factory(['default'=>false]);
     }
 }

--- a/tests/Annotations/TypeTest.php
+++ b/tests/Annotations/TypeTest.php
@@ -5,7 +5,7 @@ namespace TheCodingMachine\GraphQLite\Annotations;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 
 class TypeTest extends TestCase
 {
@@ -26,7 +26,7 @@ class TypeTest extends TestCase
     public function testException2()
     {
         $type = new Type(['default'=>false]);
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $this->expectExceptionMessage('Problem in annotation @Type for interface "TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface": you cannot use the default="false" attribute on interfaces');
         $type->setClass(FooInterface::class);
     }
@@ -34,7 +34,7 @@ class TypeTest extends TestCase
     public function testException3()
     {
         $type = new Type(['disableInheritance'=>true]);
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $this->expectExceptionMessage('Problem in annotation @Type for interface "TheCodingMachine\GraphQLite\Fixtures\AnnotatedInterfaces\Types\FooInterface": you cannot use the disableInheritance="true" attribute on interfaces');
         $type->setClass(FooInterface::class);
     }

--- a/tests/Exceptions/ErrorHandlerTest.php
+++ b/tests/Exceptions/ErrorHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Exceptions;
+
+use GraphQL\Error\Error;
+use PHPUnit\Framework\TestCase;
+
+class ErrorHandlerTest extends TestCase
+{
+
+    public function testErrorFormatter()
+    {
+        $exception = new GraphQLException('foo', 0, null, 'MyCategory', ['field' => 'foo']);
+        $error = new Error('foo', null, null, null, null, $exception);
+        $formattedError = WebonyxErrorHandler::errorFormatter($error);
+
+        $this->assertSame([
+            'message' => 'foo',
+            'extensions' => [
+                'category' => 'MyCategory',
+                'field' => 'foo'
+            ]
+        ], $formattedError);
+    }
+
+    public function testErrorHandler()
+    {
+        $exception = new GraphQLException('foo', 0, null, 'MyCategory', ['field' => 'foo']);
+        $error = new Error('foo', null, null, null, null, $exception);
+        $aggregateException = new GraphQLAggregateException();
+        $aggregateException->add($exception);
+        $aggregateException->add($exception);
+        $aggregateError = new Error('foo', null, null, null, null, $aggregateException);
+        $formattedError = WebonyxErrorHandler::errorHandler([$error, $aggregateError], [WebonyxErrorHandler::class, 'errorFormatter']);
+
+        $expectedError = [
+            'message' => 'foo',
+            'extensions' => [
+                'category' => 'MyCategory',
+                'field' => 'foo'
+            ]
+        ];
+
+        $this->assertSame([
+            [
+                'message' => 'foo',
+                'extensions' => [
+                    'category' => 'MyCategory',
+                    'field' => 'foo'
+                ]
+            ],
+            [
+                'message' => 'foo',
+                'extensions' => [
+                    'field' => 'foo',
+                    'category' => 'MyCategory',
+                ]
+            ],
+            [
+                'message' => 'foo',
+                'extensions' => [
+                    'field' => 'foo',
+                    'category' => 'MyCategory',
+                ]
+            ]], $formattedError);
+    }
+}

--- a/tests/Exceptions/GraphQLAggregateExceptionTest.php
+++ b/tests/Exceptions/GraphQLAggregateExceptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Exceptions;
+
+use GraphQL\Error\Error;
+use PHPUnit\Framework\TestCase;
+
+class GraphQLAggregateExceptionTest extends TestCase
+{
+
+    public function testAggregateException()
+    {
+        $error = new Error('foo');
+        $exceptions = new GraphQLAggregateException([$error]);
+        $exceptions->add($error);
+
+        $this->assertSame([$error, $error], $exceptions->getExceptions());
+        $this->assertTrue($exceptions->hasExceptions());
+    }
+}

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -160,7 +160,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(TypeMappingException::class);
+        $this->expectException(TypeMappingRuntimeException::class);
         $queryProvider->getQueries($controller);
     }
 
@@ -355,7 +355,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
     {
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(TypeMappingException::class);
+        $this->expectException(TypeMappingRuntimeException::class);
         $this->expectExceptionMessage("Return type in TheCodingMachine\\GraphQLite\\Fixtures\\TestObjectMissingReturnType::getTest is missing a type-hint (or type-hinted to \"mixed\"). Please provide a better type-hint.");
         $queryProvider->getFields(new TestTypeMissingReturnType(), true);
     }
@@ -431,7 +431,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
     public function testNoReturnTypeError(): void
     {
         $queryProvider = $this->buildFieldsBuilder();
-        $this->expectException(TypeMappingException::class);
+        $this->expectException(TypeMappingRuntimeException::class);
         $queryProvider->getQueries(new TestControllerNoReturnType());
     }
 
@@ -482,7 +482,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(TypeMappingException::class);
+        $this->expectException(TypeMappingRuntimeException::class);
         $this->expectExceptionMessage('Return type in TheCodingMachine\GraphQLite\Fixtures\TestControllerWithIterableReturnType::test is type-hinted to "\ArrayObject", which is iterable. Please provide an additional @param in the PHPDoc block to further specify the type. For instance: @return \ArrayObject|User[]');
         $queryProvider->getQueries($controller);
     }
@@ -493,7 +493,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(TypeMappingException::class);
+        $this->expectException(TypeMappingRuntimeException::class);
         $this->expectExceptionMessage('Return type in TheCodingMachine\GraphQLite\Fixtures\TestControllerWithArrayReturnType::test is type-hinted to array. Please provide an additional @return in the PHPDoc block to further specify the type of the array. For instance: @return string[]');
         $queryProvider->getQueries($controller);
     }
@@ -504,7 +504,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(TypeMappingException::class);
+        $this->expectException(TypeMappingRuntimeException::class);
         $this->expectExceptionMessage('Parameter $params in TheCodingMachine\GraphQLite\Fixtures\TestControllerWithArrayParam::test is type-hinted to array. Please provide an additional @param in the PHPDoc block to further specify the type of the array. For instance: @param string[] $params.');
         $queryProvider->getQueries($controller);
     }
@@ -515,7 +515,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(TypeMappingException::class);
+        $this->expectException(TypeMappingRuntimeException::class);
         $this->expectExceptionMessage('Parameter $params in TheCodingMachine\GraphQLite\Fixtures\TestControllerWithIterableParam::test is type-hinted to "\ArrayObject", which is iterable. Please provide an additional @param in the PHPDoc block to further specify the type. For instance: @param \ArrayObject|User[] $params.');
         $queryProvider->getQueries($controller);
     }
@@ -597,7 +597,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
     public function testDoubleReturnException(): void
     {
         $queryProvider = $this->buildFieldsBuilder();
-        $this->expectException(InvalidDocBlockException::class);
+        $this->expectException(InvalidDocBlockRuntimeException::class);
         $this->expectExceptionMessage('Method TheCodingMachine\\GraphQLite\\Fixtures\\TestDoubleReturnTag::test has several @return annotations.');
         $queryProvider->getFields(new TestDoubleReturnTag(), true);
     }
@@ -635,7 +635,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(InvalidPrefetchMethodException::class);
+        $this->expectException(InvalidPrefetchMethodRuntimeException::class);
         $this->expectExceptionMessage('The @Field annotation in TheCodingMachine\\GraphQLite\\Fixtures\\TestTypeWithInvalidPrefetchMethod::test specifies a "prefetch method" that could not be found. Unable to find method TheCodingMachine\\GraphQLite\\Fixtures\\TestTypeWithInvalidPrefetchMethod::notExists.');
         $queryProvider->getFields($controller);
     }
@@ -646,7 +646,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $this->expectException(InvalidPrefetchMethodException::class);
+        $this->expectException(InvalidPrefetchMethodRuntimeException::class);
         $this->expectExceptionMessage('The @Field annotation in TheCodingMachine\GraphQLite\Fixtures\TestTypeWithInvalidPrefetchParameter::prefetch specifies a "prefetch method" but the data from the prefetch method is not gathered. The "prefetch" method should accept a second parameter that will contain data returned by the prefetch method.');
         $queryProvider->getFields($controller);
     }

--- a/tests/InputTypeUtilsTest.php
+++ b/tests/InputTypeUtilsTest.php
@@ -12,7 +12,7 @@ class InputTypeUtilsTest extends AbstractQueryProviderTest
     {
         $inputTypeGenerator = $this->getInputTypeUtils();
 
-        $this->expectException(MissingTypeHintException::class);
+        $this->expectException(MissingTypeHintRuntimeException::class);
         $this->expectExceptionMessage('Factory "TheCodingMachine\\GraphQLite\\InputTypeUtilsTest::factoryNoReturnType" must have a return type.');
         $inputTypeGenerator->getInputTypeNameAndClassName(new ReflectionMethod($this, 'factoryNoReturnType'));
     }
@@ -21,7 +21,7 @@ class InputTypeUtilsTest extends AbstractQueryProviderTest
     {
         $inputTypeGenerator = $this->getInputTypeUtils();
 
-        $this->expectException(MissingTypeHintException::class);
+        $this->expectException(MissingTypeHintRuntimeException::class);
         $this->expectExceptionMessage('The return type of factory "TheCodingMachine\\GraphQLite\\InputTypeUtilsTest::factoryStringReturnType" must be an object, "string" passed instead.');
         $inputTypeGenerator->getInputTypeNameAndClassName(new ReflectionMethod($this, 'factoryStringReturnType'));
     }
@@ -30,7 +30,7 @@ class InputTypeUtilsTest extends AbstractQueryProviderTest
     {
         $inputTypeGenerator = $this->getInputTypeUtils();
 
-        $this->expectException(MissingTypeHintException::class);
+        $this->expectException(MissingTypeHintRuntimeException::class);
         $this->expectExceptionMessage('Factory "TheCodingMachine\\GraphQLite\\InputTypeUtilsTest::factoryNullableReturnType" must have a non nullable return type.');
         $inputTypeGenerator->getInputTypeNameAndClassName(new ReflectionMethod($this, 'factoryNullableReturnType'));
     }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -54,7 +54,7 @@ use TheCodingMachine\GraphQLite\Security\SecurityExpressionLanguageProvider;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQLite\TypeGenerator;
-use TheCodingMachine\GraphQLite\TypeMismatchException;
+use TheCodingMachine\GraphQLite\TypeMismatchRuntimeException;
 use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
@@ -874,7 +874,7 @@ class EndToEndTest extends TestCase
             $queryString
         );
 
-        $this->expectException(TypeMismatchException::class);
+        $this->expectException(TypeMismatchRuntimeException::class);
         $this->expectExceptionMessage('In TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers\\ProductController::getProductsBadType() (declaring field "productsBadType"): Expected resolved value to be an object but got "array"');
         $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS);
     }

--- a/tests/Mappers/CompositeTypeMapperTest.php
+++ b/tests/Mappers/CompositeTypeMapperTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
-use TheCodingMachine\GraphQLite\TypeMappingException;
+use TheCodingMachine\GraphQLite\TypeMappingRuntimeException;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
@@ -37,7 +37,7 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
                         ],
                     ]);
                 } else {
-                    throw TypeMappingException::createFromType(TestObject::class);
+                    throw TypeMappingRuntimeException::createFromType(TestObject::class);
                 }
             }
 
@@ -51,7 +51,7 @@ class CompositeTypeMapperTest extends AbstractQueryProviderTest
                         ],
                     ]);
                 } else {
-                    throw TypeMappingException::createFromType(TestObject::class);
+                    throw TypeMappingRuntimeException::createFromType(TestObject::class);
                 }
             }
 

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -21,7 +21,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Types\FooExtendType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\FooType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory;
 use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactoryNoType;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\NamingStrategy;
 use TheCodingMachine\GraphQLite\TypeGenerator;
 use GraphQL\Type\Definition\ObjectType;
@@ -363,7 +363,7 @@ class GlobTypeMapperTest extends AbstractQueryProviderTest
 
         $mapper = new GlobTypeMapper('TheCodingMachine\GraphQLite\Fixtures\NonInstantiableType', $typeGenerator, $inputTypeGenerator, $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), $cache);
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $this->expectExceptionMessage('Class "TheCodingMachine\GraphQLite\Fixtures\NonInstantiableType\AbstractFooType" annotated with @Type(class="TheCodingMachine\GraphQLite\Fixtures\TestObject") must be instantiable.');
         $mapper->mapClassToType(TestObject::class, null);
     }

--- a/tests/Mappers/Parameters/TypeMapperTest.php
+++ b/tests/Mappers/Parameters/TypeMapperTest.php
@@ -70,7 +70,7 @@ class TypeMapperTest extends AbstractQueryProviderTest
         $docBlockObj = $cachedDocBlockFactory->getDocBlock($refMethod);
         $annotations = $this->getAnnotationReader()->getParameterAnnotations($refParameter);
 
-        $this->expectException(CannotHideParameterException::class);
+        $this->expectException(CannotHideParameterRuntimeException::class);
         $this->expectExceptionMessage('For parameter $foo of method TheCodingMachine\GraphQLite\Mappers\Parameters\TypeMapperTest::withoutDefaultValue(), cannot use the @HideParameter annotation. The parameter needs to provide a default value.');
 
         $typeMapper->mapParameter($refParameter, $docBlockObj, null, $annotations);

--- a/tests/Mappers/Root/BaseTypeMapperTest.php
+++ b/tests/Mappers/Root/BaseTypeMapperTest.php
@@ -10,7 +10,7 @@ use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\Resource_;
 use ReflectionMethod;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 
 class BaseTypeMapperTest extends AbstractQueryProviderTest
 {
@@ -27,7 +27,7 @@ class BaseTypeMapperTest extends AbstractQueryProviderTest
     {
         $baseTypeMapper = new BaseTypeMapper($this->getTypeMapper());
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $this->expectExceptionMessage('Type-hinting a parameter against DateTime is not allowed. Please use the DateTimeImmutable type instead.');
         $baseTypeMapper->toGraphQLInputType(new Object_(new Fqsen('\\DateTime')), null, 'foo', new ReflectionMethod(BaseTypeMapper::class, '__construct'), new DocBlock());
     }

--- a/tests/Mappers/StaticClassListTypeMapperTest.php
+++ b/tests/Mappers/StaticClassListTypeMapperTest.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\NamingStrategy;
 
 class StaticClassListTypeMapperTest extends AbstractQueryProviderTest
@@ -22,7 +22,7 @@ class StaticClassListTypeMapperTest extends AbstractQueryProviderTest
 
         $mapper = new StaticClassListTypeMapper(['NotExistsClass'], $typeGenerator, $inputTypeGenerator, $this->getInputTypeUtils(), $container, new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), $cache);
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $this->expectExceptionMessage('Could not find class "NotExistsClass"');
 
         $mapper->getSupportedClasses();

--- a/tests/ResolveUtilsTest.php
+++ b/tests/ResolveUtilsTest.php
@@ -11,13 +11,13 @@ class ResolveUtilsTest extends TestCase
 {
     public function testAssertNull(): void
     {
-        $this->expectException(TypeMismatchException::class);
+        $this->expectException(TypeMismatchRuntimeException::class);
         ResolveUtils::assertInnerReturnType(null, Type::nonNull(Type::string()));
     }
 
     public function testAssertList(): void
     {
-        $this->expectException(TypeMismatchException::class);
+        $this->expectException(TypeMismatchRuntimeException::class);
         ResolveUtils::assertInnerReturnType(12, Type::nonNull(Type::listOf(Type::string())));
     }
 

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -83,7 +83,7 @@ class SchemaFactoryTest extends TestCase
 
         $factory = new SchemaFactory($cache, $container);
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $factory->createSchema();
     }
 
@@ -95,7 +95,7 @@ class SchemaFactoryTest extends TestCase
         $factory = new SchemaFactory($cache, $container);
         $factory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $factory->createSchema();
     }
 

--- a/tests/TypeRegistryTest.php
+++ b/tests/TypeRegistryTest.php
@@ -19,7 +19,7 @@ class TypeRegistryTest extends TestCase
         $registry = new TypeRegistry();
         $registry->registerType($type);
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $registry->registerType($type);
     }
 
@@ -35,7 +35,7 @@ class TypeRegistryTest extends TestCase
 
         $this->assertSame($type, $registry->getType('Foo'));
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $registry->getType('Bar');
     }
 
@@ -71,7 +71,7 @@ class TypeRegistryTest extends TestCase
 
         $this->assertSame($type, $registry->getMutableObjectType('Foo'));
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $this->assertSame($type, $registry->getMutableObjectType('FooBar'));
     }
 
@@ -92,7 +92,7 @@ class TypeRegistryTest extends TestCase
 
         $this->assertSame($type, $registry->getMutableInterface('Foo'));
 
-        $this->expectException(GraphQLException::class);
+        $this->expectException(GraphQLRuntimeException::class);
         $this->assertSame($type, $registry->getMutableInterface('FooBar'));
     }
 }

--- a/tests/Types/ResolvableMutableInputObjectTypeTest.php
+++ b/tests/Types/ResolvableMutableInputObjectTypeTest.php
@@ -9,7 +9,7 @@ use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
 use TheCodingMachine\GraphQLite\Fixtures\TestObjectWithRecursiveList;
 use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory;
-use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 
 class ResolvableMutableInputObjectTypeTest extends AbstractQueryProviderTest

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,7 +2,7 @@
   "docs": {
     "Introduction": ["features"],
     "Installation": ["getting-started", "symfony-bundle", "laravel-package", "universal_service_providers", "other-frameworks"],
-    "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "external_type_declaration", "input-types", "inheritance-interfaces"],
+    "Usage": ["queries", "mutations", "type_mapping", "autowiring", "extend_type", "external_type_declaration", "input-types", "inheritance-interfaces", "error-handling"],
     "Security": ["authentication_authorization", "fine-grained-security", "implementing-security"],
     "Performance": ["query-plan", "prefetch-method"],
     "Advanced": ["file-uploads", "pagination", "custom-types", "field-middlewares", "argument-resolving", "extend_input_type", "multiple_output_types", "symfony-bundle-advanced", "laravel-package-advanced", "internals", "troubleshooting", "migrating"],


### PR DESCRIPTION
In GraphQL, when an error occurs, the server must add an "error" entry in the response.

```json
{
  "errors": [
    {
      "message": "Name for character with ID 1002 could not be fetched.",
      "locations": [ { "line": 6, "column": 7 } ],
      "path": [ "hero", "heroFriends", 1, "name" ],
      "extensions": {
        "category": "Exception"
      }
    }
  ]
}
```

You can generate such errors with GraphQLite by throwing a `GraphQLException`.

```php
use TheCodingMachine\GraphQLite\Exceptions\GraphQLException;

throw new GraphQLException("Exception message");
```

## HTTP response code

By default, when you throw a `GraphQLException`, the HTTP status code will be 500.

If your exception code is in the 4xx - 5xx range, the exception code will be used as an HTTP status code.

```php
// This exception will generate a HTTP 404 status code
throw new GraphQLException("Not found", 404);
```

<div class="alert alert-info">GraphQL allows to have several errors for one request. If you have several 
<code>GraphQLException</code> thrown for the same request, the HTTP status code used will be the highest one.</div>

## Customizing the category

By default, GraphQLite adds a "category" entry in the "extensions section". You can customize the category with the 
4th parameter of the constructor:

```php
throw new GraphQLException("Not found", 404, null, "NOT_FOUND");
```

will generate:

```json
{
  "errors": [
    {
      "message": "Not found",
      "extensions": {
        "category": "NOT_FOUND"
      }
    }
  ]
}
```

## Customizing the extensions section

You can customize the whole "extensions" section with the 5th parameter of the constructor:

```php
throw new GraphQLException("Field required", 400, null, "VALIDATION", ['field' => 'name']);
```

will generate:

```json
{
  "errors": [
    {
      "message": "Field required",
      "extensions": {
        "category": "VALIDATION",
        "field": "name"
      }
    }
  ]
}
```

## Writing your own exceptions

Rather that throwing the base `GraphQLException`, you should consider writing your own exception.

Any exception that implements interface `TheCodingMachine\GraphQLite\Exceptions\GraphQLExceptionInterface` will be displayed
in the GraphQL "errors" section.

```php
class ValidationException extends Exception implements GraphQLExceptionInterface
{
    /**
     * Returns true when exception message is safe to be displayed to a client.
     */
    public function isClientSafe(): bool
    {
        return true;
    }

    /**
     * Returns string describing a category of the error.
     *
     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
     */
    public function getCategory(): string
    {
        return 'VALIDATION';
    }

    /**
     * Returns the "extensions" object attached to the GraphQL error.
     *
     * @return array<string, mixed>
     */
    public function getExtensions(): array
    {
        return [];
    }
}
```

## Many errors for one exception

Sometimes, you need to display several errors in the response. But of course, at any given point in your code, you can
throw only one exception.

If you want to display several exceptions, you can bundle these exceptions in a `GraphQLAggregateException` that you can
throw.

```php
use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;

/**
 * @Query
 */
public function createProduct(string $name, float $price): Product
{
    $exceptions = new GraphQLAggregateException();

    if ($name === '') {
        $exceptions->add(new GraphQLException('Name cannot be empty', 400, null, 'VALIDATION));
    }
    if ($price <= 0) {
        $exceptions->add(new GraphQLException('Price must be positive', 400, null, 'VALIDATION));
    }

    if ($exceptions->hasExceptions()) {
        throw $exceptions;
    }
}
```
