### PR TITLE
Internalizing PSR-15 middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,11 @@
         "symfony/cache": "^4.3",
         "thecodingmachine/cache-utils": "^1",
         "ocramius/package-versions": "^1.4",
-        "symfony/expression-language": "^4"
+        "symfony/expression-language": "^4",
+        "ext-json": "*",
+        "psr/http-server-handler": "^1",
+        "psr/http-server-middleware": "^1",
+        "psr/http-factory": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2.4",
@@ -37,7 +41,8 @@
         "doctrine/coding-standard": "^6.0",
         "phpstan/phpstan-webmozart-assert": "^0.11.2",
         "phpstan/extension-installer": "^1.0",
-        "thecodingmachine/phpstan-strict-rules": "^0.11.2"
+        "thecodingmachine/phpstan-strict-rules": "^0.11.2",
+        "zendframework/zend-diactoros": "^2"
     },
     "suggest": {
         "beberlei/porpaginas": "If you want automatic pagination in your GraphQL types"

--- a/docs/other_frameworks.md
+++ b/docs/other_frameworks.md
@@ -24,7 +24,7 @@ In order to bootstrap GraphQLite, you will need:
 Additionally, you will have to route the HTTP requests to the underlying GraphQL library.
 
 GraphQLite relies on the [webonyx/graphql-php](http://webonyx.github.io/graphql-php/) library internally.
-This library plays well with PSR-7 requests and there is a [PSR-15 middleware available](https://github.com/phps-cans/psr7-middleware-graphql).
+This library plays well with PSR-7 requests and we also provide a [PSR-15 middleware](https://github.com/phps-cans/psr7-middleware-graphql).
 
 ## Integration
 
@@ -111,15 +111,43 @@ header('Content-Type: application/json');
 echo json_encode($output);
 ```
 
-## Advanced example
+## PSR-15 Middleware
 
-When using a framework, you will need a way to route your HTTP requests to the `webonyx/graphql-php` library. 
-By chance, it plays well with PSR-7 requests and there is a PSR-15 middleware available.
+When using a framework, you will need a way to route your HTTP requests to the `webonyx/graphql-php` library.
+
+If the framework you are using is compatible with PSR-15 (like Slim PHP or Zend-Expressive / Laminas), GraphQLite
+comes with a PSR-15 middleware out of the box.
+
+In order to get an instance of this middleware, you can use the `Psr15GraphQLMiddlewareBuilder` builder class:
+
+```php
+// $schema is an instance of the GraphQL schema returned by SchemaFactory::createSchema (see previous chapter)
+$builder = new Psr15GraphQLMiddlewareBuilder($schema);
+
+$middleware = $builder->createMiddleware();
+
+// You can now inject your middleware in your favorite PSR-15 compatible framework.
+// For instance:
+$zendMiddlewarePipe->pipe($middleware);
+```
+
+The builder offers a number of setters to modify its behaviour:
+
+```php
+$builder->setUrl("/graphql"); // Modify the URL endpoint (defaults to /graphql)
+$config = $builder->getConfig(); // Returns a Webonyx ServerConfig object. Use this object to configure Webonyx in details.
+$builder->setConfig($config);
+
+$builder->setResponseFactory(new ResponseFactory()); // Set a PSR-18 ResponseFactory (not needed if you are using zend-framework/zend-diactoros ^2
+$builder->setStreamFactory(new StreamFactory()); // Set a PSR-18 StreamFactory (not needed if you are using zend-framework/zend-diactoros ^2
+$builder->setHttpCodeDecider(new HttpCodeDecider()); // Set a class in charge of deciding the HTTP status code based on the response.
+```
+
+### Example
 
 In this example, we will focus on getting a working version of GraphQLite using:
 
-- [Zend Stratigility](https://docs.zendframework.com/zend-stratigility/) as a PSR-7 server
-- `phps-cans/psr7-middleware-graphql` to route PSR-7 requests to the GraphQL engine
+- [Zend Stratigility](https://docs.zendframework.com/zend-stratigility/) as a PSR-15 server
 - `mouf/picotainer` (a micro-container) for the PSR-11 container
 - `symfony/cache ` for the PSR-16 cache
 
@@ -135,9 +163,7 @@ The choice of the libraries is really up to you. You can adapt it based on your 
     }
   },
   "require": {
-    "thecodingmachine/graphqlite": "^3",
-    "phps-cans/psr7-middleware-graphql": "^0.2",
-    "middlewares/payload": "^2.1",
+    "thecodingmachine/graphqlite": "^4",
     "zendframework/zend-diactoros": "^2",
     "zendframework/zend-stratigility": "^3",
     "zendframework/zend-httphandlerrunner": "^1.0",
@@ -191,40 +217,27 @@ This `MiddlewarePipe` comes from the container declared in the `config/container
 ```php
 <?php
 
-use GraphQL\Server\StandardServer;
 use GraphQL\Type\Schema;
 use Mouf\Picotainer\Picotainer;
-use PsCs\Middleware\Graphql\WebonyxGraphqlMiddleware;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\ApcuCache;
+use TheCodingMachine\GraphQLite\Http\Psr15GraphQLMiddlewareBuilder;
 use TheCodingMachine\GraphQLite\SchemaFactory;
-use Zend\Diactoros\ResponseFactory;
-use Zend\Diactoros\StreamFactory;
 use Zend\Stratigility\MiddlewarePipe;
 
 // Picotainer is a minimalist PSR-11 container.
 return new Picotainer([
     MiddlewarePipe::class => function(ContainerInterface $container) {
         $pipe = new MiddlewarePipe();
-        // JsonPayload converts JSON body into a parser PHP array.
-        $pipe->pipe(new JsonPayload());
         $pipe->pipe($container->get(WebonyxGraphqlMiddleware::class));
         return $pipe;
     },
     // The WebonyxGraphqlMiddleware is a PSR-15 compatible
     // middleware that exposes Webonyx schemas. 
     WebonyxGraphqlMiddleware::class => function(ContainerInterface $container) {
-        return new WebonyxGraphqlMiddleware(
-            $container->get(StandardServer::class),
-            new ResponseFactory(),
-            new StreamFactory()
-        );
-    },
-    StandardServer::class => function(ContainerInterface $container) {
-        return new StandardServer([
-            'schema' => $container->get(Schema::class)
-        ]);
+        $builder = new Psr15GraphQLMiddlewareBuilder($container->get(Schema::class));
+        return $builder->createMiddleware();
     },
     CacheInterface::class => function() {
         return new ApcuCache();

--- a/docs/universal_service_providers.md
+++ b/docs/universal_service_providers.md
@@ -27,7 +27,7 @@ In order to bootstrap GraphQLite, you will need:
 Additionally, you will have to route the HTTP requests to the underlying GraphQL library.
 
 GraphQLite relies on the [webonyx/graphql-php](http://webonyx.github.io/graphql-php/) library internally.
-This library plays well with PSR-7 requests and there is a [PSR-15 middleware available](https://github.com/phps-cans/psr7-middleware-graphql).
+This library plays well with PSR-7 requests and we provide a [PSR-15 middleware](other_frameworks.md).
 
 ## Integration
 
@@ -53,7 +53,9 @@ GraphQL queries. The service provider provides this `Schema` class.
 
 **index.php**
 ```php
+<?php
 use Simplex\Container;
+use TheCodingMachine\GraphQLite\Http\Psr15GraphQLMiddlewareBuilder;
 use TheCodingMachine\GraphQLite\Schema;
 use TheCodingMachine\SymfonyCacheServiceProvider;
 use TheCodingMachine\DoctrineAnnotationsServiceProvider;
@@ -67,4 +69,8 @@ $container->set('graphqlite.namespace.types', ['App\\Types']);
 $container->set('graphqlite.namespace.controllers', ['App\\Controllers']);
 
 $schema = $container->get(Schema::class);
+
+// or if you want the PSR-15 middleware:
+
+$middleware = $container->get(Psr15GraphQLMiddlewareBuilder::class);
 ```

--- a/src/Http/Psr15GraphQLMiddlewareBuilder.php
+++ b/src/Http/Psr15GraphQLMiddlewareBuilder.php
@@ -1,0 +1,106 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Http;
+
+use GraphQL\Error\Debug;
+use GraphQL\Server\ServerConfig;
+use GraphQL\Type\Schema;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use TheCodingMachine\GraphQLite\Exceptions\WebonyxErrorHandler;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
+use Zend\Diactoros\ResponseFactory;
+use Zend\Diactoros\StreamFactory;
+use function class_exists;
+
+/**
+ * A factory generating a PSR-15 middleware tailored for GraphQLite.
+ */
+class Psr15GraphQLMiddlewareBuilder
+{
+    /**
+     * @var string
+     */
+    private $url = '/graphql';
+    /**
+     * @var ServerConfig
+     */
+    private $config;
+
+    /**
+     * @var ResponseFactoryInterface|null
+     */
+    private $responseFactory;
+
+    /**
+     * @var StreamFactoryInterface|null
+     */
+    private $streamFactory;
+
+    /**
+     * @var HttpCodeDeciderInterface|null
+     */
+    private $httpCodeDecider;
+
+    public function __construct(Schema $schema)
+    {
+        $this->config = new ServerConfig();
+        $this->config->setSchema($schema);
+        $this->config->setDebug(Debug::RETHROW_UNSAFE_EXCEPTIONS);
+        $this->config->setErrorFormatter([WebonyxErrorHandler::class, 'errorFormatter']);
+        $this->config->setErrorsHandler([WebonyxErrorHandler::class, 'errorHandler']);
+        $this->httpCodeDecider = new HttpCodeDecider();
+    }
+
+    public function setUrl(string $url): self
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    public function getConfig(): ServerConfig
+    {
+        return $this->config;
+    }
+
+    public function setConfig(ServerConfig $config): self
+    {
+        $this->config = $config;
+        return $this;
+    }
+
+    public function setResponseFactory(ResponseFactoryInterface $responseFactory): self
+    {
+        $this->responseFactory = $responseFactory;
+        return $this;
+    }
+
+    public function setStreamFactory(StreamFactoryInterface $streamFactory): self
+    {
+        $this->streamFactory = $streamFactory;
+        return $this;
+    }
+
+    public function setHttpCodeDecider(HttpCodeDeciderInterface $httpCodeDecider): self
+    {
+        $this->httpCodeDecider = $httpCodeDecider;
+        return $this;
+    }
+
+    public function createMiddleware(): MiddlewareInterface
+    {
+        if ($this->responseFactory === null && !class_exists(ResponseFactory::class)) {
+            throw new GraphQLRuntimeException('You need to set a ResponseFactory to use the Psr15GraphQLMiddlewareBuilder. Call Psr15GraphQLMiddlewareBuilder::setResponseFactory or try installing zend-diactoros: composer require zendframework/zend-diactoros'); // @codeCoverageIgnore
+        }
+        $this->responseFactory = $this->responseFactory ?: new ResponseFactory();
+
+        if ($this->streamFactory === null && !class_exists(StreamFactory::class)) {
+            throw new GraphQLRuntimeException('You need to set a StreamFactory to use the Psr15GraphQLMiddlewareBuilder. Call Psr15GraphQLMiddlewareBuilder::setStreamFactory or try installing zend-diactoros: composer require zendframework/zend-diactoros'); // @codeCoverageIgnore
+        }
+        $this->responseFactory = $this->responseFactory ?: new ResponseFactory();
+
+        return new WebonyxGraphqlMiddleware($this->config, $this->responseFactory, $this->streamFactory, $this->httpCodeDecider, $this->url);
+    }
+}

--- a/src/Http/Psr15GraphQLMiddlewareBuilder.php
+++ b/src/Http/Psr15GraphQLMiddlewareBuilder.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Http;
 
@@ -20,28 +21,18 @@ use function class_exists;
  */
 class Psr15GraphQLMiddlewareBuilder
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $url = '/graphql';
-    /**
-     * @var ServerConfig
-     */
+    /** @var ServerConfig */
     private $config;
 
-    /**
-     * @var ResponseFactoryInterface|null
-     */
+    /** @var ResponseFactoryInterface|null */
     private $responseFactory;
 
-    /**
-     * @var StreamFactoryInterface|null
-     */
+    /** @var StreamFactoryInterface|null */
     private $streamFactory;
 
-    /**
-     * @var HttpCodeDeciderInterface|null
-     */
+    /** @var HttpCodeDeciderInterface */
     private $httpCodeDecider;
 
     public function __construct(Schema $schema)
@@ -57,6 +48,7 @@ class Psr15GraphQLMiddlewareBuilder
     public function setUrl(string $url): self
     {
         $this->url = $url;
+
         return $this;
     }
 
@@ -68,38 +60,42 @@ class Psr15GraphQLMiddlewareBuilder
     public function setConfig(ServerConfig $config): self
     {
         $this->config = $config;
+
         return $this;
     }
 
     public function setResponseFactory(ResponseFactoryInterface $responseFactory): self
     {
         $this->responseFactory = $responseFactory;
+
         return $this;
     }
 
     public function setStreamFactory(StreamFactoryInterface $streamFactory): self
     {
         $this->streamFactory = $streamFactory;
+
         return $this;
     }
 
     public function setHttpCodeDecider(HttpCodeDeciderInterface $httpCodeDecider): self
     {
         $this->httpCodeDecider = $httpCodeDecider;
+
         return $this;
     }
 
     public function createMiddleware(): MiddlewareInterface
     {
-        if ($this->responseFactory === null && !class_exists(ResponseFactory::class)) {
+        if ($this->responseFactory === null && ! class_exists(ResponseFactory::class)) {
             throw new GraphQLRuntimeException('You need to set a ResponseFactory to use the Psr15GraphQLMiddlewareBuilder. Call Psr15GraphQLMiddlewareBuilder::setResponseFactory or try installing zend-diactoros: composer require zendframework/zend-diactoros'); // @codeCoverageIgnore
         }
         $this->responseFactory = $this->responseFactory ?: new ResponseFactory();
 
-        if ($this->streamFactory === null && !class_exists(StreamFactory::class)) {
+        if ($this->streamFactory === null && ! class_exists(StreamFactory::class)) {
             throw new GraphQLRuntimeException('You need to set a StreamFactory to use the Psr15GraphQLMiddlewareBuilder. Call Psr15GraphQLMiddlewareBuilder::setStreamFactory or try installing zend-diactoros: composer require zendframework/zend-diactoros'); // @codeCoverageIgnore
         }
-        $this->responseFactory = $this->responseFactory ?: new ResponseFactory();
+        $this->streamFactory = $this->streamFactory ?: new StreamFactory();
 
         return new WebonyxGraphqlMiddleware($this->config, $this->responseFactory, $this->streamFactory, $this->httpCodeDecider, $this->url);
     }

--- a/src/Http/WebonyxGraphqlMiddleware.php
+++ b/src/Http/WebonyxGraphqlMiddleware.php
@@ -1,0 +1,206 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Http;
+
+use GraphQL\Error\Debug;
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\Executor\Promise\Promise;
+use GraphQL\Server\ServerConfig;
+use GraphQL\Server\StandardServer;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+use function json_decode;
+use const JSON_ERROR_NONE;
+use function array_map;
+use function explode;
+use function in_array;
+use function is_array;
+use function json_encode;
+use function json_last_error;
+use function json_last_error_msg;
+
+final class WebonyxGraphqlMiddleware implements MiddlewareInterface
+{
+    /** @var StandardServer */
+    private $standardServer;
+    /** @var string */
+    private $graphqlUri;
+    /** @var string[] */
+    private $graphqlHeaderList = ['application/graphql'];
+    /** @var string[] */
+    private $allowedMethods = [
+        'GET',
+        'POST',
+    ];
+
+    /** @var bool|int */
+    //private $debug;
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+    /** @var StreamFactoryInterface */
+    private $streamFactory;
+    /**
+     * @var HttpCodeDeciderInterface
+     */
+    private $httpCodeDecider;
+    /**
+     * @var ServerConfig
+     */
+    private $config;
+
+    /**
+     * @param bool|int $debug
+     */
+    public function __construct(
+        ServerConfig $config,
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory,
+        HttpCodeDeciderInterface $httpCodeDecider,
+        string $graphqlUri = '/graphql',
+        StandardServer $handler = null
+    ) {
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory   = $streamFactory;
+        $this->graphqlUri      = $graphqlUri;
+        $this->httpCodeDecider = $httpCodeDecider;
+        $this->config = $config;
+        $this->standardServer  = $handler ?: new StandardServer($config);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        if (! $this->isGraphqlRequest($request)) {
+            return $handler->handle($request);
+        }
+
+        // Let's json deserialize if this is not already done.
+        if ($request->getParsedBody() === null) {
+            $content = $request->getBody()->getContents();
+            $data = json_decode($content, true);
+
+            // FIXME: DO WE NEED THIS????
+            if ($data === false || json_last_error() !== JSON_ERROR_NONE) {
+                throw new InvalidArgumentException(json_last_error_msg().' in body: "'.$content.'"'); // @codeCoverageIgnore
+            }
+
+            $request = $request->withParsedBody($data);
+        }
+
+        $result = $this->standardServer->executePsrRequest($request);
+        //return $this->standardServer->processPsrRequest($request, $this->responseFactory->createResponse(), $this->streamFactory->createStream());
+
+        return $this->getJsonResponse($this->processResult($result), $this->decideHttpCode($result));
+    }
+
+    /**
+     * @param ExecutionResult|ExecutionResult[]|Promise $result
+     *
+     * @return mixed[]
+     */
+    private function processResult($result) : array
+    {
+        if ($result instanceof ExecutionResult) {
+            return $result->toArray($this->config->getDebug());
+        }
+
+        if (is_array($result)) {
+            return array_map(function (ExecutionResult $executionResult) {
+                return $executionResult->toArray($this->config->getDebug());
+            }, $result);
+        }
+
+        if ($result instanceof Promise) {
+            throw new RuntimeException('Only SyncPromiseAdapter is supported');
+        }
+
+        throw new RuntimeException('Unexpected response from StandardServer::executePsrRequest'); // @codeCoverageIgnore
+    }
+
+    /**
+     * @param ExecutionResult|ExecutionResult[]|Promise $result
+     *
+     * @return int
+     */
+    private function decideHttpCode($result) : int
+    {
+        if ($result instanceof ExecutionResult) {
+            return $this->httpCodeDecider->decideHttpStatusCode($result);
+        }
+
+        if (is_array($result)) {
+            $codes = array_map(function (ExecutionResult $executionResult) {
+                return $this->httpCodeDecider->decideHttpStatusCode($executionResult);
+            }, $result);
+            return max($codes);
+        }
+
+        // @codeCoverageIgnoreStart
+        // Code unreachable because exceptions will be triggered in processResult first.
+        // We keep it for defensive programming purpose
+        if ($result instanceof Promise) {
+            throw new RuntimeException('Only SyncPromiseAdapter is supported');
+        }
+
+        throw new RuntimeException('Unexpected response from StandardServer::executePsrRequest');
+        // @codeCoverageIgnoreEnd
+    }
+
+    private function isGraphqlRequest(ServerRequestInterface $request) : bool
+    {
+        return $this->isMethodAllowed($request) && ($this->hasUri($request) || $this->hasGraphQLHeader($request));
+    }
+
+    private function isMethodAllowed(ServerRequestInterface $request) : bool
+    {
+        return in_array($request->getMethod(), $this->allowedMethods, true);
+    }
+
+    private function hasUri(ServerRequestInterface $request) : bool
+    {
+        return $this->graphqlUri === $request->getUri()->getPath();
+    }
+
+    private function hasGraphQLHeader(ServerRequestInterface $request) : bool
+    {
+        if (! $request->hasHeader('content-type')) {
+            return false;
+        }
+
+        $requestHeaderList = array_map('trim', explode(',', $request->getHeaderLine('content-type')));
+
+        foreach ($this->graphqlHeaderList as $allowedHeader) {
+            if (in_array($allowedHeader, $requestHeaderList, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed[] $array
+     */
+    private function getJsonResponse(array $array, int $statusCode) : ResponseInterface
+    {
+        $response = $this->responseFactory->createResponse();
+        $data     = json_encode($array);
+
+        if ($data === false || json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidArgumentException(json_last_error_msg()); // @codeCoverageIgnore
+        }
+
+        $stream   = $this->streamFactory->createStream($data);
+        $response = $response->withBody($stream)
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus($statusCode);
+
+        return $response;
+    }
+}

--- a/tests/Http/Psr15GraphQLMiddlewareBuilderTest.php
+++ b/tests/Http/Psr15GraphQLMiddlewareBuilderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Http;
+
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\Server\ServerConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\Component\Cache\Simple\ArrayCache;
+use TheCodingMachine\GraphQLite\AggregateQueryProvider;
+use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
+use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
+use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewarePipe;
+use TheCodingMachine\GraphQLite\SchemaFactory;
+use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
+use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
+use Zend\Diactoros\Response\TextResponse;
+use Zend\Diactoros\ResponseFactory;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\StreamFactory;
+use function fopen;
+use function fwrite;
+use function json_decode;
+use function json_encode;
+use function rewind;
+
+class Psr15GraphQLMiddlewareBuilderTest extends TestCase
+{
+
+    public function testCreateMiddleware()
+    {
+        $container = new BasicAutoWiringContainer(new EmptyContainer());
+        $cache = new ArrayCache();
+
+        $factory = new SchemaFactory($cache, $container);
+        $factory->setAuthenticationService(new VoidAuthenticationService());
+        $factory->setAuthorizationService(new VoidAuthorizationService());
+
+        $factory->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers');
+        $factory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
+
+        $schema = $factory->createSchema();
+
+        $middlewareBuilder = new Psr15GraphQLMiddlewareBuilder($schema);
+        $middlewareBuilder->setConfig($middlewareBuilder->getConfig());
+        $middlewareBuilder->setHttpCodeDecider(new HttpCodeDecider());
+        $middlewareBuilder->setStreamFactory(new StreamFactory());
+        $middlewareBuilder->setResponseFactory(new ResponseFactory());
+        $middlewareBuilder->setUrl('/foobar');
+
+        $handler = new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request) : ResponseInterface
+            {
+                return new TextResponse('skipped');
+            }
+        };
+
+        $middleware = $middlewareBuilder->createMiddleware();
+        $request = $this->createRequest();
+        $content = $middleware->process($request, $handler)->getBody()->getContents();
+        $data = json_decode($content, true)['data'];
+        $this->assertSame('Joe', $data['contacts'][0]['name']);
+    }
+
+    private function createRequest() : ServerRequest
+    {
+        $data        = [
+            'query'     => "{\n contacts {\nname\n}\n}",
+            'variables' => ['id' => '4d967a0f65224f1685a602cbe4eef667'],
+        ];
+        $jsonContent = json_encode($data);
+        $stream      = fopen('php://memory', 'rb+');
+        fwrite($stream, $jsonContent);
+        rewind($stream);
+        return new ServerRequest(
+            [],
+            [],
+            '/foobar',
+            'POST',
+            $stream,
+            [
+                'content-type' => 'application/json'
+            ]
+        );
+    }
+}

--- a/tests/Http/WebonyxGraphqlMiddlewareTest.php
+++ b/tests/Http/WebonyxGraphqlMiddlewareTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Http;
+
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\Executor\Promise\Adapter\SyncPromise;
+use GraphQL\Executor\Promise\Adapter\SyncPromiseAdapter;
+use GraphQL\Executor\Promise\Promise;
+use GraphQL\Server\ServerConfig;
+use GraphQL\Server\StandardServer;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Response\TextResponse;
+use Zend\Diactoros\ResponseFactory;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\StreamFactory;
+use Zend\Diactoros\Uri;
+use function fopen;
+use function fwrite;
+use function json_encode;
+use function rewind;
+
+class WebonyxGraphqlMiddlewareTest extends TestCase
+{
+    public function testProcess() : void
+    {
+        $handler = new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request) : ResponseInterface
+            {
+                return new TextResponse('skipped');
+            }
+        };
+        $standardServer = new class extends StandardServer {
+            /** @var ExecutionResult|ExecutionResult[]|Promise */
+            private $executionResult;
+            public function __construct()
+            {
+                parent::__construct([]);
+            }
+            /**
+             * @param ExecutionResult|ExecutionResult[]|Promise $executionResult
+             */
+            public function setExecutionResult($executionResult) : void
+            {
+                $this->executionResult = $executionResult;
+            }
+
+            /**
+             * @return ExecutionResult|ExecutionResult[]|Promise
+             */
+            public function executePsrRequest(ServerRequestInterface $request)
+            {
+                return $this->executionResult;
+            }
+        };
+        $middleware = new WebonyxGraphqlMiddleware(
+            new ServerConfig(),
+            new ResponseFactory(),
+            new StreamFactory(),
+            new HttpCodeDecider(),
+            '/graphql',
+            $standardServer
+        );
+        $standardServer->setExecutionResult(new ExecutionResult(['foo']));
+        $request = $this->createRequest();
+        $this->assertSame('skipped', $middleware->process($request, $handler)->getBody()->getContents());
+        $request = $this->createRequest()->withHeader('content-type', 'application/graphql');
+        $this->assertSame('{"data":["foo"]}', $middleware->process($request, $handler)->getBody()->getContents());
+        $request = $this->createRequest()->withHeader('content-type', 'application/json');
+        $this->assertSame('skipped', $middleware->process($request, $handler)->getBody()->getContents());
+        $request = $this->createRequest()->withUri(new Uri('/graphql'));
+        $this->assertSame('{"data":["foo"]}', $middleware->process($request, $handler)->getBody()->getContents());
+        $request = $this->createRequest()->withUri(new Uri('/graphql'));
+        $standardServer->setExecutionResult([new ExecutionResult(['foo']), new ExecutionResult(['bar'])]);
+        $this->assertSame(
+            '[{"data":["foo"]},{"data":["bar"]}]',
+            $middleware->process($request, $handler)->getBody()->getContents()
+        );
+        $syncPromise = new SyncPromise();
+        $request = $this->createRequest()->withUri(new Uri('/graphql'));
+        $standardServer->setExecutionResult(new Promise($syncPromise, new SyncPromiseAdapter()));
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Only SyncPromiseAdapter is supported');
+        $middleware->process($request, $handler);
+    }
+    private function createRequest() : ServerRequest
+    {
+        $data        = [
+            'query'     => 'query getMatter($id: String!) {\n matter(id: $id) {\nid\n}\n}',
+            'variables' => ['id' => '4d967a0f65224f1685a602cbe4eef667'],
+        ];
+        $jsonContent = json_encode($data);
+        $stream      = fopen('php://memory', 'r+');
+        fwrite($stream, $jsonContent);
+        rewind($stream);
+        return new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            $stream,
+            []
+        );
+    }
+}


### PR DESCRIPTION
This PR internalizes the PSR-15 middleware into GraphQLite core.
By making it internal, we can more easily manage inner settings and tailor them to GraphQLite (for instance to manage the default root object...)