### PR TITLE
Fixing error formatter skipping debug param

### DIFF
--- a/src/Exceptions/WebonyxErrorHandler.php
+++ b/src/Exceptions/WebonyxErrorHandler.php
@@ -53,7 +53,7 @@ final class WebonyxErrorHandler
 
                 $formattedErrors = array_merge($formattedErrors, $formattedInnerErrors);
             } else {
-                $formattedErrors[] = self::errorFormatter($error);
+                $formattedErrors[] = $formatter($error);
             }
         }
 


### PR DESCRIPTION
The error handler was not correctly handling error formatter wrapper that adds the debug message.
This is fixed with this PR.