### PR TITLE
A class declared with a bad namespace causes a crash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr/container": "^1",
         "doctrine/annotations": "^1.2",
         "doctrine/cache": "^1.8",
-        "thecodingmachine/class-explorer": "^1.0.2",
+        "thecodingmachine/class-explorer": "^1.1.0",
         "psr/simple-cache": "^1",
         "phpdocumentor/reflection-docblock": "^4.3",
         "phpdocumentor/type-resolver": "^1.0.1",
@@ -67,5 +67,7 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.2",
         "webonyx/graphql-php": "^0.13.4",
         "psr/container": "^1",
-        "doctrine/annotations": "^1.2",
+        "doctrine/annotations": "^1.7.0",
         "doctrine/cache": "^1.8",
         "thecodingmachine/class-explorer": "^1.1.0",
         "psr/simple-cache": "^1",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,5 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -65,13 +65,13 @@ final class GlobTypeMapper extends AbstractTypeMapper
             $this->classes = [];
             $explorer      = new GlobClassExplorer($this->namespace, $this->cache, $this->globTtl, $this->classNameMapper, $this->recursive);
             $classes       = $explorer->getClassMap();
-            foreach ($classes as $className => $fileInfo) {
+            foreach ($classes as $className => $phpFile) {
                 if (! class_exists($className, false) && ! interface_exists($className, false)) {
                     // Let's try to load the file if it was not imported yet.
                     // We are importing the file manually to avoid triggering the autoloader.
                     // The autoloader might trigger errors if the file does not respect PSR-4 or if the
                     // Symfony DebugAutoLoader is installed. (see https://github.com/thecodingmachine/graphqlite/issues/216)
-                    require_once $fileInfo->getRealPath();
+                    require_once $phpFile;
                     // Does it exists now?
                     if (! class_exists($className, false) && ! interface_exists($className, false)) {
                         continue;

--- a/tests/Fixtures/Integration/Models/BadNamespaceClass.php
+++ b/tests/Fixtures/Integration/Models/BadNamespaceClass.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * This class has a bad namespace. It should not trigger errors when using GlobTypeMapper.
+ */
+class BadNamespaceClass
+{
+
+}


### PR DESCRIPTION
Related to #216 

This PR starts with a failing test.

Possible solution:

In GlobTypeMapper (https://github.com/thecodingmachine/graphqlite/blob/6ced8b35a62e432cf9aee405654245ba1ea74058/src/Mappers/GlobTypeMapper.php#L69),

we could list the couples [class => file] (instead of the list of classes only from GlobClassExplorer).

Then, we could check if the class is already defined without calling `class_exists` with second parameter to "false". Then, if the file was never imported (we can know using `get_included_files()`), we can include the file ourselves (bypassing completely the autoloader, and thus, avoiding errors from the DebugClassLoader from Symfony if it is activated).

TODO:

- [x]  Tag a stable version of GlobClassExplorer before merging this.