### PR TITLE
Bump version of phpdocumentor/type-resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,5 @@ jobs:
         - git config --global user.email "${GH_EMAIL}"
         - echo "machine github.com login ${GH_NAME} password ${GH_TOKEN}" > ~/.netrc
         - cd website && yarn install && GIT_USER="${GH_NAME}" yarn run publish-gh-pages
-matrix:
   allow_failures:
     - stage: test_dependencies

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "thecodingmachine/class-explorer": "^1.0.2",
         "psr/simple-cache": "^1",
         "phpdocumentor/reflection-docblock": "^4.3",
-        "phpdocumentor/type-resolver": "^0.4",
+        "phpdocumentor/type-resolver": "^0.4 || ^1.0.0",
         "psr/http-message": "^1",
         "ecodev/graphql-upload": "^4.0",
         "symfony/lock": "^3 || ^4"


### PR DESCRIPTION
Hey there :vulcan_salute: 

as we have another dependency in our product that relies on `phpdocumentor/type-resolver` with version constraint `~0.4 || ^1.0.0`, folks usually have the current `1.2.0` installed. When someone now requires the [GraphQL module](https://github.com/OXID-eSales/graphql-base-module), which currently relies on GraphQLite `^3.1`, [composer will complain about this situation](https://github.com/OXID-eSales/graphql-base-module#composer-can-not-resolve-requirements). This is due to the fact the composer will not make downgrades during `composer require`. So the documented solution as of now is to require with the `--no-update` flag and run `composer update` afterwards.

This PR would solve this problem for us. I know, that this is not a problem in GraphQLite and with the next major release of the OXID eShop and GraphQL module we plan on upgrading to GraphQLite `v4`, but in the meantime this would solve us some support requests :wink: 

Kind regards
Florian