### PR TITLE
 Improving error message if an output and an input type name are in conflict

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ New features:
   - Unauthorized access to fields can now generate GraphQL errors (rather that schema errors in GraphQLite v3)
   - Added fine-grained security using the `@Security` annotation. A field can now be [marked accessible or not depending on the context](fine-grained-security.md).
     For instance, you can restrict access to the field "viewsCount" of the type `BlogPost` only for post that the current user wrote.
+  - You can now inject the current logged user in any query / mutation / field using the `@InjectUser` annotation
 - Performance:
   - You can inject the [Webonyx query plan in a parameter from a resolver](query_plan.md)
   - You can use the [dataloader pattern to improve performance drastically via the "prefetchMethod" attribute](prefetch_method.md)

--- a/src/Mappers/CannotMapTypeException.php
+++ b/src/Mappers/CannotMapTypeException.php
@@ -83,7 +83,7 @@ class CannotMapTypeException extends Exception implements CannotMapTypeException
 
     public static function mustBeInputType(string $subTypeName): self
     {
-        return new self('type "' . $subTypeName . '" must be an input type.');
+        return new self('type "' . $subTypeName . '" must be an input type (if you declared an input type with the name "' . $subTypeName . '", make sure that there are no output type with the same name as this is forbidden by the GraphQL spec).');
     }
 
     /**

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -22,7 +22,7 @@ use function get_class;
 class TypeRegistry
 {
     /** @var array<string,NamedType&Type&(MutableObjectType|InterfaceType|UnionType|(InputObjectType&ResolvableMutableInputInterface))> */
-    private $outputTypes = [];
+    private $types = [];
 
     /**
      * Registers a type.
@@ -33,10 +33,10 @@ class TypeRegistry
      */
     public function registerType(NamedType $type): void
     {
-        if (isset($this->outputTypes[$type->name])) {
+        if (isset($this->types[$type->name])) {
             throw new GraphQLRuntimeException('Type "' . $type->name . '" is already registered');
         }
-        $this->outputTypes[$type->name] = $type;
+        $this->types[$type->name] = $type;
     }
 
     /**
@@ -50,17 +50,17 @@ class TypeRegistry
      */
     public function getOrRegisterType(NamedType $type): NamedType
     {
-        if (isset($this->outputTypes[$type->name])) {
-            return $this->outputTypes[$type->name];
+        if (isset($this->types[$type->name])) {
+            return $this->types[$type->name];
         }
-        $this->outputTypes[$type->name] = $type;
+        $this->types[$type->name] = $type;
 
         return $type;
     }
 
     public function hasType(string $typeName): bool
     {
-        return isset($this->outputTypes[$typeName]);
+        return isset($this->types[$typeName]);
     }
 
     /**
@@ -68,11 +68,11 @@ class TypeRegistry
      */
     public function getType(string $typeName): NamedType
     {
-        if (! isset($this->outputTypes[$typeName])) {
+        if (! isset($this->types[$typeName])) {
             throw new GraphQLRuntimeException('Could not find type "' . $typeName . '" in registry');
         }
 
-        return $this->outputTypes[$typeName];
+        return $this->types[$typeName];
     }
 
     public function getMutableObjectType(string $typeName): MutableObjectType

--- a/tests/Fixtures/InputOutputNameConflict/Controllers/InAndOutController.php
+++ b/tests/Fixtures/InputOutputNameConflict/Controllers/InAndOutController.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\InputOutputNameConflict\Controllers;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Annotations\UseInputType;
+use TheCodingMachine\GraphQLite\Fixtures\InputOutputNameConflict\Types\InAndOut;
+
+class InAndOutController
+{
+    /**
+     * @Query()
+     * @UseInputType(for="$inAndOut", inputType="InAndOut")
+     */
+    public function testInAndOut(InAndOut $inAndOut): InAndOut
+    {
+        return $inAndOut;
+    }
+}

--- a/tests/Fixtures/InputOutputNameConflict/Types/InAndOut.php
+++ b/tests/Fixtures/InputOutputNameConflict/Types/InAndOut.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\InputOutputNameConflict\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Factory;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type(name="InAndOut")
+ */
+class InAndOut
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @Field()
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @Factory(name="InAndOut")
+     */
+    public static function create(string $value): self
+    {
+        return new self($value);
+    }
+}

--- a/tests/Fixtures/Integration/Types/ContactFactory.php
+++ b/tests/Fixtures/Integration/Types/ContactFactory.php
@@ -15,7 +15,7 @@ class ContactFactory
 {
     /**
      * @Factory()
-     * @UseInputType(for="$relations", inputType="[ContactRefInput!]!")
+     * @UseInputType(for="$relations", inputType="[ContactRef!]!")
      * @param string $name
      * @param Contact|null $manager
      * @param Contact[] $relations
@@ -34,7 +34,7 @@ class ContactFactory
     }
 
     /**
-     * @Factory(name="ContactRefInput", default=false)
+     * @Factory(name="ContactRef", default=false)
      * @return Contact
      */
     public function getContact(string $name): Contact

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -21,6 +21,7 @@ use TheCodingMachine\GraphQLite\GlobControllerQueryProvider;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
+use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterHandler;
@@ -1373,6 +1374,10 @@ class EndToEndTest extends TestCase
         $schemaFactory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\InputOutputNameConflict\\Types');
 
         $schema = $schemaFactory->createSchema();
+
+        $this->expectException(CannotMapTypeException::class);
+        $this->expectExceptionMessage('For parameter $inAndOut, in TheCodingMachine\\GraphQLite\\Fixtures\\InputOutputNameConflict\\Controllers\\InAndOutController::testInAndOut, type "InAndOut" must be an input type (if you declared an input type with the name "InAndOut", make sure that there are no output type with the same name as this is forbidden by the GraphQL spec).');
+
         $schema->validate();
     }
 }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -52,6 +52,7 @@ use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Schema;
+use TheCodingMachine\GraphQLite\SchemaFactory;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\SecurityExpressionLanguageProvider;
@@ -451,7 +452,7 @@ class EndToEndTest extends TestCase
                     {
                         name: "bar"
                     }
-                ]   
+                ]
             }
           ) {
             name,
@@ -1363,5 +1364,15 @@ class EndToEndTest extends TestCase
         );
 
         $this->assertSame(42, $result->toArray(Debug::RETHROW_UNSAFE_EXCEPTIONS)['data']['injectedUser']);
+    }
+
+    public function testInputOutputNameConflict(): void
+    {
+        $schemaFactory = new SchemaFactory(new Psr16Cache(new ArrayAdapter()), new BasicAutoWiringContainer(new EmptyContainer()));
+        $schemaFactory->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\InputOutputNameConflict\\Controllers');
+        $schemaFactory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\InputOutputNameConflict\\Types');
+
+        $schema = $schemaFactory->createSchema();
+        $schema->validate();
     }
 }


### PR DESCRIPTION
The error message will now be:

> For parameter $inAndOut, in TheCodingMachine\GraphQLite\Fixtures\InputOutputNameConflict\Controllers\InAndOutController::testInAndOut, type "InAndOut" must be an input type (if you declared an input type with the name "InAndOut", make sure that there are no output type with the same name as this is forbidden by the GraphQL spec).

See #188