### PR TITLE
Fix link to `3.0` doc

### DIFF
--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -69,7 +69,7 @@ function Versions(props) {
                     <tr>
                       <th>{version}</th>
                       <td>
-                        <a href={"docs/"+version+"/migrating.html"}>Documentation</a>
+                        <a href={"docs/"+version+"/features.html"}>Documentation</a>
                       </td>
                       <td>
                         <a href="">Release Notes</a>


### PR DESCRIPTION
The link to the documentation for `3.0` is broken, see https://graphqlite.thecodingmachine.io/versions