### PR TITLE
GraphQL handles error using the 'error' key in the response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ website/i18n/*
 /tests/dependencies/graphqlite-universal-service-provider/
 
 .phpunit.result.cache
+tags

--- a/src/Http/HttpCodeDecider.php
+++ b/src/Http/HttpCodeDecider.php
@@ -19,6 +19,14 @@ class HttpCodeDecider implements HttpCodeDeciderInterface
     private $defaultHTTPErrorCode = 400;
 
     /**
+     * @param int $defaultHTTPErrorCode Default error code used in the HTTP requests.
+     */
+    public function __construct(int $defaultHTTPErrorCode = 400)
+    {
+        $this->defaultHTTPErrorCode = $defaultHTTPErrorCode;
+    }
+
+    /**
      * Decides the HTTP status code based on the answer.
      *
      * @see https://github.com/APIs-guru/graphql-over-http#status-codes
@@ -59,10 +67,5 @@ class HttpCodeDecider implements HttpCodeDeciderInterface
         }
 
         return $status;
-    }
-
-    public function setDefaultHTTPErrorCode(int $code): void
-    {
-        $this->defaultHTTPErrorCode = $code;
     }
 }

--- a/src/Http/HttpCodeDecider.php
+++ b/src/Http/HttpCodeDecider.php
@@ -16,7 +16,7 @@ class HttpCodeDecider implements HttpCodeDeciderInterface
      *
      * @var int
      */
-    private $defaultHTTPErrorCode = 200;
+    private $defaultHTTPErrorCode = 400;
 
     /**
      * Decides the HTTP status code based on the answer.

--- a/src/Http/HttpCodeDecider.php
+++ b/src/Http/HttpCodeDecider.php
@@ -12,6 +12,13 @@ use function max;
 class HttpCodeDecider implements HttpCodeDeciderInterface
 {
     /**
+     * Default HTTP Error code.
+     *
+     * @var int
+     */
+    private $defaultHTTPErrorCode = 200;
+
+    /**
      * Decides the HTTP status code based on the answer.
      *
      * @see https://github.com/APIs-guru/graphql-over-http#status-codes
@@ -37,11 +44,11 @@ class HttpCodeDecider implements HttpCodeDeciderInterface
 
                     // A "client aware" exception is almost certainly targeting the client (there is
                     // no need to pass a server exception error message to the client).
-                    // So a ClientAware exception is almost certainly a HTTP 400 code
-                    $code = 400;
+                    // So a ClientAware exception is almost certainly a HTTP 200 code
+                    $code = $this->defaultHTTPErrorCode;
                 }
             } else {
-                $code = 400;
+                $code = $this->defaultHTTPErrorCode;
             }
             $status = max($status, $code);
         }
@@ -52,5 +59,10 @@ class HttpCodeDecider implements HttpCodeDeciderInterface
         }
 
         return $status;
+    }
+
+    public function setDefaultHTTPErrorCode(int $code): void
+    {
+        $this->defaultHTTPErrorCode = $code;
     }
 }

--- a/src/Http/WebonyxGraphqlMiddleware.php
+++ b/src/Http/WebonyxGraphqlMiddleware.php
@@ -137,7 +137,15 @@ final class WebonyxGraphqlMiddleware implements MiddlewareInterface
                 return $this->httpCodeDecider->decideHttpStatusCode($executionResult);
             }, $result);
 
-            return max($codes);
+            // PHPStan will trigger an error if we don't check the return value of the max function.
+            // @see https://www.php.net/manual/en/function.max.php
+            // > If an empty array is passed, then false will be returned and an E_WARNING error will be emitted.
+            $maxStatusCode = max($codes);
+            if ($maxStatusCode === false) {
+                $maxStatusCode = 400;
+            }
+
+            return $maxStatusCode;
         }
 
         // @codeCoverageIgnoreStart

--- a/tests/Http/HttpCodeDeciderTest.php
+++ b/tests/Http/HttpCodeDeciderTest.php
@@ -62,8 +62,7 @@ class HttpCodeDeciderTest extends TestCase
 
     public function testSetTheDefaultHTTPErroCode(): void
     {
-        $codeDecider = new HttpCodeDecider();
-        $codeDecider->setDefaultHTTPErrorCode(200);
+        $codeDecider = new HttpCodeDecider(200);
         $graphqlError = new Exception('foo');
 
         $executionResult = new ExecutionResult(null, [ $graphqlError ]);

--- a/tests/Http/HttpCodeDeciderTest.php
+++ b/tests/Http/HttpCodeDeciderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TheCodingMachine\GraphQLite\Http;
 
 use Exception;
@@ -10,7 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class HttpCodeDeciderTest extends TestCase
 {
-
     public function testDecideHttpStatusCode(): void
     {
         $codeDecider = new HttpCodeDecider();
@@ -34,12 +35,12 @@ class HttpCodeDeciderTest extends TestCase
         $errorCode600 = new Error('Foo', null, null, null, null, $exception600);
 
         $clientAwareException = new class extends Exception implements ClientAware {
-            public function isClientSafe()
+            public function isClientSafe(): bool
             {
                 return true;
             }
 
-            public function getCategory()
+            public function getCategory(): string
             {
                 return 'foo';
             }
@@ -53,9 +54,20 @@ class HttpCodeDeciderTest extends TestCase
         $this->assertSame(404, $codeDecider->decideHttpStatusCode($executionResult));
 
         $executionResult = new ExecutionResult(null, [ $graphqlError ]);
-        $this->assertSame(400, $codeDecider->decideHttpStatusCode($executionResult));
+        $this->assertSame(200, $codeDecider->decideHttpStatusCode($executionResult));
 
         $executionResult = new ExecutionResult(null, [ $clientAwareError ]);
+        $this->assertSame(200, $codeDecider->decideHttpStatusCode($executionResult));
+    }
+
+    public function testSetTheDefaultHTTPErroCode(): void
+    {
+        $codeDecider = new HttpCodeDecider();
+        $codeDecider->setDefaultHTTPErrorCode(400);
+        $graphqlError = new Exception('foo');
+
+        $executionResult = new ExecutionResult(null, [ $graphqlError ]);
+
         $this->assertSame(400, $codeDecider->decideHttpStatusCode($executionResult));
     }
 }

--- a/tests/Http/HttpCodeDeciderTest.php
+++ b/tests/Http/HttpCodeDeciderTest.php
@@ -54,20 +54,20 @@ class HttpCodeDeciderTest extends TestCase
         $this->assertSame(404, $codeDecider->decideHttpStatusCode($executionResult));
 
         $executionResult = new ExecutionResult(null, [ $graphqlError ]);
-        $this->assertSame(200, $codeDecider->decideHttpStatusCode($executionResult));
+        $this->assertSame(400, $codeDecider->decideHttpStatusCode($executionResult));
 
         $executionResult = new ExecutionResult(null, [ $clientAwareError ]);
-        $this->assertSame(200, $codeDecider->decideHttpStatusCode($executionResult));
+        $this->assertSame(400, $codeDecider->decideHttpStatusCode($executionResult));
     }
 
     public function testSetTheDefaultHTTPErroCode(): void
     {
         $codeDecider = new HttpCodeDecider();
-        $codeDecider->setDefaultHTTPErrorCode(400);
+        $codeDecider->setDefaultHTTPErrorCode(200);
         $graphqlError = new Exception('foo');
 
         $executionResult = new ExecutionResult(null, [ $graphqlError ]);
 
-        $this->assertSame(400, $codeDecider->decideHttpStatusCode($executionResult));
+        $this->assertSame(200, $codeDecider->decideHttpStatusCode($executionResult));
     }
 }


### PR DESCRIPTION
GraphQL handles error using the 'error' key in the response, not using
HTTP status code. If you have a request with two queries and one of
those have an error the status code should not be changed. Here you can
see some examples of these:

- https://medium.com/@mczachurski/graphql-error-handling-17979dc571da
- https://github.com/graphql/express-graphql/issues/111