### PR TITLE
Exception on duplicate queries

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -17,6 +17,7 @@ use TheCodingMachine\GraphQLite\Annotations\SourceField;
 use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\DuplicateMappingException;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMiddlewareInterface;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\TypeHandler;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
@@ -31,6 +32,7 @@ use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use Webmozart\Assert\Assert;
 use function array_merge;
 use function array_shift;
+use function array_values;
 use function get_parent_class;
 use function ucfirst;
 
@@ -317,7 +319,10 @@ class FieldsBuilder
             });
 
             if ($field !== null) {
-                $queryList[] = $field;
+                if (isset($queryList[$fieldDescriptor->getName()])) {
+                    throw DuplicateMappingException::createForQuery($refClass->getName(), $fieldDescriptor->getName());
+                }
+                $queryList[$fieldDescriptor->getName()] = $field;
             }
 
             /*if ($unauthorized) {
@@ -332,7 +337,7 @@ class FieldsBuilder
             }*/
         }
 
-        return $queryList;
+        return array_values($queryList);
     }
 
     /**

--- a/src/Mappers/DuplicateMappingException.php
+++ b/src/Mappers/DuplicateMappingException.php
@@ -23,4 +23,9 @@ class DuplicateMappingException extends RuntimeException
     {
         throw new self(sprintf("The type '%s' is created by 2 different classes: '%s' and '%s'", $type, $sourceClass1, $sourceClass2));
     }
+
+    public static function createForQuery(string $sourceClass, string $queryName): self
+    {
+        throw new self(sprintf("The query '%s' is duplicate in class '%s'", $queryName, $sourceClass));
+    }
 }

--- a/tests/Fixtures/DuplicateQueries/TestControllerWithDuplicateQuery.php
+++ b/tests/Fixtures/DuplicateQueries/TestControllerWithDuplicateQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DuplicateQueries;
+
+use ArrayObject;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+
+class TestControllerWithDuplicateQuery
+{
+    /**
+     * @Query(name="duplicateQuery")
+     */
+    public function testDuplicateQuery1(): string
+    {
+        return 'string1';
+    }
+
+    /**
+     * @Query(name="duplicateQuery")
+     */
+    public function testDuplicateQuery2(): string
+    {
+        return 'string2';
+    }
+}

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -179,4 +179,22 @@ class SchemaFactoryTest extends TestCase
             ]
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
+
+    public function testDuplicateQueryException(): void
+    {
+        $factory = new SchemaFactory(
+            new ArrayCache(),
+            new BasicAutoWiringContainer(
+                new EmptyContainer()
+            )
+        );
+        $factory->setAuthenticationService(new VoidAuthenticationService())
+                ->setAuthorizationService(new VoidAuthorizationService())
+                ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\DuplicateQueries')
+                ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
+
+        $this->expectException(GraphQLRuntimeException::class);
+        $schema = $factory->createSchema();
+    }
+
 }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Component\Cache\Psr16Cache;
-use Symfony\Component\Cache\Simple\ArrayCache;
-use Symfony\Component\Cache\Simple\PhpFilesCache;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
@@ -185,7 +183,7 @@ class SchemaFactoryTest extends TestCase
     public function testDuplicateQueryException(): void
     {
         $factory = new SchemaFactory(
-            new ArrayCache(),
+            new Psr16Cache(new ArrayAdapter()),
             new BasicAutoWiringContainer(
                 new EmptyContainer()
             )

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -17,6 +17,7 @@ use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\DuplicateMappingException;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterHandler;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\TypeHandler;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
@@ -31,6 +32,7 @@ use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 use TheCodingMachine\GraphQLite\Fixtures\TestSelfType;
+
 
 class SchemaFactoryTest extends TestCase
 {
@@ -193,8 +195,17 @@ class SchemaFactoryTest extends TestCase
                 ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\DuplicateQueries')
                 ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
 
-        $this->expectException(GraphQLRuntimeException::class);
+        $this->expectException(DuplicateMappingException::class);
         $schema = $factory->createSchema();
+        $queryString = '
+        query {
+            duplicateQuery
+        }
+        ';
+        GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
     }
 
 }


### PR DESCRIPTION
This pull request adds an exception in case there are duplicate queries defined in your controller as specified in #175 

- [x] write unit test
- [x] make unit tests green again