### PR TITLE
Adding back the possibility to inject pure Webonyx objects in GraphQLite

### DIFF
--- a/docs/custom_types.md
+++ b/docs/custom_types.md
@@ -89,7 +89,7 @@ services:
 
 ### Other frameworks
 
-The easiest way is to use a `StaticTypeMapper`. This class is used to register custom output types.
+The easiest way is to use a `StaticTypeMapper`. Use this class to register custom output types.
 
 ```php
 // Sample code:
@@ -105,10 +105,9 @@ $staticTypeMapper->setNotMappedTypes([
     new MyCustomOutputType()
 ]);
 
+// Register the static type mapper in your application using the SchemaFactory instance
+$schemaFactory->addTypeMapper($staticTypeMapper);
 ```
-
-The `StaticTypeMapper` instance MUST be registered in your container and linked to a `CompositeTypeMapper`
-that will aggregate all the type mappers of the application.
 
 ## Registering a custom scalar type (advanced)
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,6 +16,7 @@
     <exclude-pattern>tests/dependencies/*</exclude-pattern>
     <exclude-pattern>src/Utils/NamespacedCache.php</exclude-pattern>
     <exclude-pattern>src/Types/TypeAnnotatedInterfaceType.php</exclude-pattern>
+    <exclude-pattern>src/Mappers/Proxys/*</exclude-pattern>
 
     <!-- Excluding ServiceResolver.php and QueryFieldDescriptor.php because Slevomat 5.0 does not support array shaped. -->
     <!-- Support is added in 5.1 so we can remove these excludes when Slevomat 5.1 is out -->

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,9 @@ parameters:
         -
            message: '#Method TheCodingMachine\\GraphQLite\\Types\\Mutable(Interface|Object)Type::getFields\(\) should return array<GraphQL\\Type\\Definition\\FieldDefinition> but returns array\|float\|int#'
            path: src/Types/MutableTrait.php
+        -
+           message: '#Method TheCodingMachine\\GraphQLite\\Mappers\\Proxys\\Mutable(Interface|Object)TypeAdapter::getFields\(\) should return array<GraphQL\\Type\\Definition\\FieldDefinition> but returns array\|float\|int#'
+           path: src/Mappers/Proxys/MutableAdapterTrait.php
         #- "#Parameter \\#2 \\$inputTypeNode of static method GraphQL\\\\Utils\\\\AST::typeFromAST() expects GraphQL\\\\Language\\\\AST\\\\ListTypeNode\\|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode\\|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode, GraphQL\\\\Language\\\\AST\\\\ListTypeNode\\|GraphQL\\\\Language\\\\AST\\\\NameNode\\|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode given.#"
         - "#PHPDoc tag @throws with type Psr\\\\SimpleCache\\\\InvalidArgumentException is not subtype of Throwable#"
         - '#Variable \$context might not be defined.#'
@@ -22,6 +25,9 @@ parameters:
            message: '#Parameter \#2 \$subType of method .* expects#'
            path: src/Mappers/Root/IteratorTypeMapper.php
         -
+           message: '#Array .* does not accept GraphQL\\Type\\Definition\\InterfaceType\|GraphQL\\Type\\Definition\\ObjectType.*#'
+           path: src/Mappers/StaticTypeMapper.php
+        -
            message: '#Unreachable statement - code above always terminates.#'
            path: src/Http/WebonyxGraphqlMiddleware.php
         -
@@ -31,8 +37,7 @@ parameters:
            message: '#Method TheCodingMachine\\GraphQLite\\AnnotationReader::getMethodAnnotations\(\) should return array<int, T of object> but returns array<object>.#'
            path: src/AnnotationReader.php
         - '#Call to an undefined method GraphQL\\Error\\ClientAware::getMessage()#'
-        # Needed because of a bug in PHP-CS
-        - '#PHPDoc tag @param for parameter \$args with type mixed is not subtype of native type array<int, mixed>.#'
+
 
         #-
         #  message: '#If condition is always true#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,7 +25,7 @@ parameters:
            message: '#Parameter \#2 \$subType of method .* expects#'
            path: src/Mappers/Root/IteratorTypeMapper.php
         -
-           message: '#Array .* does not accept GraphQL\\Type\\Definition\\InterfaceType\|GraphQL\\Type\\Definition\\ObjectType.*#'
+           message: '#Method TheCodingMachine\\GraphQLite\\Mappers\\StaticTypeMapper::castOutputTypeToMutable() should return TheCodingMachine\\GraphQLite\\Mappers\\Proxys\\MutableInterfaceTypeAdapter\|TheCodingMachine\\GraphQLite\\Mappers\\Proxys\\MutableObjectTypeAdapter but returns GraphQL\\Type\\Definition\\InterfaceType|GraphQL\\Type\\Definition\\ObjectType.#'
            path: src/Mappers/StaticTypeMapper.php
         -
            message: '#Unreachable statement - code above always terminates.#'

--- a/src/Mappers/Proxys/MutableAdapterTrait.php
+++ b/src/Mappers/Proxys/MutableAdapterTrait.php
@@ -30,7 +30,7 @@ trait MutableAdapterTrait
     private $className;
 
     /** @var string */
-    private $status;
+    private $status = MutableInterface::STATUS_PENDING;
 
     /** @var array<callable> */
     private $fieldsCallables = [];

--- a/src/Mappers/Proxys/MutableAdapterTrait.php
+++ b/src/Mappers/Proxys/MutableAdapterTrait.php
@@ -78,7 +78,7 @@ trait MutableAdapterTrait
      *
      * @throws Exception
      */
-    public function getField($name)
+    public function getField($name): FieldDefinition
     {
         if ($this->status === MutableInterface::STATUS_PENDING) {
             throw new RuntimeException('You must freeze() a '.get_class($this).' before fetching its fields.');
@@ -92,7 +92,7 @@ trait MutableAdapterTrait
      *
      * @return bool
      */
-    public function hasField($name)
+    public function hasField($name): bool
     {
         if ($this->status === MutableInterface::STATUS_PENDING) {
             throw new RuntimeException('You must freeze() a '.get_class($this).' before fetching its fields.');

--- a/src/Mappers/Proxys/MutableAdapterTrait.php
+++ b/src/Mappers/Proxys/MutableAdapterTrait.php
@@ -1,0 +1,145 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Proxys;
+
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use RuntimeException;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\NoFieldsException;
+use function get_class;
+
+/**
+ * @internal
+ */
+trait MutableAdapterTrait
+{
+    /**
+     * @var ObjectType|InterfaceType
+     */
+    private $type;
+    /**
+     * @var string|null
+     */
+    private $className;
+
+    /** @var string */
+    private $status;
+
+    /** @var array<callable> */
+    private $fieldsCallables = [];
+
+    /** @var FieldDefinition[]|null */
+    private $finalFields;
+
+    /**
+     * @throws InvariantViolation
+     */
+    public function assertValid(): void
+    {
+        $this->type->assertValid();
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->type->jsonSerialize();
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->type->toString();
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->type->__toString();
+    }
+
+
+    /**
+     * @param string $name
+     *
+     * @return FieldDefinition
+     *
+     * @throws Exception
+     */
+    public function getField($name)
+    {
+        if ($this->status === MutableInterface::STATUS_PENDING) {
+            throw new RuntimeException('You must freeze() a '.get_class($this).' before fetching its fields.');
+        }
+
+        return $this->type->getField($name);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasField($name)
+    {
+        if ($this->status === MutableInterface::STATUS_PENDING) {
+            throw new RuntimeException('You must freeze() a '.get_class($this).' before fetching its fields.');
+        }
+
+        return $this->type->hasField($name);
+    }
+
+    /**
+     * @return FieldDefinition[]
+     *
+     * @throws InvariantViolation
+     */
+    public function getFields(): array
+    {
+        if ($this->finalFields === null) {
+            if ($this->status === MutableInterface::STATUS_PENDING) {
+                throw new RuntimeException('You must freeze() a '.get_class($this).' before fetching its fields.');
+            }
+
+            $this->finalFields = $this->type->getFields();
+            foreach ($this->fieldsCallables as $fieldsCallable) {
+                $this->finalFields = FieldDefinition::defineFieldMap($this, $fieldsCallable()) + $this->finalFields;
+            }
+            if (empty($this->finalFields)) {
+                throw NoFieldsException::create($this->name);
+            }
+        }
+
+        return $this->finalFields;
+    }
+
+    public function freeze(): void
+    {
+        $this->status = self::STATUS_FROZEN;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function addFields(callable $fields): void
+    {
+        if ($this->status !== MutableInterface::STATUS_PENDING) {
+            throw new RuntimeException('Tried to add fields to a frozen MutableInterfaceType.');
+        }
+        $this->fieldsCallables[] = $fields;
+    }
+}

--- a/src/Mappers/Proxys/MutableInterfaceTypeAdapter.php
+++ b/src/Mappers/Proxys/MutableInterfaceTypeAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Proxys;
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Utils\Utils;
+use RuntimeException;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\NoFieldsException;
+use function call_user_func;
+use function is_array;
+use function is_callable;
+use function is_string;
+use function sprintf;
+
+/**
+ * An adapter class (actually a proxy) that adds the "mutable" feature to any Webonyx ObjectType.
+ *
+ * @internal
+ */
+class MutableInterfaceTypeAdapter extends InterfaceType implements MutableInterface
+{
+    /** @use MutableAdapterTrait<InterfaceType> */
+    use MutableAdapterTrait;
+
+    public function __construct(InterfaceType $type, ?string $className = null)
+    {
+        $this->type = $type;
+        $this->className = $className;
+        $this->name = $type->name;
+        $this->config = $type->config;
+        $this->astNode = $type->astNode;
+        $this->extensionASTNodes = $type->extensionASTNodes;
+    }
+}

--- a/src/Mappers/Proxys/MutableInterfaceTypeAdapter.php
+++ b/src/Mappers/Proxys/MutableInterfaceTypeAdapter.php
@@ -12,6 +12,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Utils\Utils;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\NoFieldsException;
 use function call_user_func;
 use function is_array;
@@ -24,7 +25,7 @@ use function sprintf;
  *
  * @internal
  */
-class MutableInterfaceTypeAdapter extends InterfaceType implements MutableInterface
+class MutableInterfaceTypeAdapter extends MutableInterfaceType implements MutableInterface
 {
     /** @use MutableAdapterTrait<InterfaceType> */
     use MutableAdapterTrait;

--- a/src/Mappers/Proxys/MutableObjectTypeAdapter.php
+++ b/src/Mappers/Proxys/MutableObjectTypeAdapter.php
@@ -12,6 +12,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Utils\Utils;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\NoFieldsException;
 use function assert;
 use function call_user_func;
@@ -25,7 +26,7 @@ use function sprintf;
  *
  * @internal
  */
-class MutableObjectTypeAdapter extends ObjectType implements MutableInterface
+class MutableObjectTypeAdapter extends MutableObjectType implements MutableInterface
 {
     /** @use MutableAdapterTrait<ObjectType> */
     use MutableAdapterTrait;

--- a/src/Mappers/Proxys/MutableObjectTypeAdapter.php
+++ b/src/Mappers/Proxys/MutableObjectTypeAdapter.php
@@ -1,0 +1,78 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Mappers\Proxys;
+
+use Exception;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Utils\Utils;
+use RuntimeException;
+use TheCodingMachine\GraphQLite\Types\MutableInterface;
+use TheCodingMachine\GraphQLite\Types\NoFieldsException;
+use function assert;
+use function call_user_func;
+use function is_array;
+use function is_callable;
+use function is_string;
+use function sprintf;
+
+/**
+ * An adapter class (actually a proxy) that adds the "mutable" feature to any Webonyx ObjectType.
+ *
+ * @internal
+ */
+class MutableObjectTypeAdapter extends ObjectType implements MutableInterface
+{
+    /** @use MutableAdapterTrait<ObjectType> */
+    use MutableAdapterTrait;
+
+    public function __construct(ObjectType $type, ?string $className = null)
+    {
+        $this->type = $type;
+        $this->className = $className;
+        $this->name = $type->name;
+        $this->config = $type->config;
+        $this->astNode = $type->astNode;
+        $this->extensionASTNodes = $type->extensionASTNodes;
+        $this->resolveFieldFn = $type->resolveFieldFn;
+    }
+
+    /**
+     * @return InterfaceType[]
+     */
+    public function getInterfaces()
+    {
+        $type = $this->type;
+        assert($type instanceof ObjectType);
+        return $type->getInterfaces();
+    }
+
+    /**
+     * @param mixed[]      $value
+     * @param mixed[]|null $context
+     *
+     * @return bool|null
+     */
+    public function isTypeOf($value, $context, ResolveInfo $info)
+    {
+        $type = $this->type;
+        assert($type instanceof ObjectType);
+        return $type->isTypeOf($value, $context, $info);
+    }
+
+    /**
+     * @param InterfaceType $iface
+     *
+     * @return bool
+     */
+    public function implementsInterface($iface)
+    {
+        $type = $this->type;
+        assert($type instanceof ObjectType);
+        return $type->implementsInterface($iface);
+    }
+}

--- a/tests/Fixtures/StaticTypeMapper/Controllers/TestLegacyController.php
+++ b/tests/Fixtures/StaticTypeMapper/Controllers/TestLegacyController.php
@@ -1,0 +1,19 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\StaticTypeMapper\Controllers;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Fixtures\StaticTypeMapper\Types\TestLegacyObject;
+
+class TestLegacyController
+{
+    /**
+     * @Query()
+     */
+    public function getLegacyObject(): TestLegacyObject
+    {
+        return new TestLegacyObject();
+    }
+}

--- a/tests/Fixtures/StaticTypeMapper/Types/TestLegacyObject.php
+++ b/tests/Fixtures/StaticTypeMapper/Types/TestLegacyObject.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\StaticTypeMapper\Types;
+
+
+class TestLegacyObject
+{
+    public function getFoo() {
+        return 42;
+    }
+}

--- a/tests/Mappers/Proxys/MutableObjectTypeAdapterTest.php
+++ b/tests/Mappers/Proxys/MutableObjectTypeAdapterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Mappers\Proxys;
+
+use GraphQL\Type\Definition\InterfaceType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TheCodingMachine\GraphQLite\Fixtures\StaticTypeMapper\Types\TestLegacyObject;
+use TheCodingMachine\GraphQLite\Types\MutableObjectType;
+use TheCodingMachine\GraphQLite\Types\NoFieldsException;
+
+class MutableObjectTypeAdapterTest extends TestCase
+{
+
+    private function getAdapter(): MutableObjectTypeAdapter
+    {
+        $type = new ObjectType([
+            'name' => 'TestLegacyObject',
+            'fields' => [
+                'foo' => [
+                    'type' =>Type::int(),
+                    'resolve' => function(TestLegacyObject $source) {
+                        return $source->getFoo();
+                    }
+                ]
+            ]
+        ]);
+
+        $adapter = new MutableObjectTypeAdapter($type);
+
+        return $adapter;
+    }
+    public function testAdapter()
+    {
+        $type = new ObjectType([
+            'name' => 'TestLegacyObject',
+            'fields' => [
+                'foo' => [
+                    'type' =>Type::int(),
+                    'resolve' => function(TestLegacyObject $source) {
+                        return $source->getFoo();
+                    }
+                ]
+            ]
+        ]);
+
+        $adapter = new MutableObjectTypeAdapter($type);
+
+        $adapter->assertValid();
+
+        $adapter->freeze();
+        $this->assertSame($type->getInterfaces(), $adapter->getInterfaces());
+        $this->assertSame($type->jsonSerialize(), $adapter->jsonSerialize());
+        $this->assertSame($type->getField('foo'), $adapter->getField('foo'));
+        $this->assertSame($type->hasField('foo'), $adapter->hasField('foo'));
+        $interfaceType = new InterfaceType(['name' => 'Foo']);
+        $this->assertSame($type->implementsInterface($interfaceType), $adapter->implementsInterface($interfaceType));
+
+    }
+
+    public function testGetStatus(): void
+    {
+        $type = $this->getAdapter();
+
+        $this->assertSame(MutableObjectType::STATUS_PENDING, $type->getStatus());
+        $type->freeze();
+        $this->assertSame(MutableObjectType::STATUS_FROZEN, $type->getStatus());
+    }
+
+    public function testAddFields(): void
+    {
+        $type = $this->getAdapter();
+
+        $type->addFields(function() {
+            return [
+                'test'   => Type::int(),
+                'test2'   => Type::string(),
+            ];
+        });
+        $type->addFields(function() {
+            return [
+                'test3'   => Type::int(),
+            ];
+        });
+        $type->freeze();
+        $fields = $type->getFields();
+        $this->assertCount(4, $fields);
+        $this->assertArrayHasKey('test', $fields);
+        $this->assertSame(Type::int(), $fields['test']->getType());
+    }
+
+    public function testHasFieldError(): void
+    {
+        $type = $this->getAdapter();
+
+        $this->expectException(RuntimeException::class);
+        $type->hasField('test');
+    }
+
+    public function testGetFieldError(): void
+    {
+        $type = $this->getAdapter();
+
+        $this->expectException(RuntimeException::class);
+        $type->getField('test');
+    }
+
+    public function testGetFieldsError(): void
+    {
+        $type = $this->getAdapter();
+
+        $this->expectException(RuntimeException::class);
+        $type->getFields();
+    }
+
+    public function testAddFieldsError(): void
+    {
+        $type = $this->getAdapter();
+
+        $type->freeze();
+        $this->expectException(RuntimeException::class);
+        $type->addFields(function() {});
+    }
+
+    public function testNoFieldsType(): void
+    {
+        $type = new ObjectType([
+            'name' => 'TestLegacyObject',
+            'fields' => [
+
+            ]
+        ]);
+
+        $adapter = new MutableObjectTypeAdapter($type);
+
+        $adapter->freeze();
+        $this->expectException(NoFieldsException::class);
+        $this->expectExceptionMessage('The GraphQL object type "TestLegacyObject" has no fields defined. Please check that some fields are defined (using the @Field annotation). If some fields are defined, please check that at least one is visible to the current user.');
+        $adapter->getFields();
+    }
+
+}

--- a/tests/Mappers/StaticTypeMapperTest.php
+++ b/tests/Mappers/StaticTypeMapperTest.php
@@ -4,6 +4,7 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 
 use GraphQL\Error\Debug;
 use GraphQL\GraphQL;
+use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -150,7 +151,11 @@ class StaticTypeMapperTest extends AbstractQueryProviderTest
                         }
                     ]
                 ]
-            ])
+            ]),
+        ]);
+
+        $staticTypeMapper->setNotMappedTypes([
+            new InterfaceType(['name' => 'FooInterface'])
         ]);
 
         // Register the static type mapper in your application using the SchemaFactory instance

--- a/tests/Mappers/StaticTypeMapperTest.php
+++ b/tests/Mappers/StaticTypeMapperTest.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\Type;
 use PHPUnit\Framework\TestCase;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
+use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use GraphQL\Type\Definition\InputObjectType;
@@ -27,6 +28,12 @@ class StaticTypeMapperTest extends AbstractQueryProviderTest
         $this->typeMapper->setTypes([
             TestObject::class => new MutableObjectType([
                 'name'    => 'TestObject',
+                'fields'  => [
+                    'test'   => Type::string(),
+                ],
+            ]),
+            TestObject2::class => new ObjectType([
+                'name'    => 'TestObject2',
                 'fields'  => [
                     'test'   => Type::string(),
                 ],
@@ -58,7 +65,7 @@ class StaticTypeMapperTest extends AbstractQueryProviderTest
         $this->assertFalse($this->typeMapper->canMapClassToInputType(\Exception::class));
         $this->assertInstanceOf(ObjectType::class, $this->typeMapper->mapClassToType(TestObject::class, null));
         $this->assertInstanceOf(InputObjectType::class, $this->typeMapper->mapClassToInputType(TestObject::class));
-        $this->assertSame([TestObject::class], $this->typeMapper->getSupportedClasses());
+        $this->assertSame([TestObject::class, TestObject2::class], $this->typeMapper->getSupportedClasses());
         $this->assertSame('TestObject', $this->typeMapper->mapNameToType('TestObject')->name);
         $this->assertSame('TestInputObject', $this->typeMapper->mapNameToType('TestInputObject')->name);
         $this->assertSame('TestNotMappedObject', $this->typeMapper->mapNameToType('TestNotMappedObject')->name);


### PR DESCRIPTION
When migrating to 4.0, we lost the ability to inject ObjectType or InterfaceType in the StaticTypeMapper.
This commit adds "proxys" that are turning any ObjectType into a MutableObjectType (and same thing for interface).

We still need to do the same thing with InputTypes

See #277 


- [x] Create an adapter that takes an OutputType and implements both OutputType&MutableInterface.
- [x] Create an adapter that takes an InterfaceType and implements both InterfaceType&MutableInterface.
- [ ] Create an adapter that takes an InputType and implements both InputType&ResolvableMutableInputInterface
- [ ] Use those adapters automatically in `StaticTypeMapper` (these are implementation details that should be hidden to the end user)
- [ ] Add integration tests
- [x] Fix documentation (talk about how to use this with the `SchemaFactory`)