### PR TITLE
[4.0] Create a factory for the "GlobControllerQueryProvider".

### DIFF
--- a/src/GlobControllerQueryProviderFactory.php
+++ b/src/GlobControllerQueryProviderFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite;
+
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+
+class GlobControllerQueryProviderFactory implements GlobControllerQueryProviderFactoryInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function create(
+        string $namespace,
+        FieldsBuilder $fieldsBuilder,
+        ContainerInterface $container,
+        CacheInterface $cache,
+        ?int $cacheTtl = null,
+        bool $recursive = true
+    ): QueryProviderInterface
+    {
+        return new GlobControllerQueryProvider(
+            $namespace,
+            $fieldsBuilder,
+            $container,
+            $cache,
+            $cacheTtl,
+            $recursive
+        );
+    }
+}

--- a/src/GlobControllerQueryProviderFactoryInterface.php
+++ b/src/GlobControllerQueryProviderFactoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite;
+
+use Psr\Container\ContainerInterface;
+use Psr\SimpleCache\CacheInterface;
+
+interface GlobControllerQueryProviderFactoryInterface
+{
+    /**
+     * @param string $namespace
+     * @param FieldsBuilder $fieldsBuilder
+     * @param ContainerInterface $container
+     * @param CacheInterface $cache
+     * @param int|null $cacheTtl
+     * @param bool $recursive
+     * @return QueryProviderInterface
+     */
+    public function create(
+        string $namespace,
+        FieldsBuilder $fieldsBuilder,
+        ContainerInterface $container,
+        CacheInterface $cache,
+        ?int $cacheTtl = null,
+        bool $recursive = true
+    ): QueryProviderInterface;
+}

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -91,11 +91,8 @@ class SchemaFactory
     private $fieldMiddlewares = [];
     /** @var ExpressionLanguage|null */
     private $expressionLanguage;
-
-    /**
-     * @var GlobControllerQueryProviderFactoryInterface|null
-     */
-    private $globControllerQueryProviderFactoryInterface;
+    /** @var GlobControllerQueryProviderFactoryInterface */
+    private $globControllerQueryProviderFactory;
 
     public function __construct(CacheInterface $cache, ContainerInterface $container)
     {
@@ -243,14 +240,14 @@ class SchemaFactory
 
     public function setGlobControllerQueryProviderFactory(GlobControllerQueryProviderFactoryInterface $instance): self
     {
-        $this->globControllerQueryProviderFactoryInterface = $instance;
+        $this->globControllerQueryProviderFactory = $instance;
 
         return $this;
     }
 
     public function getGlobControllerQueryProviderFactory(): GlobControllerQueryProviderFactoryInterface
     {
-        return $this->globControllerQueryProviderFactoryInterface ?? new GlobControllerQueryProviderFactory();
+        return $this->globControllerQueryProviderFactory ?? new GlobControllerQueryProviderFactory();
     }
 
     /**

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -92,6 +92,11 @@ class SchemaFactory
     /** @var ExpressionLanguage|null */
     private $expressionLanguage;
 
+    /**
+     * @var GlobControllerQueryProviderFactoryInterface|null
+     */
+    private $globControllerQueryProviderFactoryInterface;
+
     public function __construct(CacheInterface $cache, ContainerInterface $container)
     {
         $this->cache     = new NamespacedCache($cache);
@@ -234,6 +239,18 @@ class SchemaFactory
         $this->schemaConfig = $schemaConfig;
 
         return $this;
+    }
+
+    public function setGlobControllerQueryProviderFactory(GlobControllerQueryProviderFactoryInterface $instance): self
+    {
+        $this->globControllerQueryProviderFactoryInterface = $instance;
+
+        return $this;
+    }
+
+    public function getGlobControllerQueryProviderFactory(): GlobControllerQueryProviderFactoryInterface
+    {
+        return $this->globControllerQueryProviderFactoryInterface ?? new GlobControllerQueryProviderFactory();
     }
 
     /**
@@ -391,7 +408,7 @@ class SchemaFactory
 
         $queryProviders = [];
         foreach ($this->controllerNamespaces as $controllerNamespace) {
-            $queryProviders[] = new GlobControllerQueryProvider(
+            $queryProviders[] = $this->getGlobControllerQueryProviderFactory()->create(
                 $controllerNamespace,
                 $fieldsBuilder,
                 $this->container,


### PR DESCRIPTION
This PR adds the ability to let users provide their own instance of a "GlobControllerQueryProvider".
I've tried to make this feature backwards compatible by providing a default factory which returns the default "GlobControllerQueryProvider".

I need this functionality for a certain extension I'm building for GraphQLite and I hope this may be useful to others too.