### PR TITLE
[4.0] [PHP 7.4] Call the "getName" method on the reflection type instead of the deprecated "__toString" method.

### DIFF
--- a/src/InputTypeUtils.php
+++ b/src/InputTypeUtils.php
@@ -62,7 +62,7 @@ class InputTypeUtils
             throw MissingTypeHintRuntimeException::nullableReturnType($refMethod);
         }
 
-        $type = ($returnType === null ? '' : $returnType->getName());
+        $type = $returnType->getName();
 
         $typeResolver = new TypeResolver();
 

--- a/src/InputTypeUtils.php
+++ b/src/InputTypeUtils.php
@@ -62,7 +62,7 @@ class InputTypeUtils
             throw MissingTypeHintRuntimeException::nullableReturnType($refMethod);
         }
 
-        $type = (string) $returnType;
+        $type = ($returnType === null ? '' : $returnType->getName());
 
         $typeResolver = new TypeResolver();
 

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -431,7 +431,7 @@ class TypeHandler implements ParameterHandlerInterface
 
     private function reflectionTypeToPhpDocType(ReflectionType $type, ReflectionClass $reflectionClass): Type
     {
-        $phpdocType = $this->phpDocumentorTypeResolver->resolve((string) $type);
+        $phpdocType = $this->phpDocumentorTypeResolver->resolve($type->getName());
         Assert::notNull($phpdocType);
 
         return $this->resolveSelf($phpdocType, $reflectionClass);


### PR DESCRIPTION
Hi,

I've tried to run this package in a PHP 7.4 environment and it seems to have a few issues with some deprecated reflection functionality, this pull request aims to fix those problems.

I've ran the tests and they all turned out green, I also did some basic manual testing and everything seemed to work again. If there's anything I missed, please let me know.

Thanks,

Jens