### PR TITLE
[4.0] [PHP 7.4] Make GraphQLite compatible with PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ jobs:
       after_script:
         - travis_retry php vendor/bin/php-coveralls -v
     - stage: test
+      php: 7.4snapshot
+      env: PREFER_LOWEST=""
+      before_script:
+        - *composerupdate
+      script:
+        - *phpunit
+    - stage: test
       php: 7.2
       env: PREFER_LOWEST=""
       before_script:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,12 +8,13 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/Bootstrap.php"
 >
     <testsuites>
         <testsuite name="GraphQLite Test Suite">
             <directory>./tests/</directory>
             <exclude>./tests/dependencies/</exclude>
+            <exclude>./tests/Bootstrap.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/src/InputTypeUtils.php
+++ b/src/InputTypeUtils.php
@@ -62,7 +62,7 @@ class InputTypeUtils
             throw MissingTypeHintRuntimeException::nullableReturnType($refMethod);
         }
 
-        $type = (string) $returnType;
+        $type = $returnType->getName();
 
         $typeResolver = new TypeResolver();
 

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -431,7 +431,7 @@ class TypeHandler implements ParameterHandlerInterface
 
     private function reflectionTypeToPhpDocType(ReflectionType $type, ReflectionClass $reflectionClass): Type
     {
-        $phpdocType = $this->phpDocumentorTypeResolver->resolve((string) $type);
+        $phpdocType = $this->phpDocumentorTypeResolver->resolve($type->getName());
         Assert::notNull($phpdocType);
 
         return $this->resolveSelf($phpdocType, $reflectionClass);

--- a/src/MissingTypeHintRuntimeException.php
+++ b/src/MissingTypeHintRuntimeException.php
@@ -16,7 +16,7 @@ class MissingTypeHintRuntimeException extends GraphQLRuntimeException
 
     public static function invalidReturnType(ReflectionMethod $method): self
     {
-        return new self(sprintf('The return type of factory "%s::%s" must be an object, "%s" passed instead.', $method->getDeclaringClass()->getName(), $method->getName(), $method->getReturnType()));
+        return new self(sprintf('The return type of factory "%s::%s" must be an object, "%s" passed instead.', $method->getDeclaringClass()->getName(), $method->getName(), $method->getReturnType() ? $method->getReturnType()->getName() : 'mixed'));
     }
 
     public static function nullableReturnType(ReflectionMethod $method): self

--- a/src/MissingTypeHintRuntimeException.php
+++ b/src/MissingTypeHintRuntimeException.php
@@ -17,6 +17,7 @@ class MissingTypeHintRuntimeException extends GraphQLRuntimeException
     public static function invalidReturnType(ReflectionMethod $method): self
     {
         $returnType = $method->getReturnType();
+
         return new self(sprintf('The return type of factory "%s::%s" must be an object, "%s" passed instead.', $method->getDeclaringClass()->getName(), $method->getName(), $returnType ? $returnType->getName() : 'mixed'));
     }
 

--- a/src/MissingTypeHintRuntimeException.php
+++ b/src/MissingTypeHintRuntimeException.php
@@ -16,7 +16,8 @@ class MissingTypeHintRuntimeException extends GraphQLRuntimeException
 
     public static function invalidReturnType(ReflectionMethod $method): self
     {
-        return new self(sprintf('The return type of factory "%s::%s" must be an object, "%s" passed instead.', $method->getDeclaringClass()->getName(), $method->getName(), $method->getReturnType() ? $method->getReturnType()->getName() : 'mixed'));
+        $returnType = $method->getReturnType();
+        return new self(sprintf('The return type of factory "%s::%s" must be an object, "%s" passed instead.', $method->getDeclaringClass()->getName(), $method->getName(), $returnType ? $returnType->getName() : 'mixed'));
     }
 
     public static function nullableReturnType(ReflectionMethod $method): self

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+$autoloader = require_once __DIR__ . '/../vendor/autoload.php';
+
+AnnotationRegistry::registerLoader('class_exists');
+
+return $autoloader;


### PR DESCRIPTION
This PR build on #152 to add PHP 7.4 support with no deprecations.