### PR TITLE
Backport classNameMapper injectability from #144 to graphqlite v3

### DIFF
--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -40,6 +40,10 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
      */
     private $container;
     /**
+     * @var ClassNameMapper
+     */
+    private $classNameMapper;
+    /**
      * @var AggregateControllerQueryProvider
      */
     private $aggregateControllerQueryProvider;
@@ -69,10 +73,11 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
      * @param int|null $cacheTtl
      * @param bool $recursive Whether subnamespaces of $namespace must be analyzed.
      */
-    public function __construct(string $namespace, FieldsBuilderFactory $fieldsBuilderFactory, RecursiveTypeMapperInterface $recursiveTypeMapper, ContainerInterface $container, LockFactory $lockFactory, CacheInterface $cache, ?int $cacheTtl = null, bool $recursive = true)
+    public function __construct(string $namespace, FieldsBuilderFactory $fieldsBuilderFactory, RecursiveTypeMapperInterface $recursiveTypeMapper, ContainerInterface $container, LockFactory $lockFactory, CacheInterface $cache, ?ClassNameMapper $classNameMapper = null, ?int $cacheTtl = null, bool $recursive = true)
     {
         $this->namespace = $namespace;
         $this->container = $container;
+        $this->classNameMapper = $classNameMapper ?? ClassNameMapper::createFromComposerFile(null, null, true);
         $this->cache = $cache;
         $this->cacheTtl = $cacheTtl;
         $this->fieldsBuilderFactory = $fieldsBuilderFactory;
@@ -126,7 +131,7 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
      */
     private function buildInstancesList(): array
     {
-        $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->cacheTtl, ClassNameMapper::createFromComposerFile(null, null, true), $this->recursive);
+        $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->cacheTtl, $this->classNameMapper, $this->recursive);
         $classes = $explorer->getClasses();
         $instances = [];
         foreach ($classes as $className) {

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -126,15 +126,20 @@ final class GlobTypeMapper implements TypeMapperInterface
      * @var LockFactory
      */
     private $lockFactory;
+    /**
+     * @var ClassNameMapper
+     */
+    private $classNameMapper;
 
     /**
      * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
      */
-    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, LockFactory $lockFactory, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null, bool $recursive = true)
+    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, LockFactory $lockFactory, CacheInterface $cache, ClassNameMapper $classNameMapper = null, ?int $globTtl = 2, ?int $mapTtl = null, bool $recursive = true)
     {
         $this->namespace = $namespace;
         $this->typeGenerator = $typeGenerator;
         $this->container = $container;
+        $this->classNameMapper = $classNameMapper ?? ClassNameMapper::createFromComposerFile(null, null, true);
         $this->annotationReader = $annotationReader;
         $this->namingStrategy = $namingStrategy;
         $this->cache = $cache;
@@ -288,7 +293,7 @@ final class GlobTypeMapper implements TypeMapperInterface
     {
         if ($this->classes === null) {
             $this->classes = [];
-            $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->globTtl, ClassNameMapper::createFromComposerFile(null, null, true), $this->recursive);
+            $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->globTtl, $this->classNameMapper, $this->recursive);
             $classes = $explorer->getClasses();
             foreach ($classes as $className) {
                 if (!\class_exists($className)) {

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use Doctrine\Common\Cache\ApcuCache;
 use function extension_loaded;
 use GraphQL\Type\SchemaConfig;
+use Mouf\Composer\ClassNameMapper;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Lock\Factory as LockFactory;
@@ -74,6 +75,10 @@ class SchemaFactory
      * @var ContainerInterface
      */
     private $container;
+    /**
+     * @var ClassNameMapper
+     */
+    private $classNameMapper;
     /**
      * @var SchemaConfig
      */
@@ -180,6 +185,12 @@ class SchemaFactory
         return $this;
     }
 
+    public function setClassNameMapper(ClassNameMapper $classNameMapper): self
+    {
+        $this->classNameMapper = $classNameMapper;
+        return $this;
+    }
+
     public function createSchema(): Schema
     {
         $annotationReader = new AnnotationReader($this->getDoctrineAnnotationReader(), AnnotationReader::LAX_MODE);
@@ -210,7 +221,7 @@ class SchemaFactory
 
         foreach ($this->typeNamespaces as $typeNamespace) {
             $typeMappers[] = new GlobTypeMapper($typeNamespace, $typeGenerator, $inputTypeGenerator, $inputTypeUtils,
-                $this->container, $annotationReader, $namingStrategy, $lockFactory, $this->cache);
+                $this->container, $annotationReader, $namingStrategy, $lockFactory, $this->cache, $this->classNameMapper);
         }
 
         foreach ($this->typeMappers as $typeMapper) {
@@ -229,7 +240,7 @@ class SchemaFactory
         $queryProviders = [];
         foreach ($this->controllerNamespaces as $controllerNamespace) {
             $queryProviders[] = new GlobControllerQueryProvider($controllerNamespace, $fieldsBuilderFactory, $recursiveTypeMapper,
-                $this->container, $lockFactory, $this->cache);
+                $this->container, $lockFactory, $this->cache, $this->classNameMapper);
         }
 
         foreach ($this->queryProviders as $queryProvider) {


### PR DESCRIPTION
This pull requests backports #144 to GraphQLite v3

**Why?**
For the moment we are still using Symfony 3 components in our system, whereas GraphQLite master is already using Symfony 4 components. As we will take a while to update to Symfony 4 components, we are locked on GraphQLite v3