### PR TITLE
Error GraphQL Request must include at least one of those two parameters: "query" or "queryId"

### DIFF
--- a/src/Http/WebonyxGraphqlMiddleware.php
+++ b/src/Http/WebonyxGraphqlMiddleware.php
@@ -76,7 +76,7 @@ final class WebonyxGraphqlMiddleware implements MiddlewareInterface
         }
 
         // Let's json deserialize if this is not already done.
-        if ($request->getParsedBody() === null) {
+        if (empty($request->getParsedBody())) {
             $content = $request->getBody()->getContents();
             $data = json_decode($content, true);
 


### PR DESCRIPTION
My setup: slim 4 using psr 15 middleware.

When performing any valid request error `{"errors":[{"message":"GraphQL Request must include at least one of those two parameters: \"query\" or \"queryId\"","extensions":{"category":"request"}}]}` is returned.
I've narrowed this to $request->getParsedBody() returning empty array instead of null in slim 4 framework when parsed body is empty. This will fix this issue.