### PR TITLE
fix datetime input tests

### DIFF
--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -494,7 +494,7 @@ class EndToEndTest extends TestCase
         $schema = $this->mainContainer->get(Schema::class);
         $queryString = '
         mutation {
-          saveBirthDate(birthDate: "1942-12-24 00:00:00")  {
+          saveBirthDate(birthDate: "1942-12-24T00:00:00+00:00")  {
             name
             birthDate
           }
@@ -535,7 +535,7 @@ class EndToEndTest extends TestCase
             null,
             null,
             [
-                "birthDate" => "1942-12-24 00:00:00"
+                "birthDate" => "1942-12-24T00:00:00+00:00"
             ]
         );
 
@@ -558,7 +558,7 @@ class EndToEndTest extends TestCase
           saveContact(
             contact: {
                 name: "foo",
-                birthDate: "1942-12-24 00:00:00",
+                birthDate: "1942-12-24T00:00:00+00:00",
                 relations: [
                     {
                         name: "bar"


### PR DESCRIPTION
This PR fixes some invalid tests

<details>
  <summary>Detailed output</summary>

  ```

There were 3 failures:

1) TheCodingMachine\GraphQLite\Integration\EndToEndTest::testEndToEndInputTypeDate
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
     'saveBirthDate' => Array &1 (
         'name' => 'Bill'
-        'birthDate' => '1942-12-24T00:00:00+00:00'
+        'birthDate' => '1942-12-24T00:00:00+01:00'
     )
 )

/home/esprit/git/graphqlite/tests/Integration/EndToEndTest.php:514

2) TheCodingMachine\GraphQLite\Integration\EndToEndTest::testEndToEndInputTypeDateAsParam
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
     'saveBirthDate' => Array &1 (
         'name' => 'Bill'
-        'birthDate' => '1942-12-24T00:00:00+00:00'
+        'birthDate' => '1942-12-24T00:00:00+01:00'
     )
 )

/home/esprit/git/graphqlite/tests/Integration/EndToEndTest.php:547

3) TheCodingMachine\GraphQLite\Integration\EndToEndTest::testEndToEndInputType
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
     'saveContact' => Array &1 (
         'name' => 'foo'
-        'birthDate' => '1942-12-24T00:00:00+00:00'
+        'birthDate' => '1942-12-24T00:00:00+01:00'
         'relations' => Array &2 (
             0 => Array &3 (
                 'name' => 'bar'

/home/esprit/git/graphqlite/tests/Integration/EndToEndTest.php:593

  ```
  
</details>

It can be reproduced by changing default timezone in php