### PR TITLE
Optimize controllers instantiations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ title: Changelog
 sidebar_label: Changelog
 ---
 
-## 4.0-beta1
+## 4.0
 
 This is a complete refactoring from 3.x. While existing annotations are kept compatible, the internals have completely
 changed.

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -435,6 +435,7 @@ class SchemaFactory
                 $controllerNamespace,
                 $fieldsBuilder,
                 $this->container,
+                $annotationReader,
                 $this->cache,
                 $this->classNameMapper,
                 $this->globTtl

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -14,6 +14,16 @@ use TheCodingMachine\GraphQLite\Types\ID;
 class TestController
 {
     /**
+     * @Mutation
+     * @param TestObject $testObject
+     * @return TestObject
+     */
+    public function mutation(TestObject $testObject): TestObject
+    {
+        return $testObject;
+    }
+
+    /**
      * @Query
      * @param int $int
      * @param TestObject[] $list
@@ -37,16 +47,6 @@ class TestController
             $str .= $test->getTest();
         }
         return new TestObject($string.$int.$str.($boolean?'true':'false').$float.$dateTimeImmutable->format('YmdHis').$dateTime->format('YmdHis').$withDefault.($id !== null ? $id->val() : '').$enum->getValue());
-    }
-
-    /**
-     * @Mutation
-     * @param TestObject $testObject
-     * @return TestObject
-     */
-    public function mutation(TestObject $testObject): TestObject
-    {
-        return $testObject;
     }
 
     /**

--- a/tests/GlobControllerQueryProviderTest.php
+++ b/tests/GlobControllerQueryProviderTest.php
@@ -36,7 +36,7 @@ class GlobControllerQueryProviderTest extends AbstractQueryProviderTest
             }
         };
 
-        $globControllerQueryProvider = new GlobControllerQueryProvider('TheCodingMachine\\GraphQLite\\Fixtures', $this->getFieldsBuilder(), $container, new Psr16Cache(new NullAdapter()), null, false);
+        $globControllerQueryProvider = new GlobControllerQueryProvider('TheCodingMachine\\GraphQLite\\Fixtures', $this->getFieldsBuilder(), $container, $this->getAnnotationReader(), new Psr16Cache(new NullAdapter()), null, false, false);
 
         $queries = $globControllerQueryProvider->getQueries();
         $this->assertCount(7, $queries);

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -90,7 +90,7 @@ class EndToEndTest extends TestCase
             },
             QueryProviderInterface::class => function(ContainerInterface $container) {
                 return new GlobControllerQueryProvider('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers', $container->get(FieldsBuilder::class),
-                    $container->get(BasicAutoWiringContainer::class), new Psr16Cache(new ArrayAdapter()));
+                    $container->get(BasicAutoWiringContainer::class), $container->get(AnnotationReader::class), new Psr16Cache(new ArrayAdapter()));
             },
             FieldsBuilder::class => function(ContainerInterface $container) {
                 return new FieldsBuilder(


### PR DESCRIPTION
In the glob of controllers, we are now analyzing each class to see if it contains @Query or @Mutation annotations *before* instantiating it.
It can save troubles with the container trying to instantiate classes that are not services.

Closes #207