### PR TITLE
Fixing CI tests of dependencies with Composer 2

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -48,7 +48,7 @@ On the other hand, if you are a power user and if you are wiring GraphQLite serv
 - The `HydratorInterface` and all implementations are gone. When returning an input object from a TypeMapper, the object
   must now implement the `ResolvableMutableInputInterface` (an input object type that contains its own resolver)
 
-Note: we strongly recommend to use the Symfony bundle, the Laravel package, the Universal module or the SchemaManager
+Note: we strongly recommend using the Symfony bundle, the Laravel package, the Universal module or the SchemaManager
 to bootstrap GraphQLite. Wiring directly GraphQLite classes (like the `FieldsBuilder`) into your container is not recommended,
 as the signature of the constructor of those classes may vary from one minor release to another.
 Use the `SchemaManager` instead.

--- a/tests/dependencies/makeComposerLocal.php
+++ b/tests/dependencies/makeComposerLocal.php
@@ -6,8 +6,6 @@ $composerBundlePath = $argv[1];
 //fetch the dev-master alias from the local graphqlite composer
 $composerGraphqlite = json_decode(file_get_contents(__DIR__.'/copy/composer.json'), true);
 
-$masterAlias = $composerGraphqlite['extra']['branch-alias']['dev-master'];
-
 //edit the bundle composer to use the local graphqlite
 $composerBundle = json_decode(file_get_contents($composerBundlePath), true);
 
@@ -18,6 +16,6 @@ $composerBundle['repositories'] = [
     ]
 ];
 
-$composerBundle['require']['thecodingmachine/graphqlite'] = $masterAlias;
+$composerBundle['require']['thecodingmachine/graphqlite'] = '*';
 
 file_put_contents($composerBundlePath, json_encode($composerBundle));

--- a/tests/dependencies/makeComposerLocal.php
+++ b/tests/dependencies/makeComposerLocal.php
@@ -6,6 +6,9 @@ $composerBundlePath = $argv[1];
 //fetch the dev-master alias from the local graphqlite composer
 $composerGraphqlite = json_decode(file_get_contents(__DIR__.'/copy/composer.json'), true);
 
+$masterAlias = $composerGraphqlite['extra']['branch-alias']['dev-master'];
+$fakeVersion = str_replace('.x-dev', '', $masterAlias).'.999999';
+
 //edit the bundle composer to use the local graphqlite
 $composerBundle = json_decode(file_get_contents($composerBundlePath), true);
 
@@ -16,6 +19,6 @@ $composerBundle['repositories'] = [
     ]
 ];
 
-$composerBundle['require']['thecodingmachine/graphqlite'] = '*';
+$composerBundle['require']['thecodingmachine/graphqlite'] = '* as '.$fakeVersion;
 
 file_put_contents($composerBundlePath, json_encode($composerBundle));


### PR DESCRIPTION
Composer 2 handles repositories in a slightly different way from Composer 1.