### PR TITLE
Parameter annotations (@Autowire...) cannot be written in @SourceFields

### DIFF
--- a/src/Annotations/Autowire.php
+++ b/src/Annotations/Autowire.php
@@ -11,7 +11,7 @@ use function ltrim;
  * Use this annotation to autowire a service from the container into a given parameter of a field/query/mutation.
  *
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"METHOD", "ANNOTATION"})
  * @Attributes({
  *   @Attribute("for", type = "string"),
  *   @Attribute("identifier", type = "string")

--- a/src/Annotations/Exceptions/InvalidParameterException.php
+++ b/src/Annotations/Exceptions/InvalidParameterException.php
@@ -14,4 +14,9 @@ class InvalidParameterException extends BadMethodCallException
     {
         return new self(sprintf('Parameter "%s" declared in annotation "%s" of method "%s::%s()" does not exist.', $parameter, $annotationClass, $reflectionMethod->getDeclaringClass()->getName(), $reflectionMethod->getName()));
     }
+
+    public static function parameterNotFoundFromSourceField(string $parameter, string $annotationClass, ReflectionMethod $reflectionMethod): self
+    {
+        return new self(sprintf('Could not find parameter "%s" declared in annotation "%s". This annotation is itself declared in a SourceField annotation targeting resolver "%s::%s()".', $parameter, $annotationClass, $reflectionMethod->getDeclaringClass()->getName(), $reflectionMethod->getName()));
+    }
 }

--- a/src/Annotations/Exceptions/InvalidParameterException.php
+++ b/src/Annotations/Exceptions/InvalidParameterException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Annotations\Exceptions;
+
+use BadMethodCallException;
+use ReflectionMethod;
+use function sprintf;
+
+class InvalidParameterException extends BadMethodCallException
+{
+    public static function parameterNotFound(string $parameter, string $annotationClass, ReflectionMethod $reflectionMethod): self
+    {
+        return new self(sprintf('Parameter "%s" declared in annotation "%s" of method "%s::%s()" does not exist.', $parameter, $annotationClass, $reflectionMethod->getDeclaringClass()->getName(), $reflectionMethod->getName()));
+    }
+}

--- a/src/Annotations/HideParameter.php
+++ b/src/Annotations/HideParameter.php
@@ -12,7 +12,7 @@ use function ltrim;
  * This is only possible if the parameter has a default value.
  *
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"METHOD", "ANNOTATION"})
  * @Attributes({
  *   @Attribute("for", type = "string")
  * })

--- a/src/Annotations/ParameterAnnotations.php
+++ b/src/Annotations/ParameterAnnotations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use function array_filter;
+use function array_merge;
 use function array_pop;
 use function count;
 
@@ -52,5 +53,10 @@ class ParameterAnnotations
         }
 
         return array_pop($annotations);
+    }
+
+    public function merge(ParameterAnnotations $parameterAnnotations): void
+    {
+        $this->annotations = array_merge($this->annotations, $parameterAnnotations->annotations);
     }
 }

--- a/src/Annotations/ParameterAnnotations.php
+++ b/src/Annotations/ParameterAnnotations.php
@@ -55,6 +55,14 @@ class ParameterAnnotations
         return array_pop($annotations);
     }
 
+    /**
+     * @return array<int, ParameterAnnotationInterface>
+     */
+    public function getAllAnnotations(): array
+    {
+        return $this->annotations;
+    }
+
     public function merge(ParameterAnnotations $parameterAnnotations): void
     {
         $this->annotations = array_merge($this->annotations, $parameterAnnotations->annotations);

--- a/src/Annotations/SourceField.php
+++ b/src/Annotations/SourceField.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\GraphQLite\Annotations;
 use BadMethodCallException;
 use function array_key_exists;
 use function array_map;
+use function is_array;
 
 /**
  * SourceFields are fields that are directly source from the base object into GraphQL.
@@ -51,7 +52,11 @@ class SourceField implements SourceFieldInterface
         $this->outputType = $attributes['outputType'] ?? null;
         $middlewareAnnotations = [];
         $parameterAnnotations = [];
-        foreach ($attributes['annotations'] ?? [] as $annotation) {
+        $annotations = $attributes['annotations'] ?? [];
+        if (! is_array($annotations)) {
+            $annotations = [ $annotations ];
+        }
+        foreach ($annotations ?? [] as $annotation) {
             if ($annotation instanceof MiddlewareAnnotationInterface) {
                 $middlewareAnnotations[] = $annotation;
             } elseif ($annotation instanceof ParameterAnnotationInterface) {

--- a/src/Annotations/SourceFieldInterface.php
+++ b/src/Annotations/SourceFieldInterface.php
@@ -20,5 +20,10 @@ interface SourceFieldInterface
      */
     public function getOutputType(): ?string;
 
-    public function getAnnotations(): MiddlewareAnnotations;
+    public function getMiddlewareAnnotations(): MiddlewareAnnotations;
+
+    /**
+     * @return array<string, ParameterAnnotations> Key: the name of the attribute
+     */
+    public function getParameterAnnotations(): array;
 }

--- a/src/Annotations/UseInputType.php
+++ b/src/Annotations/UseInputType.php
@@ -11,7 +11,7 @@ use function ltrim;
  * Use this annotation to force using a specific input type for an input argument.
  *
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"METHOD", "ANNOTATION"})
  * @Attributes({
  *   @Attribute("for", type = "string"),
  *   @Attribute("inputType", type = "string"),

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -479,8 +479,11 @@ class FieldsBuilder
             }
         }
 
+        $parameterAnnotationsPerParameter = $this->annotationReader->getParameterAnnotationsPerParameter($refParameters);
+
         foreach ($refParameters as $parameter) {
-            $parameterAnnotations = $this->annotationReader->getParameterAnnotations($parameter);
+            $parameterAnnotations = $parameterAnnotationsPerParameter[$parameter->getName()] ?? new ParameterAnnotations([]);
+            //$parameterAnnotations = $this->annotationReader->getParameterAnnotations($parameter);
             if (! empty($additionalParameterAnnotations[$parameter->getName()])) {
                 $parameterAnnotations->merge($additionalParameterAnnotations[$parameter->getName()]);
             }

--- a/tests/AnnotationReaderTest.php
+++ b/tests/AnnotationReaderTest.php
@@ -143,4 +143,11 @@ class AnnotationReaderTest extends TestCase
         $this->expectException(AnnotationException::class);
         $annotationReader->getMethodAnnotations(new ReflectionMethod(ClassWithInvalidClassAnnotation::class, 'testMethod'), Type::class);
     }
+
+    public function testEmptyGetParameterAnnotations(): void
+    {
+        $annotationReader = new AnnotationReader(new DoctrineAnnotationReader());
+
+        $this->assertEmpty($annotationReader->getParameterAnnotationsPerParameter([]));
+    }
 }

--- a/tests/Annotations/SourceFieldTest.php
+++ b/tests/Annotations/SourceFieldTest.php
@@ -13,4 +13,10 @@ class SourceFieldTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         new SourceField([]);
     }
+
+    public function testExceptionInConstruct2(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        new SourceField(['name'=>'test', 'annotations'=>new Field()]);
+    }
 }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -21,11 +21,13 @@ use stdClass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Cache\Simple\ArrayCache;
+use TheCodingMachine\GraphQLite\Annotations\Exceptions\InvalidParameterException;
 use TheCodingMachine\GraphQLite\Fixtures\TestController;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerNoReturnType;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithArrayParam;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithArrayReturnType;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithBadSecurity;
+use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithInvalidParameterAnnotation;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithParamDateTime;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithFailWith;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithInputType;
@@ -746,6 +748,17 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $this->expectException(TypeMappingRuntimeException::class);
         $this->expectExceptionMessage('Parameter $testObject in TheCodingMachine\GraphQLite\Fixtures\TestControllerWithUnionInputParam::test is type-hinted to "\TheCodingMachine\GraphQLite\Fixtures\TestObject|\TheCodingMachine\GraphQLite\Fixtures\TestObject2". Type-hinting a parameter to a union type is forbidden in GraphQL. Only return types can be union types.');
+        $queries = $queryProvider->getQueries($controller);
+    }
+
+    public function testParameterAnnotationOnNonExistingParameter(): void
+    {
+        $controller = new TestControllerWithInvalidParameterAnnotation();
+
+        $queryProvider = $this->buildFieldsBuilder();
+
+        $this->expectException(InvalidParameterException::class);
+        $this->expectExceptionMessage('Parameter "id" declared in annotation "TheCodingMachine\\GraphQLite\\Annotations\\HideParameter" of method "TheCodingMachine\\GraphQLite\\Fixtures\\TestControllerWithInvalidParameterAnnotation::test()" does not exist.');
         $queries = $queryProvider->getQueries($controller);
     }
 }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -60,6 +60,7 @@ use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithPrefetchMethod;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithSourceFieldInterface;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
+use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithSourceFieldInvalidParameterAnnotation;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterHandler;
@@ -250,7 +251,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $queryProvider = $this->buildFieldsBuilder();
 
-        $fields = $queryProvider->getFields($controller, true);
+        $fields = $queryProvider->getFields($controller);
 
         $this->assertCount(3, $fields);
 
@@ -267,7 +268,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
     {
         $queryProvider = $this->buildFieldsBuilder();
 
-        $fields = $queryProvider->getSelfFields(TestSelfType::class, true);
+        $fields = $queryProvider->getSelfFields(TestSelfType::class);
 
         $this->assertCount(1, $fields);
 
@@ -760,5 +761,16 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage('Parameter "id" declared in annotation "TheCodingMachine\\GraphQLite\\Annotations\\HideParameter" of method "TheCodingMachine\\GraphQLite\\Fixtures\\TestControllerWithInvalidParameterAnnotation::test()" does not exist.');
         $queries = $queryProvider->getQueries($controller);
+    }
+
+    public function testParameterAnnotationOnNonExistingParameterInSourceField(): void
+    {
+        $controller = new TestTypeWithSourceFieldInvalidParameterAnnotation();
+
+        $queryProvider = $this->buildFieldsBuilder();
+
+        $this->expectException(InvalidParameterException::class);
+        $this->expectExceptionMessage('Could not find parameter "foo" declared in annotation "TheCodingMachine\\GraphQLite\\Annotations\\HideParameter". This annotation is itself declared in a SourceField annotation targeting resolver "TheCodingMachine\\GraphQLite\\Fixtures\\TestObject::getSibling()".');
+        $fields = $queryProvider->getFields($controller);
     }
 }

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -195,12 +195,12 @@ class Contact
         return 'OK';
     }
 
-    public function injectServiceFromExternal(string $testSkip = "foo", stdClass $otherTestService = null, string $id = '42'): string
+    public function injectServiceFromExternal(string $testService, string $testSkip = "foo", string $id = '42'): string
     {
-        if ($testSkip !== 'foo') {
+        if ($testService !== 'foo') {
             return 'KO';
         }
-        if (!$otherTestService instanceof stdClass) {
+        if ($testSkip !== 'foo') {
             return 'KO';
         }
         if ($id !== '42') {

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -194,4 +194,18 @@ class Contact
         }
         return 'OK';
     }
+
+    public function injectServiceFromExternal(string $testSkip = "foo", stdClass $otherTestService = null, string $id = '42'): string
+    {
+        if ($testSkip !== 'foo') {
+            return 'KO';
+        }
+        if (!$otherTestService instanceof stdClass) {
+            return 'KO';
+        }
+        if ($id !== '42') {
+            return 'KO';
+        }
+        return 'OK';
+    }
 }

--- a/tests/Fixtures/Integration/Types/ContactType.php
+++ b/tests/Fixtures/Integration/Types/ContactType.php
@@ -20,7 +20,7 @@ use TheCodingMachine\GraphQLite\Annotations\UseInputType;
  * @SourceField(name="birthDate")
  * @SourceField(name="manager")
  * @SourceField(name="relations")
- * @SourceField(name="injectServiceFromExternal", annotations={@Autowire(for="testService", identifier="testService"), @HideParameter(for="testSkip"), @UseInputType(for="ID!")})
+ * @SourceField(name="injectServiceFromExternal", annotations={@Autowire(for="testService", identifier="testService"), @HideParameter(for="testSkip"), @UseInputType(for="$id", inputType="String")})
  */
 class ContactType
 {

--- a/tests/Fixtures/Integration/Types/ContactType.php
+++ b/tests/Fixtures/Integration/Types/ContactType.php
@@ -10,6 +10,9 @@ use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\SourceField;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
+use TheCodingMachine\GraphQLite\Annotations\Autowire;
+use TheCodingMachine\GraphQLite\Annotations\HideParameter;
+use TheCodingMachine\GraphQLite\Annotations\UseInputType;
 
 /**
  * @ExtendType(class=Contact::class)
@@ -17,6 +20,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
  * @SourceField(name="birthDate")
  * @SourceField(name="manager")
  * @SourceField(name="relations")
+ * @SourceField(name="injectServiceFromExternal", annotations={@Autowire(for="testService", identifier="testService"), @HideParameter(for="testSkip"), @UseInputType(for="ID!")})
  */
 class ContactType
 {

--- a/tests/Fixtures/TestControllerWithInvalidParameterAnnotation.php
+++ b/tests/Fixtures/TestControllerWithInvalidParameterAnnotation.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use TheCodingMachine\GraphQLite\Annotations\HideParameter;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+
+class TestControllerWithInvalidParameterAnnotation
+{
+    /**
+     * @Query()
+     * @HideParameter(for="id")
+     */
+    public function test(string $foo = 'bar'): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Fixtures/TestTypeWithSourceFieldInvalidParameterAnnotation.php
+++ b/tests/Fixtures/TestTypeWithSourceFieldInvalidParameterAnnotation.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Annotations\HideParameter;
+
+/**
+ * @Type(class=TestObject::class)
+ * @SourceField(name="sibling", annotations={@HideParameter(for="id")})
+ */
+class TestTypeWithSourceFieldInvalidParameterAnnotation
+{
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -885,10 +885,10 @@ class EndToEndTest extends TestCase
         $this->assertSame([
             'contacts' => [
                 [
-                    'injectService' => 'OK',
+                    'injectServiceFromExternal' => 'OK',
                 ],
                 [
-                    'injectService' => 'OK',
+                    'injectServiceFromExternal' => 'OK',
                 ]
 
             ]

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -862,6 +862,39 @@ class EndToEndTest extends TestCase
         ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
     }
 
+    public function testParameterAnnotationsInSourceField(): void
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            contacts {
+                injectServiceFromExternal
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'contacts' => [
+                [
+                    'injectService' => 'OK',
+                ],
+                [
+                    'injectService' => 'OK',
+                ]
+
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
+
     public function testEndToEndEnums(): void
     {
         /**


### PR DESCRIPTION
Closes #177 

This PR starts with a failing test.

- [x] Make sure we can use ParameterAnnotationInterface annotations in a SourceField
- [x]  Add exceptions if a ParameterAnnotationInterface is referencing an parameter that does not exist.