### PR TITLE
Adding @MagicField annotation

### DIFF
--- a/docs/annotations_reference.md
+++ b/docs/annotations_reference.md
@@ -75,6 +75,18 @@ name           | *yes*       | string | The name of the field.
 [outputType](custom_output_types.md)     | *no*       | string | Forces the GraphQL output type of the field. Otherwise, return type is used.
 annotations    | *no*       | array<Annotations>  | A set of annotations that apply to this field. You would typically used a "@Logged" or "@Right" annotation here.
 
+## @MagicField annotation
+
+The `@MagicField` annotation is used to declare a GraphQL field that originates from a PHP magic property (using `__get` magic method).
+
+**Applies on**: classes annotated with `@Type` or `@ExtendType`.
+
+Attribute      | Compulsory | Type | Definition
+---------------|------------|------|--------
+name           | *yes*       | string | The name of the field.
+[outputType](custom_output_types.md)     | *yes*       | string | The GraphQL output type of the field.
+annotations    | *no*       | array<Annotations>  | A set of annotations that apply to this field. You would typically used a "@Logged" or "@Right" annotation here.
+
 ## @Logged annotation
 
 The `@Logged` annotation is used to declare a Query/Mutation/Field is only visible to logged users.

--- a/docs/annotations_reference.md
+++ b/docs/annotations_reference.md
@@ -73,7 +73,10 @@ Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 name           | *yes*       | string | The name of the field.
 [outputType](custom_output_types.md)     | *no*       | string | Forces the GraphQL output type of the field. Otherwise, return type is used.
+phpType        | *no*       | string | The PHP type of the field (as you would write it in a Docblock)
 annotations    | *no*       | array<Annotations>  | A set of annotations that apply to this field. You would typically used a "@Logged" or "@Right" annotation here.
+
+**Note**: `outputType` and `phpType` are mutually exclusive.
 
 ## @MagicField annotation
 
@@ -84,8 +87,11 @@ The `@MagicField` annotation is used to declare a GraphQL field that originates 
 Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 name           | *yes*       | string | The name of the field.
-[outputType](custom_output_types.md)     | *yes*       | string | The GraphQL output type of the field.
+[outputType](custom_output_types.md)  | *no*(*)       | string | The GraphQL output type of the field.
+phpType     | *no*(*)       | string | The PHP type of the field (as you would write it in a Docblock)
 annotations    | *no*       | array<Annotations>  | A set of annotations that apply to this field. You would typically used a "@Logged" or "@Right" annotation here.
+
+(*) **Note**: `outputType` and `phpType` are mutually exclusive. You MUST provide one of them.
 
 ## @Logged annotation
 

--- a/docs/custom_types.md
+++ b/docs/custom_types.md
@@ -53,6 +53,7 @@ You can use the `outputType` attribute in the following annotations:
 * `@Mutation`
 * `@Field`
 * `@SourceField`
+* `@MagicField` (the `outputType` is compulsory on a magic field)
 
 ## Registering a custom output type (advanced)
 

--- a/docs/custom_types.md
+++ b/docs/custom_types.md
@@ -53,7 +53,7 @@ You can use the `outputType` attribute in the following annotations:
 * `@Mutation`
 * `@Field`
 * `@SourceField`
-* `@MagicField` (the `outputType` is compulsory on a magic field)
+* `@MagicField`
 
 ## Registering a custom output type (advanced)
 

--- a/docs/external_type_declaration.md
+++ b/docs/external_type_declaration.md
@@ -72,6 +72,35 @@ By doing so, you let GraphQLite know that the type exposes the `getName` method 
 
 Internally, GraphQLite will look for methods named `name()`, `getName()` and `isName()`).
 
+## `@MagicField` annotation
+
+If your object has no getters, but instead uses magic properties (using the magic `__get` method), you should use the `@MagicField` annotation:
+
+```php
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use App\Entities\Product;
+
+/**
+ * @Type()
+ * @MagicField(name="name", outputType="String!")
+ * @MagicField(name="price", outputType="Float")
+ */
+class ProductType
+{
+    public function __get(string $property) {
+        // return some magic property
+    }
+}
+```
+
+By doing so, you let GraphQLite know that the type exposes "name" and the "price" magic properties of the underlying `Product` object.
+
+This is particularly useful in frameworks like Laravel, where Eloquent is making a very wide use of such properties.
+
+Please note that GraphQLite has no way to know the type of a magic property. Therefore, you have specify the GraphQL type
+of each property manually.
+
 ### Authentication and authorization
 
 You may also check for logged users or users with a specific right using the "annotations" property.

--- a/docs/laravel-package-advanced.md
+++ b/docs/laravel-package-advanced.md
@@ -140,8 +140,8 @@ working with magic properties.
 /**
  * @Type()
  * @MagicField(name="id" outputType="ID!")
- * @MagicField(name="name" outputType="String!")
- * @MagicField(name="category" outputType="Category")
+ * @MagicField(name="name" phpType="string")
+ * @MagicField(name="categories" phpType="Category[]")
  */
 class Product extends Model
 {
@@ -149,4 +149,55 @@ class Product extends Model
 ```
 
 Please note that since the properties are "magic", they don't have a type. Therefore,
-you need to pass the "outputType" attribute with the GraphQL type matching the property.
+you need to pass either the "outputType" attribute with the GraphQL type matching the property,
+or the "phpType" attribute with the PHP type matching the property.
+
+### Pitfalls to avoid with Eloquent
+
+When designing relationships in Eloquent, you write a method to expose that relationship this way:
+
+```php
+class User extends Model
+{
+    /**
+     * Get the phone record associated with the user.
+     */
+    public function phone()
+    {
+        return $this->hasOne('App\Phone');
+    }
+}
+```
+
+It would be tempting to put a `@Field` annotation on the `phone()` method, but this will not work. Indeed,
+the `phone()` method does not return a `App\Phone` object. It is the `phone` magic property that returns it.
+
+In short:
+
+<div class="alert alert-error">This does not work:
+<pre><code class="hljs css language-php">
+class User extends Model
+{
+    /**
+     * @Field
+     */
+    public function phone()
+    {
+        return $this->hasOne('App\Phone');
+    }
+}</code></pre>
+</div>
+
+<div class="alert alert-success">This works:
+<pre><code class="hljs css language-php">
+/**
+ * @MagicField(name="phone", phpType="App\\Phone")
+ */
+class User extends Model
+{
+    public function phone()
+    {
+        return $this->hasOne('App\Phone');
+    }
+}</code></pre>
+</div>

--- a/docs/laravel-package-advanced.md
+++ b/docs/laravel-package-advanced.md
@@ -125,3 +125,28 @@ class MyController
 ```
 
 The behaviour will be exactly the same except you will be missing the `totalCount` and `lastPage` fields.
+
+## Using GraphQLite with Eloquent efficiently
+
+In GraphQLite, you are supposed to put a `@Field` annotation on each getter.
+
+Eloquent uses PHP magic properties to expose your database records.
+Because Eloquent relies on magic properties, it is quite rare for an Eloquent model to have proper getters and setters.
+
+So we need to find a workaround. GraphQLite comes with a `@MagicField` annotation to help you
+working with magic properties.
+
+```php
+/**
+ * @Type()
+ * @MagicField(name="id" outputType="ID!")
+ * @MagicField(name="name" outputType="String!")
+ * @MagicField(name="category" outputType="Category")
+ */
+class Product extends Model
+{
+}
+```
+
+Please note that since the properties are "magic", they don't have a type. Therefore,
+you need to pass the "outputType" attribute with the GraphQL type matching the property.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -14,6 +14,8 @@ If you are a "regular" GraphQLite user, migration to v4 should be straightforwar
     - The "logged", "right" and "failWith" attributes have been removed (`@SourceField(logged=true)`).
       Instead, use the annotations attribute with the same annotations you use for the `@Field` annotation: 
       `@SourceField(annotations={@Logged, @FailWith(null)})`
+    - If you use magic property and were creating a getter for every magic property (to put a `@Field` annotation on it),
+      you can now replace this getter with a `@MagicField` annotation.
 - In GraphQLite v3, the default was to hide a field from the schema if a user has no access to it.
   In GraphQLite v4, the default is to still show this field, but to throw an error if the user makes a query on it
   (this way, the schema is the same for all users). If you want the old mode, use the new

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -21,7 +21,7 @@ use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotationInterface;
 use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotations;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotationInterface;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotations;
-use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
 use TheCodingMachine\GraphQLite\Annotations\Type;
 use Webmozart\Assert\Assert;
 use function array_diff_key;
@@ -124,14 +124,14 @@ class AnnotationReader
     /**
      * @param ReflectionClass<T> $refClass
      *
-     * @return SourceField[]
+     * @return SourceFieldInterface[]
      *
      * @template T of object
      */
     public function getSourceFields(ReflectionClass $refClass): array
     {
-        /** @var SourceField[] $sourceFields */
-        $sourceFields = $this->getClassAnnotations($refClass, SourceField::class);
+        /** @var SourceFieldInterface[] $sourceFields */
+        $sourceFields = $this->getClassAnnotations($refClass, SourceFieldInterface::class);
 
         return $sourceFields;
     }

--- a/src/Annotations/MagicField.php
+++ b/src/Annotations/MagicField.php
@@ -21,12 +21,12 @@ use function is_array;
  *   @Attribute("annotations", type = "mixed"),
  * })
  */
-class SourceField implements SourceFieldInterface
+class MagicField implements SourceFieldInterface
 {
     /** @var string */
     private $name;
 
-    /** @var string|null */
+    /** @var string */
     private $outputType;
 
     /** @var MiddlewareAnnotations */
@@ -40,11 +40,11 @@ class SourceField implements SourceFieldInterface
      */
     public function __construct(array $attributes = [])
     {
-        if (! isset($attributes['name'])) {
-            throw new BadMethodCallException('The @SourceField annotation must be passed a name. For instance: "@SourceField(name=\'phone\')"');
+        if (! isset($attributes['name']) || ! isset($attributes['outputType'])) {
+            throw new BadMethodCallException('The @MagicField annotation must be passed a name and an output type. For instance: "@MagicField(name=\'phone\', outputType=\'String!\')"');
         }
         $this->name       = $attributes['name'];
-        $this->outputType = $attributes['outputType'] ?? null;
+        $this->outputType = $attributes['outputType'];
         $middlewareAnnotations = [];
         $parameterAnnotations = [];
         $annotations = $attributes['annotations'] ?? [];
@@ -57,7 +57,7 @@ class SourceField implements SourceFieldInterface
             } elseif ($annotation instanceof ParameterAnnotationInterface) {
                 $parameterAnnotations[$annotation->getTarget()][] = $annotation;
             } else {
-                throw new BadMethodCallException('The @SourceField annotation\'s "annotations" attribute must be passed an array of annotations implementing either MiddlewareAnnotationInterface or ParameterAnnotationInterface."');
+                throw new BadMethodCallException('The @MagicField annotation\'s "annotations" attribute must be passed an array of annotations implementing either MiddlewareAnnotationInterface or ParameterAnnotationInterface."');
             }
         }
         $this->middlewareAnnotations = new MiddlewareAnnotations($middlewareAnnotations);
@@ -81,7 +81,7 @@ class SourceField implements SourceFieldInterface
      * Returns the GraphQL return type of the request (as a string).
      * The string is the GraphQL output type name.
      */
-    public function getOutputType(): ?string
+    public function getOutputType(): string
     {
         return $this->outputType;
     }
@@ -101,6 +101,6 @@ class SourceField implements SourceFieldInterface
 
     public function shouldFetchFromMagicProperty(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/src/Annotations/MagicField.php
+++ b/src/Annotations/MagicField.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use BadMethodCallException;
-use function array_key_exists;
 use function array_map;
 use function is_array;
 
@@ -17,7 +16,6 @@ use function is_array;
  * @Attributes({
  *   @Attribute("name", type = "string"),
  *   @Attribute("outputType", type = "string"),
- *   @Attribute("failWith", type = "mixed"),
  *   @Attribute("annotations", type = "mixed"),
  * })
  */
@@ -64,9 +62,6 @@ class MagicField implements SourceFieldInterface
         $this->parameterAnnotations = array_map(static function (array $parameterAnnotationsForAttribute): ParameterAnnotations {
             return new ParameterAnnotations($parameterAnnotationsForAttribute);
         }, $parameterAnnotations);
-        if (! array_key_exists('failWith', $attributes)) {
-            return;
-        }
     }
 
     /**

--- a/src/Annotations/SourceField.php
+++ b/src/Annotations/SourceField.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Annotations;
 
 use BadMethodCallException;
-use function array_key_exists;
 use function array_map;
 use function is_array;
 
@@ -17,7 +16,6 @@ use function is_array;
  * @Attributes({
  *   @Attribute("name", type = "string"),
  *   @Attribute("outputType", type = "string"),
- *   @Attribute("failWith", type = "mixed"),
  *   @Attribute("annotations", type = "mixed"),
  * })
  */
@@ -64,9 +62,6 @@ class SourceField implements SourceFieldInterface
         $this->parameterAnnotations = array_map(static function (array $parameterAnnotationsForAttribute): ParameterAnnotations {
             return new ParameterAnnotations($parameterAnnotationsForAttribute);
         }, $parameterAnnotations);
-        if (! array_key_exists('failWith', $attributes)) {
-            return;
-        }
     }
 
     /**

--- a/src/Annotations/SourceField.php
+++ b/src/Annotations/SourceField.php
@@ -16,6 +16,7 @@ use function is_array;
  * @Attributes({
  *   @Attribute("name", type = "string"),
  *   @Attribute("outputType", type = "string"),
+ *   @Attribute("phpType", type = "string"),
  *   @Attribute("annotations", type = "mixed"),
  * })
  */
@@ -26,6 +27,9 @@ class SourceField implements SourceFieldInterface
 
     /** @var string|null */
     private $outputType;
+
+    /** @var string|null */
+    private $phpType;
 
     /** @var MiddlewareAnnotations */
     private $middlewareAnnotations;
@@ -41,8 +45,12 @@ class SourceField implements SourceFieldInterface
         if (! isset($attributes['name'])) {
             throw new BadMethodCallException('The @SourceField annotation must be passed a name. For instance: "@SourceField(name=\'phone\')"');
         }
+        if (isset($attributes['outputType']) && isset($attributes['phpType'])) {
+            throw new BadMethodCallException('In a @SourceField annotation, you cannot use the outputType and the phpType at the same time. For instance: "@SourceField(name=\'phone\', outputType=\'String!\')" or "@SourceField(name=\'phone\', phpType=\'string\')"');
+        }
         $this->name       = $attributes['name'];
         $this->outputType = $attributes['outputType'] ?? null;
+        $this->phpType = $attributes['phpType'] ?? null;
         $middlewareAnnotations = [];
         $parameterAnnotations = [];
         $annotations = $attributes['annotations'] ?? [];
@@ -79,6 +87,11 @@ class SourceField implements SourceFieldInterface
     public function getOutputType(): ?string
     {
         return $this->outputType;
+    }
+
+    public function getPhpType(): ?string
+    {
+        return $this->phpType;
     }
 
     public function getMiddlewareAnnotations(): MiddlewareAnnotations

--- a/src/Annotations/SourceFieldInterface.php
+++ b/src/Annotations/SourceFieldInterface.php
@@ -26,4 +26,10 @@ interface SourceFieldInterface
      * @return array<string, ParameterAnnotations> Key: the name of the attribute
      */
     public function getParameterAnnotations(): array;
+
+    /**
+     * If true, this source field should be fetched from a magic property (rather than from a getter)
+     * In this case, getOutputType MUST NOT return null.
+     */
+    public function shouldFetchFromMagicProperty(): bool;
 }

--- a/src/Annotations/SourceFieldInterface.php
+++ b/src/Annotations/SourceFieldInterface.php
@@ -15,10 +15,16 @@ interface SourceFieldInterface
     public function getName(): string;
 
     /**
-     * Returns the GraphQL return type of the request (as a string).
+     * Returns the GraphQL return type of the field (as a string).
      * The string is the GraphQL output type name.
      */
     public function getOutputType(): ?string;
+
+    /**
+     * Returns the PHP return type of the field (as a string).
+     * The string is the PHPDoc for the PHP type.
+     */
+    public function getPhpType(): ?string;
 
     public function getMiddlewareAnnotations(): MiddlewareAnnotations;
 

--- a/src/Middlewares/MagicPropertyResolver.php
+++ b/src/Middlewares/MagicPropertyResolver.php
@@ -49,7 +49,7 @@ class MagicPropertyResolver implements ResolverInterface
     public function __invoke(...$args)
     {
         if ($this->object === null) {
-            throw new GraphQLRuntimeException('You must call "setObject" on SourceResolver before invoking the object.');
+            throw new GraphQLRuntimeException('You must call "setObject" on MagicPropertyResolver before invoking the object.');
         }
         if (! method_exists($this->object, '__get')) {
             throw MissingMagicGetException::cannotFindMagicGet(get_class($this->object));

--- a/src/Middlewares/MissingMagicGetException.php
+++ b/src/Middlewares/MissingMagicGetException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Middlewares;
+
+use RuntimeException;
+
+class MissingMagicGetException extends RuntimeException
+{
+    /**
+     * @param class-string $className
+     */
+    public static function cannotFindMagicGet(string $className): self
+    {
+        return new self('You cannot use a @MagicField annotation on an object that does not implement the __get() magic method. The class ' . $className . ' must implement a __get() method.');
+    }
+}

--- a/src/Middlewares/ResolverInterface.php
+++ b/src/Middlewares/ResolverInterface.php
@@ -13,7 +13,7 @@ interface ResolverInterface
 {
     public function getObject(): object;
 
-    public function getMethodName(): string;
+    public function toString(): string;
 
     /**
      * @param mixed $args

--- a/src/Middlewares/ServiceResolver.php
+++ b/src/Middlewares/ServiceResolver.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Middlewares;
 
+use function get_class;
+use function is_object;
+
 /**
  * A class that represents a callable on an object.
  * The object can be modified after class invocation.
@@ -39,8 +42,10 @@ class ServiceResolver implements ResolverInterface
         return $callable(...$args);
     }
 
-    public function getMethodName(): string
+    public function toString(): string
     {
-        return $this->callable[1];
+        $class = get_class($this->getObject());
+
+        return $class.'::'.$this->callable[1].'()';
     }
 }

--- a/src/Parameters/MissingArgumentException.php
+++ b/src/Parameters/MissingArgumentException.php
@@ -25,7 +25,7 @@ class MissingArgumentException extends BadMethodCallException implements GraphQL
             '%s in GraphQL input type \'%s\' used in factory \'%s\'',
             $previous->getMessage(),
             $inputType,
-            self::toMethod($callable)
+            self::toLocation($callable)
         );
 
         return new self($message, 0, $previous);
@@ -37,7 +37,7 @@ class MissingArgumentException extends BadMethodCallException implements GraphQL
             '%s in GraphQL input type \'%s\' used in decorator \'%s\'',
             $previous->getMessage(),
             $inputType,
-            self::toMethod($callable)
+            self::toLocation($callable)
         );
 
         return new self($message, 0, $previous);
@@ -49,20 +49,16 @@ class MissingArgumentException extends BadMethodCallException implements GraphQL
             '%s in GraphQL query/mutation/field \'%s\' used in method \'%s\'',
             $previous->getMessage(),
             $name,
-            self::toMethod($callable)
+            self::toLocation($callable)
         );
 
         return new self($message, 0, $previous);
     }
 
-    private static function toMethod(callable $callable): string
+    private static function toLocation(callable $callable): string
     {
-        // TODO: is $callable not only a ResolverInterface ???
-        // TODO: is $callable not only a ResolverInterface ???
-        // TODO: is $callable not only a ResolverInterface ???
-        // TODO: CHECK CODE COVERAGE!
         if ($callable instanceof ResolverInterface) {
-            return get_class($callable->getObject()) . '::' . $callable->getMethodName() . '()';
+            return $callable->toString();
         }
         if (! is_array($callable)) {
             return '';

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -14,6 +14,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQLite\Context\ContextInterface;
 use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;
+use TheCodingMachine\GraphQLite\Middlewares\MagicPropertyResolver;
 use TheCodingMachine\GraphQLite\Middlewares\MissingAuthorizationException;
 use TheCodingMachine\GraphQLite\Middlewares\ResolverInterface;
 use TheCodingMachine\GraphQLite\Middlewares\SourceResolver;
@@ -53,7 +54,7 @@ class QueryField extends FieldDefinition
         }
 
         $resolveFn = function ($source, array $args, $context, ResolveInfo $info) use ($arguments, $originalResolver, $resolver) {
-            if ($originalResolver instanceof SourceResolver) {
+            if ($originalResolver instanceof SourceResolver || $originalResolver instanceof MagicPropertyResolver) {
                 $originalResolver->setObject($source);
             }
             /*if ($resolve !== null) {
@@ -77,7 +78,7 @@ class QueryField extends FieldDefinition
                     $class = get_class($class);
                 }
 
-                $e->addInfo($this->name, $class, $originalResolver->getMethodName());
+                $e->addInfo($this->name, $originalResolver->toString());
                 throw $e;
             }
 
@@ -101,7 +102,7 @@ class QueryField extends FieldDefinition
 
                 return new Deferred(function () use ($prefetchBuffer, $source, $args, $context, $info, $prefetchArgs, $prefetchMethodName, $arguments, $resolveFn, $originalResolver) {
                     if (! $prefetchBuffer->hasResult($args)) {
-                        if ($originalResolver instanceof SourceResolver) {
+                        if ($originalResolver instanceof SourceResolver || $originalResolver instanceof MagicPropertyResolver) {
                             $originalResolver->setObject($source);
                         }
 

--- a/src/TypeMismatchRuntimeException.php
+++ b/src/TypeMismatchRuntimeException.php
@@ -32,8 +32,8 @@ class TypeMismatchRuntimeException extends GraphQLRuntimeException
         return new self('Expected resolved value to be an object but got "' . gettype($result) . '"');
     }
 
-    public function addInfo(string $fieldName, string $className, string $methodName): void
+    public function addInfo(string $fieldName, string $location): void
     {
-        $this->message = 'In ' . $className . '::' . $methodName . '() (declaring field "' . $fieldName . '"): ' . $this->message;
+        $this->message = 'In ' . $location . ' (declaring field "' . $fieldName . '"): ' . $this->message;
     }
 }

--- a/tests/Annotations/MagicFieldTest.php
+++ b/tests/Annotations/MagicFieldTest.php
@@ -20,6 +20,12 @@ class MagicFieldTest extends TestCase
         new MagicField(['name'=>'test', 'outputType'=>'String!', 'annotations'=>new Field()]);
     }
 
+    public function testExceptionInConstruct3(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        new MagicField(['name'=>'test', 'phpType'=>'string', 'outputType'=>'String!']);
+    }
+
     public function testAnnotations(): void
     {
         $magicField = new MagicField(['name'=>'test', 'outputType'=>'String!', 'annotations'=>[new Logged(), new Autowire(['for'=>'foo'])]]);

--- a/tests/Annotations/MagicFieldTest.php
+++ b/tests/Annotations/MagicFieldTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Annotations;
+
+use BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+
+class MagicFieldTest extends TestCase
+{
+
+    public function testExceptionInConstruct(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        new MagicField([]);
+    }
+
+    public function testExceptionInConstruct2(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        new MagicField(['name'=>'test', 'outputType'=>'String!', 'annotations'=>new Field()]);
+    }
+
+    public function testAnnotations(): void
+    {
+        $magicField = new MagicField(['name'=>'test', 'outputType'=>'String!', 'annotations'=>[new Logged(), new Autowire(['for'=>'foo'])]]);
+        $this->assertNotEmpty($magicField->getMiddlewareAnnotations()->getAnnotationsByType(Logged::class));
+        $this->assertNotEmpty($magicField->getParameterAnnotations()['foo']->getAnnotationsByType(Autowire::class));
+    }
+}

--- a/tests/Annotations/SourceFieldTest.php
+++ b/tests/Annotations/SourceFieldTest.php
@@ -19,4 +19,10 @@ class SourceFieldTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         new SourceField(['name'=>'test', 'annotations'=>new Field()]);
     }
+
+    public function testExceptionInConstruct3(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        new SourceField(['name'=>'test', 'phpType'=>'string', 'outputType'=>'String!']);
+    }
 }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -56,6 +56,7 @@ use TheCodingMachine\GraphQLite\Fixtures\TestTypeMissingField;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeMissingReturnType;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithFailWith;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithInvalidPrefetchParameter;
+use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithMagicProperty;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithPrefetchMethod;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeWithSourceFieldInterface;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
@@ -68,6 +69,7 @@ use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Middlewares\AuthorizationFieldMiddleware;
 use TheCodingMachine\GraphQLite\Middlewares\BadExpressionInSecurityException;
+use TheCodingMachine\GraphQLite\Middlewares\MissingMagicGetException;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
@@ -773,5 +775,27 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage('Could not find parameter "foo" declared in annotation "TheCodingMachine\\GraphQLite\\Annotations\\HideParameter". This annotation is itself declared in a SourceField annotation targeting resolver "TheCodingMachine\\GraphQLite\\Fixtures\\TestObject::getSibling()".');
         $fields = $queryProvider->getFields($controller);
+    }
+
+    public function testMagicField(): void
+    {
+        $controller = new TestTypeWithMagicProperty();
+
+        $queryProvider = $this->buildFieldsBuilder();
+
+        $fields = $queryProvider->getFields($controller);
+
+        $this->assertCount(1, $fields);
+        $query = $fields['foo'];
+        $this->assertSame('foo', $query->name);
+
+        $resolve = $query->resolveFn;
+        $result = $resolve(new TestTypeWithMagicProperty(), [], null, $this->createMock(ResolveInfo::class));
+
+        $this->assertSame('foo', $result);
+
+        $this->expectException(MissingMagicGetException::class);
+        $this->expectExceptionMessage('You cannot use a @MagicField annotation on an object that does not implement the __get() magic method. The class stdClass must implement a __get() method.');
+        $result = $resolve(new stdClass(), [], null, $this->createMock(ResolveInfo::class));
     }
 }

--- a/tests/Fixtures/Integration/Models/Contact.php
+++ b/tests/Fixtures/Integration/Models/Contact.php
@@ -4,6 +4,7 @@
 namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
 
 
+use TheCodingMachine\GraphQLite\Annotations\MagicField;
 use function array_search;
 use DateTimeInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -20,6 +21,7 @@ use TheCodingMachine\GraphQLite\Annotations\Autowire;
 
 /**
  * @Type()
+ * @MagicField(name="magicNumber", phpType="int")
  */
 class Contact
 {
@@ -52,11 +54,8 @@ class Contact
     {
         $this->name = $name;
     }
-
-    /**
-     * @return string
-     */
-    public function getName(): string
+    
+    public function getName()
     {
         return $this->name;
     }
@@ -109,7 +108,7 @@ class Contact
     /**
      * @return DateTimeInterface
      */
-    public function getBirthDate(): DateTimeInterface
+    public function getBirthDate()
     {
         return $this->birthDate;
     }
@@ -207,5 +206,10 @@ class Contact
             return 'KO';
         }
         return 'OK';
+    }
+
+    public function __get(string $property)
+    {
+        return 42;
     }
 }

--- a/tests/Fixtures/Integration/Types/ContactType.php
+++ b/tests/Fixtures/Integration/Types/ContactType.php
@@ -16,7 +16,7 @@ use TheCodingMachine\GraphQLite\Annotations\UseInputType;
 
 /**
  * @ExtendType(class=Contact::class)
- * @SourceField(name="name")
+ * @SourceField(name="name", phpType="string")
  * @SourceField(name="birthDate")
  * @SourceField(name="manager")
  * @SourceField(name="relations")

--- a/tests/Fixtures/Integration/Types/ExtendedContactOtherType.php
+++ b/tests/Fixtures/Integration/Types/ExtendedContactOtherType.php
@@ -13,7 +13,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
 
 /**
  * @ExtendType(name="ContactOther")
- * @SourceField(name="name")
+ * @SourceField(name="name", phpType="string")
  */
 class ExtendedContactOtherType
 {

--- a/tests/Fixtures/TestTypeWithMagicProperty.php
+++ b/tests/Fixtures/TestTypeWithMagicProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use TheCodingMachine\GraphQLite\Annotations\MagicField;
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\FromSourceFieldsInterface;
+
+/**
+ * @Type()
+ * @MagicField(name="foo", outputType="String!")
+ */
+class TestTypeWithMagicProperty
+{
+    public function __get(string $var)
+    {
+        return 'foo';
+    }
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1282,4 +1282,35 @@ class EndToEndTest extends TestCase
         $this->assertEquals('unicorn', $resultArray['data']['getProducts2'][0]['special']);
     }
 
+    public function testEndToEndMagicFieldWithPhpType(): void
+    {
+        /**
+         * @var Schema $schema
+         */
+        $schema = $this->mainContainer->get(Schema::class);
+
+        $queryString = '
+        query {
+            contacts {
+                magicNumber
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString
+        );
+
+        $this->assertSame([
+            'contacts' => [
+                [
+                    'magicNumber' => 42,
+                ],
+                [
+                    'magicNumber' => 42,
+                ],
+            ]
+        ], $result->toArray(Debug::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+    }
 }

--- a/tests/Middlewares/MagicPropertyResolverTest.php
+++ b/tests/Middlewares/MagicPropertyResolverTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Middlewares;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
+
+class MagicPropertyResolverTest extends TestCase
+{
+
+    public function testExceptionInInvoke()
+    {
+        $sourceResolver = new MagicPropertyResolver('test');
+        $this->expectException(GraphQLRuntimeException::class);
+        $sourceResolver();
+    }
+
+    public function testToString()
+    {
+        $sourceResolver = new MagicPropertyResolver('test');
+        $sourceResolver->setObject(new stdClass());
+        $this->assertSame("stdClass::__get('test')", $sourceResolver->toString());
+    }
+
+    public function testGetObject()
+    {
+        $sourceResolver = new MagicPropertyResolver('test');
+        $obj = new stdClass();
+        $sourceResolver->setObject($obj);
+        $this->assertSame($obj, $sourceResolver->getObject());
+    }
+}

--- a/tests/Middlewares/ServiceResolverTest.php
+++ b/tests/Middlewares/ServiceResolverTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite\Middlewares;
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 
 class ServiceResolverTest extends TestCase
@@ -15,9 +16,10 @@ class ServiceResolverTest extends TestCase
         $sourceResolver();
     }
 
-    public function testGetMethodName()
+    public function testToString()
     {
         $sourceResolver = new SourceResolver('test');
-        $this->assertSame('test', $sourceResolver->getMethodName());
+        $sourceResolver->setObject(new stdClass());
+        $this->assertSame('stdClass::test()', $sourceResolver->toString());
     }
 }

--- a/tests/Middlewares/SourceResolverTest.php
+++ b/tests/Middlewares/SourceResolverTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 
-class ServiceResolverTest extends TestCase
+class SourceResolverTest extends TestCase
 {
 
     public function testExceptionInInvoke()

--- a/tests/QueryFieldDescriptorTest.php
+++ b/tests/QueryFieldDescriptorTest.php
@@ -26,6 +26,16 @@ class QueryFieldDescriptorTest extends TestCase
         $descriptor->setTargetMethodOnSource('test');
     }
 
+    public function testExceptionInSetMagicProperty(): void
+    {
+        $descriptor = new QueryFieldDescriptor();
+        $descriptor->setMagicProperty('test');
+        $descriptor->getResolver();
+
+        $this->expectException(GraphQLRuntimeException::class);
+        $descriptor->setMagicProperty('test');
+    }
+
     public function testExceptionInGetOriginalResolver(): void
     {
         $descriptor = new QueryFieldDescriptor();

--- a/tests/Reflection/CachedDocBlockFactoryTest.php
+++ b/tests/Reflection/CachedDocBlockFactoryTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite\Reflection;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
@@ -26,5 +27,22 @@ class CachedDocBlockFactoryTest extends TestCase
         $newCachedDocBlockFactory = new CachedDocBlockFactory($arrayCache);
         $docBlock3 = $newCachedDocBlockFactory->getDocBlock($refMethod);
         $this->assertEquals($docBlock3, $docBlock);
+    }
+
+    public function testGetContext(): void
+    {
+        $arrayCache = new Psr16Cache(new ArrayAdapter());
+        $cachedDocBlockFactory = new CachedDocBlockFactory($arrayCache);
+
+        $refClass = new ReflectionClass(CachedDocBlockFactory::class);
+
+        $context = $cachedDocBlockFactory->getContextFromClass($refClass);
+
+        $context2 = $cachedDocBlockFactory->getContextFromClass($refClass);
+        $this->assertSame($context2, $context);
+
+        $newCachedDocBlockFactory = new CachedDocBlockFactory($arrayCache);
+        $context3 = $newCachedDocBlockFactory->getContextFromClass($refClass);
+        $this->assertEquals($context3, $context);
     }
 }


### PR DESCRIPTION
The MagicField annotation allows creating fields targetting a magic property via the__get method.
Very useful to play with Laravel Eloquent.

TODO:

- [x]  Create MagicField annotation
- [x] Add a way to declare the phpType rather than the outputType as an attribute

Closes #160