### PR TITLE
Remove line feed when no description in DocBlock 

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -41,6 +41,7 @@ use function get_class;
 use function get_parent_class;
 use function is_string;
 use function reset;
+use function rtrim;
 use function trim;
 use function ucfirst;
 

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -408,7 +408,7 @@ class FieldsBuilder
                 $fieldDescriptor->setTargetMethodOnSource($methodName);
 
                 $docBlockObj     = $this->cachedDocBlockFactory->getDocBlock($refMethod);
-                $docBlockComment = $docBlockObj->getSummary() . "\n" . $docBlockObj->getDescription()->render();
+                $docBlockComment = rtrim($docBlockObj->getSummary() . "\n" . $docBlockObj->getDescription()->render());
 
                 $deprecated      = $docBlockObj->getTagsByName('deprecated');
                 if (count($deprecated) >= 1) {

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -264,6 +264,7 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
         $this->assertInstanceOf(NonNull::class, $fields['sibling']->getType());
         $this->assertInstanceOf(ObjectType::class, $fields['sibling']->getType()->getWrappedType());
         $this->assertSame('TestObject', $fields['sibling']->getType()->getWrappedType()->name);
+        $this->assertSame('This is a test summary', $fields['test']->description);
     }
 
     public function testSourceFieldOnSelfType(): void

--- a/tests/Fixtures/TestObject.php
+++ b/tests/Fixtures/TestObject.php
@@ -21,6 +21,7 @@ class TestObject
     }
 
     /**
+     * This is a test summary
      * @return string
      */
     public function getTest(): string


### PR DESCRIPTION
I'm using the @Sourcefields annotation to implement our existing domain model. All of our methods are documented with a summary but no description. In graphql-playground the "Docs" tab was displaying everything correctly, but clicking on the Schema tab, the whole browser window would go blank. I found that the trailing line feed in the field description was causing the problem. I added code to remove the line feed and an accompanying test.

Thanks for an awesome library by the way.