### PR TITLE
[3.0] [PHP 7.4] Call the "getName" method on the reflection type instead of the deprecated "__toString" method.

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -308,7 +308,9 @@ class FieldsBuilder
         $returnType = $refMethod->getReturnType();
         if ($returnType !== null) {
             $typeResolver = new \phpDocumentor\Reflection\TypeResolver();
-            $phpdocType = $typeResolver->resolve((string) $returnType);
+            $phpdocType = $typeResolver->resolve(
+                $returnType->getName()
+            );
             $phpdocType = $this->resolveSelf($phpdocType, $refMethod->getDeclaringClass());
         } else {
             $phpdocType = new Mixed_();
@@ -490,10 +492,11 @@ class FieldsBuilder
             $parameterType = $parameter->getType();
             $allowsNull = $parameterType === null ? true : $parameterType->allowsNull();
 
-            $type = (string) $parameterType;
-            if ($type === '') {
+            if ($parameterType === null) {
                 throw MissingTypeHintException::missingTypeHint($parameter);
             }
+
+            $type = $parameterType->getName();
             $phpdocType = $typeResolver->resolve($type);
             $phpdocType = $this->resolveSelf($phpdocType, $parameter->getDeclaringClass());
 


### PR DESCRIPTION
Hi,

First of all, thanks for creating and releasing this package!
I've tried to run this package in a PHP 7.4 environment and it seems to have a few issues with some deprecated reflection functionality, this pull request aims to fix those problems.

I've ran the tests and they all turned out green, I also did some basic manual testing and everything seemed to work again. If there's anything I missed, please let me know.

If you need me to send a PR to the upcoming 4.0 branch (master), also please let me know.

More information: [https://www.php.net/manual/en/reflectiontype.tostring.php](url)

Thanks,

Jens