### PR TITLE
[3.0] [PHP 7.4] Add a bootstrap file for PHPUnit, so the annotations gets registered before running the tests.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,12 +9,13 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/Bootstrap.php"
 >
     <testsuites>
         <testsuite name="GraphQLite Test Suite">
             <directory>./tests/</directory>
             <exclude>./tests/dependencies/</exclude>
+            <exclude>./tests/Bootstrap.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+$autoloader = require_once __DIR__ . '/../vendor/autoload.php';
+
+AnnotationRegistry::registerLoader('class_exists');
+
+return $autoloader;


### PR DESCRIPTION
The annotations currently aren't autoloaded in the PHPUnit tests and is causing problems for the CI build. This PR adds a small bootstrap script which registers the annotations manually.

More information:

https://github.com/doctrine/annotations/issues/103
