### PR TITLE
Fixed typo in Context.php preventing prefetch to work on more than one Field

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -27,11 +27,11 @@ class Context implements ContextInterface, ResetableContextInterface
      */
     public function getPrefetchBuffer(QueryField $field): PrefetchBuffer
     {
-        if ($this->prefetchBuffers->offsetExists($this)) {
-            $prefetchBuffer = $this->prefetchBuffers->offsetGet($this);
+        if ($this->prefetchBuffers->offsetExists($field)) {
+            $prefetchBuffer = $this->prefetchBuffers->offsetGet($field);
         } else {
             $prefetchBuffer = new PrefetchBuffer();
-            $this->prefetchBuffers->offsetSet($this, $prefetchBuffer);
+            $this->prefetchBuffers->offsetSet($field, $prefetchBuffer);
         }
 
         return $prefetchBuffer;


### PR DESCRIPTION
Bug: Having `prefetchMethod` on more than one Field causes a disaster that ends with `Expected a callable. Got: array` deep within the guts of the library.

TL;DR: Prefetch buffers were overlapping because of a typo/copy-paste issue in `Context.php`.

After spending the better part of the day going through your entire code to figure out how resolving+prefetching works I finally found the bug in the most unexpected place. I literally dissected every bit of code along the way, from building the field descriptor, to the evaluation of the bunch of closures that produce the resolved value. All seemed fine, but nonetheless the wrong set of data was passed to the second (positioned second in the query) `Field` with `prefetchMethod` which ended up in fatal error of course. Then I thought, the issue should then be in storing or retrieving that prefetched data.. and yep, there in `Context.php` standed the glorious captain obvious... `$this` was used as a key to the `SplObjectStorage`, instead of the passed `$field`.

Cheers!

Signed-off-by: Ivan Ganev <iganev@cytec.bg>