### PR TITLE
Make `ClassNameMapper` injectable in `SchemaFactory`

### DIFF
--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -38,14 +38,17 @@ final class GlobTypeMapper extends AbstractTypeMapper
     private $classes;
     /** @var bool */
     private $recursive;
+    /** @var ClassNameMapper */
+    private $classNameMapper;
 
     /**
      * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
      */
-    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null, bool $recursive = true)
+    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?ClassNameMapper $classNameMapper = null, ?int $globTtl = 2, ?int $mapTtl = null, bool $recursive = true)
     {
         $this->namespace           = $namespace;
         $this->recursive           = $recursive;
+        $this->classNameMapper     = $classNameMapper ?? ClassNameMapper::createFromComposerFile(null, null, true);
         $cachePrefix = str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $namespace);
         parent::__construct($cachePrefix, $typeGenerator, $inputTypeGenerator, $inputTypeUtils, $container, $annotationReader, $namingStrategy, $recursiveTypeMapper, $cache, $globTtl, $mapTtl);
     }
@@ -60,7 +63,7 @@ final class GlobTypeMapper extends AbstractTypeMapper
     {
         if ($this->classes === null) {
             $this->classes = [];
-            $explorer      = new GlobClassExplorer($this->namespace, $this->cache, $this->globTtl, ClassNameMapper::createFromComposerFile(null, null, true), $this->recursive);
+            $explorer      = new GlobClassExplorer($this->namespace, $this->cache, $this->globTtl, $this->classNameMapper, $this->recursive);
             $classes       = $explorer->getClasses();
             foreach ($classes as $className) {
                 if (! class_exists($className) && ! interface_exists($className)) {

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ApcuCache;
 use Doctrine\Common\Cache\PhpFileCache;
 use GraphQL\Type\SchemaConfig;
+use Mouf\Composer\ClassNameMapper;
 use PackageVersions\Versions;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
@@ -83,6 +84,8 @@ class SchemaFactory
     private $namingStrategy;
     /** @var ContainerInterface */
     private $container;
+    /** @var ClassNameMapper */
+    private $classNameMapper;
     /** @var SchemaConfig */
     private $schemaConfig;
     /** @var int */
@@ -236,6 +239,13 @@ class SchemaFactory
         return $this;
     }
 
+    public function setClassNameMapper(ClassNameMapper $classNameMapper): self
+    {
+        $this->classNameMapper = $classNameMapper;
+
+        return $this;
+    }
+
     /**
      * Sets the time to live time of the cache for annotations in files.
      * By default this is set to 2 seconds which is ok for development environments.
@@ -360,6 +370,7 @@ class SchemaFactory
                 $namingStrategy,
                 $recursiveTypeMapper,
                 $this->cache,
+                $this->classNameMapper,
                 $this->globTtl
             ));
         }
@@ -396,6 +407,7 @@ class SchemaFactory
                 $fieldsBuilder,
                 $this->container,
                 $this->cache,
+                $this->classNameMapper,
                 $this->globTtl
             );
         }


### PR DESCRIPTION
This pull request makes the `ClassNameMapper` instance injectable via setter in the `SchemaFactory`. If not injected, everything behaves as before this PR.