### PR TITLE
Fixing migrating link in post release doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,5 @@ jobs:
         - git config --global user.email "${GH_EMAIL}"
         - echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
         - cd website && yarn install && GIT_USER="${GH_NAME}" yarn run publish-gh-pages
-matrix:
   allow_failures:
     - stage: test_dependencies

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -72,7 +72,7 @@ function Versions(props) {
                         <a href={"docs/"+version+"/features.html"}>Documentation</a>
                       </td>
                       <td>
-                        <a href="">Release Notes</a>
+                        <a href={"docs/"+version+"/migrating.html"}>Release Notes</a>
                       </td>
                     </tr>
                   ),

--- a/website/versioned_docs/version-3.0/migrating.md
+++ b/website/versioned_docs/version-3.0/migrating.md
@@ -1,0 +1,66 @@
+---
+id: version-3.0-migrating
+title: Release notes
+sidebar_label: Release notes
+original_id: migrating
+---
+
+## First stable release of GraphQLite
+
+GraphQLite is PHP library that allows you to write your GraphQL queries in simple-to-write controllers.
+
+- Create a complete GraphQL API by simply annotating your PHP classes
+- Framework agnostic, but Symfony and Laravel bindings available!
+- Comes with batteries included: queries, mutations, mapping of arrays / iterators, file uploads, extendable types and more!
+
+After several months of work, we are very happy to announce the availability of GraphQLite v3.0.
+
+If you are wondering where are v1 and v2... yeah... GraphQLite is a fork of "thecodingmachine/graphql-controllers" that already had a v1 and a v2. But so much has changed that it deserved a new name!
+
+[Check out the documentation](https://graphqlite.thecodingmachine.io)
+
+## Basic example
+
+First, declare a query in your controller:
+
+```php
+class ProductController
+{
+    /**
+     * @Query()
+     */
+    public function product(string $id): Product
+    {
+        // Some code that looks for a product and returns it.
+    }
+}
+```
+
+Then, annotate the `Product` class to declare what fields are exposed to the GraphQL API:
+
+```php
+/**
+ * @Type()
+ */
+class Product
+{
+    /**
+     * @Field()
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    // ...
+}
+```
+
+That's it, you're good to go :tada:! Query and enjoy!
+
+```graphql
+{
+  product(id: 42) {
+    name
+  }
+}
+```


### PR DESCRIPTION
All versions need to have a migrating.md page because Docusaurus v1 assumes the same structure in all versions