### PR TITLE
Fix default params messing set cache time and rename _Ttl_ suffixes into _TTL_

### DIFF
--- a/src/FactoryContext.php
+++ b/src/FactoryContext.php
@@ -37,9 +37,9 @@ final class FactoryContext
     /** @var CacheInterface */
     private $cache;
     /** @var int|null */
-    private $globTtl;
+    private $globTTL;
     /** @var int|null */
-    private $mapTtl;
+    private $mapTTL;
 
     public function __construct(
         AnnotationReader $annotationReader,
@@ -52,8 +52,8 @@ final class FactoryContext
         RecursiveTypeMapperInterface $recursiveTypeMapper,
         ContainerInterface $container,
         CacheInterface $cache,
-        ?int $globTtl = 2,
-        ?int $mapTtl = null
+        ?int $globTTL,
+        ?int $mapTTL = null
     ) {
         $this->annotationReader = $annotationReader;
         $this->typeResolver = $typeResolver;
@@ -65,8 +65,8 @@ final class FactoryContext
         $this->recursiveTypeMapper = $recursiveTypeMapper;
         $this->container = $container;
         $this->cache = $cache;
-        $this->globTtl = $globTtl;
-        $this->mapTtl = $mapTtl;
+        $this->globTTL = $globTTL;
+        $this->mapTTL = $mapTTL;
     }
 
     public function getAnnotationReader(): AnnotationReader
@@ -119,13 +119,13 @@ final class FactoryContext
         return $this->cache;
     }
 
-    public function getGlobTtl(): ?int
+    public function getGlobTTL(): ?int
     {
-        return $this->globTtl;
+        return $this->globTTL;
     }
 
-    public function getMapTtl(): ?int
+    public function getMapTTL(): ?int
     {
-        return $this->mapTtl;
+        return $this->mapTTL;
     }
 }

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -43,7 +43,7 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
     /** @var CacheInterface */
     protected $cache;
     /** @var int|null */
-    protected $globTtl;
+    protected $globTTL;
 
     /**
      * Cache storing the GlobAnnotationsCache objects linked to a given ReflectionClass.
@@ -63,7 +63,7 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
     /** @var TypeGenerator */
     private $typeGenerator;
     /** @var int|null */
-    private $mapTtl;
+    private $mapTTL;
     /** @var NamingStrategyInterface */
     private $namingStrategy;
     /** @var InputTypeGenerator */
@@ -79,16 +79,16 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
     /** @var GlobExtendTypeMapperCache */
     private $globExtendTypeMapperCache;
 
-    public function __construct(string $cachePrefix, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null)
+    public function __construct(string $cachePrefix, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTTL = 2, ?int $mapTTL = null)
     {
         $this->typeGenerator       = $typeGenerator;
         $this->container           = $container;
         $this->annotationReader    = $annotationReader;
         $this->namingStrategy      = $namingStrategy;
         $this->cache               = $cache;
-        $this->globTtl             = $globTtl;
-        $this->cacheContract       = new Psr16Adapter($this->cache, $cachePrefix, $this->globTtl ?? 0);
-        $this->mapTtl              = $mapTtl;
+        $this->globTTL             = $globTTL;
+        $this->cacheContract       = new Psr16Adapter($this->cache, $cachePrefix, $this->globTTL ?? 0);
+        $this->mapTTL              = $mapTTL;
         $this->inputTypeGenerator  = $inputTypeGenerator;
         $this->inputTypeUtils      = $inputTypeUtils;
         $this->recursiveTypeMapper = $recursiveTypeMapper;
@@ -177,7 +177,7 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
                 }
 
                 return $annotationsCache;
-            }, '', $this->mapTtl);
+            }, '', $this->mapTTL);
 
             if ($annotationsCache === 'nothing') {
                 continue;
@@ -227,7 +227,7 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
                 }
 
                 return 'nothing';
-            }, '', $this->mapTtl);
+            }, '', $this->mapTTL);
 
             if ($annotationsCache === 'nothing') {
                 continue;

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -44,13 +44,13 @@ final class GlobTypeMapper extends AbstractTypeMapper
     /**
      * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
      */
-    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?ClassNameMapper $classNameMapper = null, ?int $globTtl = 2, ?int $mapTtl = null, bool $recursive = true)
+    public function __construct(string $namespace, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?ClassNameMapper $classNameMapper = null, ?int $globTTL = 2, ?int $mapTTL = null, bool $recursive = true)
     {
         $this->namespace           = $namespace;
         $this->recursive           = $recursive;
         $this->classNameMapper     = $classNameMapper ?? ClassNameMapper::createFromComposerFile(null, null, true);
         $cachePrefix = str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $namespace);
-        parent::__construct($cachePrefix, $typeGenerator, $inputTypeGenerator, $inputTypeUtils, $container, $annotationReader, $namingStrategy, $recursiveTypeMapper, $cache, $globTtl, $mapTtl);
+        parent::__construct($cachePrefix, $typeGenerator, $inputTypeGenerator, $inputTypeUtils, $container, $annotationReader, $namingStrategy, $recursiveTypeMapper, $cache, $globTTL, $mapTTL);
     }
 
     /**
@@ -63,7 +63,7 @@ final class GlobTypeMapper extends AbstractTypeMapper
     {
         if ($this->classes === null) {
             $this->classes = [];
-            $explorer      = new GlobClassExplorer($this->namespace, $this->cache, $this->globTtl, $this->classNameMapper, $this->recursive);
+            $explorer      = new GlobClassExplorer($this->namespace, $this->cache, $this->globTTL, $this->classNameMapper, $this->recursive);
             $classes       = $explorer->getClassMap();
             foreach ($classes as $className => $phpFile) {
                 if (! class_exists($className, false) && ! interface_exists($className, false)) {

--- a/src/Mappers/Root/RootTypeMapperFactoryContext.php
+++ b/src/Mappers/Root/RootTypeMapperFactoryContext.php
@@ -33,9 +33,9 @@ final class RootTypeMapperFactoryContext
     /** @var CacheInterface */
     private $cache;
     /** @var int|null */
-    private $globTtl;
+    private $globTTL;
     /** @var int|null */
-    private $mapTtl;
+    private $mapTTL;
 
     public function __construct(
         AnnotationReader $annotationReader,
@@ -45,8 +45,8 @@ final class RootTypeMapperFactoryContext
         RecursiveTypeMapperInterface $recursiveTypeMapper,
         ContainerInterface $container,
         CacheInterface $cache,
-        ?int $globTtl = 2,
-        ?int $mapTtl = null
+        ?int $globTTL,
+        ?int $mapTTL = null
     ) {
         $this->annotationReader = $annotationReader;
         $this->typeResolver = $typeResolver;
@@ -55,8 +55,8 @@ final class RootTypeMapperFactoryContext
         $this->recursiveTypeMapper = $recursiveTypeMapper;
         $this->container = $container;
         $this->cache = $cache;
-        $this->globTtl = $globTtl;
-        $this->mapTtl = $mapTtl;
+        $this->globTTL = $globTTL;
+        $this->mapTTL = $mapTTL;
     }
 
     public function getAnnotationReader(): AnnotationReader
@@ -94,13 +94,13 @@ final class RootTypeMapperFactoryContext
         return $this->cache;
     }
 
-    public function getGlobTtl(): ?int
+    public function getGlobTTL(): ?int
     {
-        return $this->globTtl;
+        return $this->globTTL;
     }
 
-    public function getMapTtl(): ?int
+    public function getMapTTL(): ?int
     {
-        return $this->mapTtl;
+        return $this->mapTTL;
     }
 }

--- a/src/Mappers/StaticClassListTypeMapper.php
+++ b/src/Mappers/StaticClassListTypeMapper.php
@@ -36,11 +36,11 @@ final class StaticClassListTypeMapper extends AbstractTypeMapper
     /**
      * @param array<int, string> $classList The list of classes to analyze.
      */
-    public function __construct(array $classList, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTtl = 2, ?int $mapTtl = null)
+    public function __construct(array $classList, TypeGenerator $typeGenerator, InputTypeGenerator $inputTypeGenerator, InputTypeUtils $inputTypeUtils, ContainerInterface $container, AnnotationReader $annotationReader, NamingStrategyInterface $namingStrategy, RecursiveTypeMapperInterface $recursiveTypeMapper, CacheInterface $cache, ?int $globTTL = 2, ?int $mapTTL = null)
     {
         $this->classList = $classList;
         $cachePrefix = str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', implode('_', $classList));
-        parent::__construct($cachePrefix, $typeGenerator, $inputTypeGenerator, $inputTypeUtils, $container, $annotationReader, $namingStrategy, $recursiveTypeMapper, $cache, $globTtl, $mapTtl);
+        parent::__construct($cachePrefix, $typeGenerator, $inputTypeGenerator, $inputTypeUtils, $container, $annotationReader, $namingStrategy, $recursiveTypeMapper, $cache, $globTTL, $mapTTL);
     }
 
     /**

--- a/src/Mappers/StaticClassListTypeMapperFactory.php
+++ b/src/Mappers/StaticClassListTypeMapperFactory.php
@@ -40,8 +40,8 @@ final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterfa
             $context->getNamingStrategy(),
             $context->getRecursiveTypeMapper(),
             $context->getCache(),
-            $context->getGlobTtl(),
-            $context->getMapTtl()
+            $context->getGlobTTL(),
+            $context->getMapTTL()
         );
     }
 }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -259,7 +259,7 @@ class SchemaFactory
      * By default this is set to 2 seconds which is ok for development environments.
      * Set this to "null" (i.e. infinity) for production environments.
      */
-    public function setGlobTtl(?int $globTTL): self
+    public function setGlobTTL(?int $globTTL): self
     {
         $this->globTTL = $globTTL;
 
@@ -269,21 +269,21 @@ class SchemaFactory
     /**
      * Sets GraphQLite in "prod" mode (cache settings optimized for best performance).
      *
-     * This is a shortcut for `$schemaFactory->setGlobTtl(null)`
+     * This is a shortcut for `$schemaFactory->setGlobTTL(null)`
      */
     public function prodMode(): self
     {
-        return $this->setGlobTtl(null);
+        return $this->setGlobTTL(null);
     }
 
     /**
      * Sets GraphQLite in "dev" mode (this is the default mode: cache settings optimized for best developer experience).
      *
-     * This is a shortcut for `$schemaFactory->setGlobTtl(2)`
+     * This is a shortcut for `$schemaFactory->setGlobTTL(2)`
      */
     public function devMode(): self
     {
-        return $this->setGlobTtl(self::GLOB_CACHE_SECONDS);
+        return $this->setGlobTTL(self::GLOB_CACHE_SECONDS);
     }
 
     /**

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -95,7 +95,7 @@ class SchemaFactory
     /** @var SchemaConfig */
     private $schemaConfig;
     /** @var int|null */
-    private $globTtl = 2;
+    private $globTTL = 2;
     /** @var array<int, FieldMiddlewareInterface> */
     private $fieldMiddlewares = [];
     /** @var ExpressionLanguage|null */
@@ -257,9 +257,9 @@ class SchemaFactory
      * By default this is set to 2 seconds which is ok for development environments.
      * Set this to "null" (i.e. infinity) for production environments.
      */
-    public function setGlobTtl(?int $globTtl): self
+    public function setGlobTtl(?int $globTTL): self
     {
-        $this->globTtl = $globTtl;
+        $this->globTTL = $globTTL;
 
         return $this;
     }
@@ -344,7 +344,8 @@ class SchemaFactory
                 $typeRegistry,
                 $recursiveTypeMapper,
                 $this->container,
-                $this->cache
+                $this->cache,
+                $this->globTTL
             );
 
             $reversedRootTypeMapperFactories = array_reverse($this->rootTypeMapperFactories);
@@ -400,7 +401,7 @@ class SchemaFactory
                 $recursiveTypeMapper,
                 $this->cache,
                 $this->classNameMapper,
-                $this->globTtl
+                $this->globTTL
             ));
         }
 
@@ -419,7 +420,8 @@ class SchemaFactory
                 $inputTypeGenerator,
                 $recursiveTypeMapper,
                 $this->container,
-                $this->cache
+                $this->cache,
+                $this->globTTL
             );
         }
 
@@ -438,7 +440,7 @@ class SchemaFactory
                 $annotationReader,
                 $this->cache,
                 $this->classNameMapper,
-                $this->globTtl
+                $this->globTTL
             );
         }
 

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -62,6 +62,8 @@ use function sys_get_temp_dir;
  */
 class SchemaFactory
 {
+    public const GLOB_CACHE_SECONDS = 2;
+
     /** @var string[] */
     private $controllerNamespaces = [];
     /** @var string[] */
@@ -95,7 +97,7 @@ class SchemaFactory
     /** @var SchemaConfig */
     private $schemaConfig;
     /** @var int|null */
-    private $globTTL = 2;
+    private $globTTL = self::GLOB_CACHE_SECONDS;
     /** @var array<int, FieldMiddlewareInterface> */
     private $fieldMiddlewares = [];
     /** @var ExpressionLanguage|null */
@@ -281,7 +283,7 @@ class SchemaFactory
      */
     public function devMode(): self
     {
-        return $this->setGlobTtl(2);
+        return $this->setGlobTtl(self::GLOB_CACHE_SECONDS);
     }
 
     /**

--- a/tests/FactoryContextTest.php
+++ b/tests/FactoryContextTest.php
@@ -10,6 +10,8 @@ use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 
 class FactoryContextTest extends AbstractQueryProviderTest
 {
+    const GLOB_TTL_SECONDS = 2;
+
     public function testContext(): void
     {
         $namingStrategy = new NamingStrategy();
@@ -26,7 +28,8 @@ class FactoryContextTest extends AbstractQueryProviderTest
             $this->getInputTypeGenerator(),
             $this->getTypeMapper(),
             $container,
-            $arrayCache
+            $arrayCache,
+            self::GLOB_TTL_SECONDS
         );
 
         $this->assertSame($this->getAnnotationReader(), $context->getAnnotationReader());
@@ -39,7 +42,7 @@ class FactoryContextTest extends AbstractQueryProviderTest
         $this->assertSame($this->getTypeMapper(), $context->getRecursiveTypeMapper());
         $this->assertSame($container, $context->getContainer());
         $this->assertSame($arrayCache, $context->getCache());
-        $this->assertSame(2, $context->getGlobTtl());
-        $this->assertNull($context->getMapTtl());
+        $this->assertSame(self::GLOB_TTL_SECONDS, $context->getGlobTTL());
+        $this->assertNull($context->getMapTTL());
     }
 }

--- a/tests/RootTypeMapperFactoryContextTest.php
+++ b/tests/RootTypeMapperFactoryContextTest.php
@@ -11,6 +11,8 @@ use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperFactoryContext;
 
 class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
 {
+    const GLOB_TTL_SECONDS = 2;
+
     public function testContext(): void
     {
         $namingStrategy = new NamingStrategy();
@@ -24,7 +26,8 @@ class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
             $this->getTypeRegistry(),
             $this->getTypeMapper(),
             $container,
-            $arrayCache
+            $arrayCache,
+            self::GLOB_TTL_SECONDS
         );
 
         $this->assertSame($this->getAnnotationReader(), $context->getAnnotationReader());
@@ -34,7 +37,7 @@ class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
         $this->assertSame($this->getTypeMapper(), $context->getRecursiveTypeMapper());
         $this->assertSame($container, $context->getContainer());
         $this->assertSame($arrayCache, $context->getCache());
-        $this->assertSame(2, $context->getGlobTtl());
-        $this->assertNull($context->getMapTtl());
+        $this->assertSame(self::GLOB_TTL_SECONDS, $context->getGlobTTL());
+        $this->assertNull($context->getMapTTL());
     }
 }


### PR DESCRIPTION
**Intro**
Hello there! 
I wanted to say hello for your work by submitting this PR.

**Summary**
1. It tries to fix globTTL bug (TTL not being passed, but used default value instead)
2. It renames Ttl to TTL
3. It extracts "2" seconds cache time into const.

**Reasoning**
I think it makes sense to rename Ttl into TTL as it's abbreviation itself, so no need to lowercase it (on the plus side - IMO it reads easier).

When calling RootTypeMapperFactoryContext constructor from SchemaFactory, there was globTtl variable missing causing this class to use default value (2). Same for FactoryContext.
I also extracted magic "2" into const and removed it from optional params. Hopefully this will avoid such situations in future. 