### PR TITLE
Fix docblock union types not discoverable in type registry

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -65,14 +65,15 @@ class FieldsBuilder
         NamingStrategyInterface $namingStrategy,
         RootTypeMapperInterface $rootTypeMapper,
         ParameterMiddlewareInterface $parameterMapper,
-        FieldMiddlewareInterface $fieldMiddleware
+        FieldMiddlewareInterface $fieldMiddleware,
+        TypeRegistry $typeRegistry
     ) {
         $this->annotationReader      = $annotationReader;
         $this->recursiveTypeMapper   = $typeMapper;
         $this->typeResolver          = $typeResolver;
         $this->cachedDocBlockFactory = $cachedDocBlockFactory;
         $this->namingStrategy        = $namingStrategy;
-        $this->typeMapper            = new TypeHandler($typeMapper, $argumentResolver, $rootTypeMapper, $typeResolver);
+        $this->typeMapper            = new TypeHandler($typeMapper, $argumentResolver, $rootTypeMapper, $typeResolver, $typeRegistry);
         $this->parameterMapper       = $parameterMapper;
         $this->fieldMiddleware = $fieldMiddleware;
     }

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -39,6 +39,7 @@ use TheCodingMachine\GraphQLite\Parameters\DefaultValueParameter;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\TypeMappingRuntimeException;
+use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
@@ -60,18 +61,22 @@ class TypeHandler implements ParameterHandlerInterface
     private $rootTypeMapper;
     /** @var TypeResolver */
     private $typeResolver;
+    /** @var \TheCodingMachine\GraphQLite\TypeRegistry */
+    private $typeRegistry;
 
     public function __construct(
         RecursiveTypeMapperInterface $typeMapper,
         ArgumentResolver $argumentResolver,
         RootTypeMapperInterface $rootTypeMapper,
-        TypeResolver $typeResolver
+        TypeResolver $typeResolver,
+        TypeRegistry $typeRegistry
     ) {
         $this->recursiveTypeMapper       = $typeMapper;
         $this->argumentResolver          = $argumentResolver;
         $this->rootTypeMapper            = $rootTypeMapper;
         $this->phpDocumentorTypeResolver = new PhpDocumentorTypeResolver();
         $this->typeResolver              = $typeResolver;
+        $this->typeRegistry = $typeRegistry;
     }
 
     /**
@@ -257,6 +262,8 @@ class TypeHandler implements ParameterHandlerInterface
             }
 
             $graphQlType = new UnionType($unionTypes, $this->recursiveTypeMapper);
+            $this->typeRegistry->registerType($graphQlType);
+
         }
 
         /* elseif (count($filteredDocBlockTypes) === 1) {
@@ -323,6 +330,7 @@ class TypeHandler implements ParameterHandlerInterface
             $graphQlType = $unionTypes[0];
         } else {
             $graphQlType = new UnionType($unionTypes, $this->recursiveTypeMapper);
+            $this->typeRegistry->registerType($graphQlType);
         }
 
         if (! $isNullable) {

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -61,7 +61,7 @@ class TypeHandler implements ParameterHandlerInterface
     private $rootTypeMapper;
     /** @var TypeResolver */
     private $typeResolver;
-    /** @var \TheCodingMachine\GraphQLite\TypeRegistry */
+    /** @var TypeRegistry */
     private $typeRegistry;
 
     public function __construct(
@@ -263,7 +263,6 @@ class TypeHandler implements ParameterHandlerInterface
 
             $graphQlType = new UnionType($unionTypes, $this->recursiveTypeMapper);
             $this->typeRegistry->registerType($graphQlType);
-
         }
 
         /* elseif (count($filteredDocBlockTypes) === 1) {

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -348,7 +348,8 @@ class SchemaFactory
             $namingStrategy,
             $compositeRootTypeMapper,
             $parameterMiddlewarePipe,
-            $fieldMiddlewarePipe
+            $fieldMiddlewarePipe,
+            $typeRegistry
         );
 
         $typeGenerator      = new TypeGenerator($annotationReader, $namingStrategy, $typeRegistry, $this->container, $recursiveTypeMapper, $fieldsBuilder);

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -13,6 +13,7 @@ use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
+use TheCodingMachine\GraphQLite\Types\UnionType;
 use function get_class;
 
 /**
@@ -20,7 +21,7 @@ use function get_class;
  */
 class TypeRegistry
 {
-    /** @var array<string,NamedType&Type&(MutableObjectType|InterfaceType|(InputObjectType&ResolvableMutableInputInterface))> */
+    /** @var array<string,NamedType&Type&(MutableObjectType|InterfaceType|UnionType|(InputObjectType&ResolvableMutableInputInterface))> */
     private $outputTypes = [];
 
     /**
@@ -28,7 +29,7 @@ class TypeRegistry
      * IMPORTANT: the type MUST be fully computed (so ExtendType annotations must have ALREADY been applied to the tag)
      * ONLY THE RecursiveTypeMapper IS ALLOWED TO CALL THIS METHOD.
      *
-     * @param NamedType&Type&(MutableObjectType|InterfaceType|(InputObjectType&ResolvableMutableInputInterface)) $type
+     * @param NamedType&Type&(MutableObjectType|InterfaceType|UnionType|(InputObjectType&ResolvableMutableInputInterface)) $type
      */
     public function registerType(NamedType $type): void
     {
@@ -44,7 +45,7 @@ class TypeRegistry
     }
 
     /**
-     * @return NamedType&Type&(ObjectType|InterfaceType|(InputObjectType&ResolvableMutableInputInterface))
+     * @return NamedType&Type&(ObjectType|InterfaceType|UnionType|(InputObjectType&ResolvableMutableInputInterface))
      */
     public function getType(string $typeName): NamedType
     {

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -294,7 +294,8 @@ abstract class AbstractQueryProviderTest extends TestCase
                 new BaseTypeMapper($this->getTypeMapper())
             ]),
             $this->getParameterMiddlewarePipe(),
-            $fieldMiddlewarePipe
+            $fieldMiddlewarePipe,
+            $this->getTypeRegistry()
         );
     }
 

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -293,7 +293,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new AuthorizationFieldMiddleware(
                 $authenticationService,
                 new VoidAuthorizationService()
-            )
+            ),
+            $this->getTypeRegistry()
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -324,7 +325,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new AuthorizationFieldMiddleware(
                 new VoidAuthenticationService(),
                 $authorizationService
-            )
+            ),
+            $this->getTypeRegistry()
         );
 
         $fields = $queryProvider->getFields(new TestType(), true);
@@ -385,7 +387,8 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
             new AuthorizationFieldMiddleware(
                 new VoidAuthenticationService(),
                 new VoidAuthorizationService()
-            )
+            ),
+            $this->getTypeRegistry()
         );
         $fields = $queryProvider->getFields(new TestTypeWithSourceFieldInterface(), true);
         $this->assertCount(1, $fields);

--- a/tests/Fixtures/Integration/Controllers/ProductController.php
+++ b/tests/Fixtures/Integration/Controllers/ProductController.php
@@ -6,13 +6,11 @@ namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Controllers;
 
 use DateTimeImmutable;
 use Porpaginas\Arrays\ArrayResult;
-use Psr\Http\Message\UploadedFileInterface;
-use TheCodingMachine\GraphQLite\Annotations\Mutation;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Product;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\ProductTypeEnum;
-use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\User;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\SpecialProduct;
 
 class ProductController
 {
@@ -40,7 +38,7 @@ class ProductController
             [
                 new Product('Foo', 42.0, ProductTypeEnum::NON_FOOD()),
                 new Product('Foo', 42.0, ProductTypeEnum::NON_FOOD()),
-            ]
+            ],
         ];
     }
 
@@ -58,5 +56,14 @@ class ProductController
     public function echoDate(DateTimeImmutable $date): DateTimeImmutable
     {
         return $date;
+    }
+
+    /**
+     * @Query(name="getProduct")
+     * @return \TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Product|\TheCodingMachine\GraphQLite\Fixtures\Integration\Models\SpecialProduct
+     */
+    public function getProduct()
+    {
+        return new SpecialProduct('Special box', 10.99);
     }
 }

--- a/tests/Fixtures/Integration/Models/SpecialProduct.php
+++ b/tests/Fixtures/Integration/Models/SpecialProduct.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * Class SpecialProduct
+ * @package TheCodingMachine\GraphQLite\Fixtures\Integration\Models
+ * @Type()
+ */
+class SpecialProduct
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var float
+     */
+    private $price;
+
+    public function __construct(string $name, float $price)
+    {
+        $this->name = $name;
+        $this->price = $price;
+    }
+
+    /**
+     * @Field()
+     * @return string
+     */
+    public function getSpecial(): string
+    {
+        return "unicorn";
+    }
+
+    /**
+     * @Field()
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @Field()
+     * @return float
+     */
+    public function getPrice(): float
+    {
+        return $this->price;
+    }
+}

--- a/tests/Mappers/Parameters/TypeMapperTest.php
+++ b/tests/Mappers/Parameters/TypeMapperTest.php
@@ -22,7 +22,7 @@ class TypeMapperTest extends AbstractQueryProviderTest
         $typeMapper = new TypeHandler($this->getTypeMapper(), $this->getArgumentResolver(), new CompositeRootTypeMapper([
             new MyCLabsEnumTypeMapper(),
             new BaseTypeMapper($this->getTypeMapper())
-        ]), $this->getTypeResolver());
+        ]), $this->getTypeResolver(), $this->getTypeRegistry());
 
         $cachedDocBlockFactory = new CachedDocBlockFactory(new ArrayCache());
 
@@ -39,7 +39,7 @@ class TypeMapperTest extends AbstractQueryProviderTest
         $typeMapper = new TypeHandler($this->getTypeMapper(), $this->getArgumentResolver(), new CompositeRootTypeMapper([
             new MyCLabsEnumTypeMapper(),
             new BaseTypeMapper($this->getTypeMapper())
-        ]), $this->getTypeResolver());
+        ]), $this->getTypeResolver(), $this->getTypeRegistry());
 
         $cachedDocBlockFactory = new CachedDocBlockFactory(new ArrayCache());
 
@@ -61,7 +61,7 @@ class TypeMapperTest extends AbstractQueryProviderTest
         $typeMapper = new TypeHandler($this->getTypeMapper(), $this->getArgumentResolver(), new CompositeRootTypeMapper([
             new MyCLabsEnumTypeMapper(),
             new BaseTypeMapper($this->getTypeMapper())
-        ]), $this->getTypeResolver());
+        ]), $this->getTypeResolver(), $this->getTypeRegistry());
 
         $cachedDocBlockFactory = new CachedDocBlockFactory(new ArrayCache());
 


### PR DESCRIPTION
I found a problem using union types. They get discovered and displayed in schema but never mapped to their instance type. 

This resulted in 
```
cannot find GraphQL type "UnionTypeOneType2". Check your TypeMapper configuration.
```

This PR is an attempt to fix this. I also included end to end test with a new product type.

I injected the `typeRegistry` directly into the TypeHandler which I don't like very much but wasn't able  to figure out cleaner solution. Comments are quite welcome

Thank you for this awesome library !