### PR TITLE
Improve exception description in case of duplicate field

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -207,6 +207,8 @@ class FieldsBuilder
         $refClass = new ReflectionClass($controller);
 
         $queryList = [];
+        /** @var array<string, ReflectionMethod> $refMethodByFields */
+        $refMethodByFields = [];
 
         $oldDeclaringClass = null;
         $context           = null;
@@ -316,10 +318,11 @@ class FieldsBuilder
             });
 
             if ($field !== null) {
-                if (isset($queryList[$fieldDescriptor->getName()])) {
-                    throw DuplicateMappingException::createForQuery($refClass->getName(), $fieldDescriptor->getName());
+                if (isset($refMethodByFields[$name])) {
+                    throw DuplicateMappingException::createForQuery($refClass->getName(), $name, $refMethodByFields[$name], $refMethod);
                 }
-                $queryList[$fieldDescriptor->getName()] = $field;
+                $queryList[$name] = $field;
+                $refMethodByFields[$name] = $refMethod;
             }
 
             /*if ($unauthorized) {

--- a/src/Mappers/DuplicateMappingException.php
+++ b/src/Mappers/DuplicateMappingException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use RuntimeException;
 use ReflectionMethod;
+use RuntimeException;
 use function sprintf;
 
 class DuplicateMappingException extends RuntimeException

--- a/src/Mappers/DuplicateMappingException.php
+++ b/src/Mappers/DuplicateMappingException.php
@@ -24,9 +24,9 @@ class DuplicateMappingException extends RuntimeException
         throw new self(sprintf("The type '%s' is created by 2 different classes: '%s' and '%s'", $type, $sourceClass1, $sourceClass2));
     }
 
-    public static function createForQuery(string $sourceClass, string $queryName): self
+    public static function createForQuery(string $sourceClass, string $queryName, \ReflectionMethod $method1, \ReflectionMethod $method2): self
     {
-        throw new self(sprintf("The query/mutation '%s' is declared twice in class '%s'", $queryName, $sourceClass));
+        throw new self(sprintf("The query/mutation/field '%s' is declared twice in class '%s'. First in '%s::%s()', second in '%s::%s()'", $queryName, $sourceClass, $method1->getDeclaringClass()->getName(), $method1->getName(), $method2->getDeclaringClass()->getName(), $method2->getName()));
     }
 
     public static function createForQueryInTwoControllers(string $sourceClass1, string $sourceClass2, string $queryName): self

--- a/src/Mappers/DuplicateMappingException.php
+++ b/src/Mappers/DuplicateMappingException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Mappers;
 
 use RuntimeException;
+use ReflectionMethod;
 use function sprintf;
 
 class DuplicateMappingException extends RuntimeException
@@ -24,7 +25,7 @@ class DuplicateMappingException extends RuntimeException
         throw new self(sprintf("The type '%s' is created by 2 different classes: '%s' and '%s'", $type, $sourceClass1, $sourceClass2));
     }
 
-    public static function createForQuery(string $sourceClass, string $queryName, \ReflectionMethod $method1, \ReflectionMethod $method2): self
+    public static function createForQuery(string $sourceClass, string $queryName, ReflectionMethod $method1, ReflectionMethod $method2): self
     {
         throw new self(sprintf("The query/mutation/field '%s' is declared twice in class '%s'. First in '%s::%s()', second in '%s::%s()'", $queryName, $sourceClass, $method1->getDeclaringClass()->getName(), $method1->getName(), $method2->getDeclaringClass()->getName(), $method2->getName()));
     }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -194,7 +194,7 @@ class SchemaFactoryTest extends TestCase
                 ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
 
         $this->expectException(DuplicateMappingException::class);
-        $this->expectExceptionMessage("The query/mutation 'duplicateQuery' is declared twice in class 'TheCodingMachine\\GraphQLite\\Fixtures\\DuplicateQueries\\TestControllerWithDuplicateQuery");
+        $this->expectExceptionMessage("The query/mutation/field 'duplicateQuery' is declared twice in class 'TheCodingMachine\GraphQLite\Fixtures\DuplicateQueries\TestControllerWithDuplicateQuery'. First in 'TheCodingMachine\GraphQLite\Fixtures\DuplicateQueries\TestControllerWithDuplicateQuery::testDuplicateQuery1()', second in 'TheCodingMachine\GraphQLite\Fixtures\DuplicateQueries\TestControllerWithDuplicateQuery::testDuplicateQuery2()'");
         $schema = $factory->createSchema();
         $queryString = '
         query {


### PR DESCRIPTION
Because otherwise one may not understand what's really going on.