### PR TITLE
Fixed incorrect comparison operator

### DIFF
--- a/src/Http/WebonyxGraphqlMiddleware.php
+++ b/src/Http/WebonyxGraphqlMiddleware.php
@@ -76,7 +76,7 @@ final class WebonyxGraphqlMiddleware implements MiddlewareInterface
         }
 
         // Let's json deserialize if this is not already done.
-        if ($request->getParsedBody() === null) {
+        if ($request->getParsedBody() !== null) {
             $content = $request->getBody()->getContents();
             $data = json_decode($content, true);
 


### PR DESCRIPTION
GraphQL won't parse the request body payload for GraphQL JSON.  Additionally, it won't fetch the schema as is typically handled through common GraphQL clients.