### PR TITLE
Missing PHP 8 Attributes for some annotations

### DIFF
--- a/src/Annotations/HideParameter.php
+++ b/src/Annotations/HideParameter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Annotations;
 
+use Attribute;
 use BadMethodCallException;
 
 use function ltrim;
@@ -18,6 +19,7 @@ use function ltrim;
  *   @Attribute("for", type = "string")
  * })
  */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class HideParameter implements ParameterAnnotationInterface
 {
     /** @var string */
@@ -26,13 +28,13 @@ class HideParameter implements ParameterAnnotationInterface
     /**
      * @param array<string, mixed> $values
      */
-    public function __construct(array $values = [])
+    public function __construct(array $values = [], ?string $for = null)
     {
-        if (! isset($values['for'])) {
+        if (! isset($for) && ! isset($values['for'])) {
             return;
         }
 
-        $this->for = ltrim($values['for'], '$');
+        $this->for = ltrim($for ?? $values['for'], '$');
     }
 
     public function getTarget(): string

--- a/src/Annotations/HideParameter.php
+++ b/src/Annotations/HideParameter.php
@@ -19,7 +19,7 @@ use function ltrim;
  *   @Attribute("for", type = "string")
  * })
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PARAMETER)]
 class HideParameter implements ParameterAnnotationInterface
 {
     /** @var string */
@@ -28,13 +28,13 @@ class HideParameter implements ParameterAnnotationInterface
     /**
      * @param array<string, mixed> $values
      */
-    public function __construct(array $values = [], ?string $for = null)
+    public function __construct(array $values = [])
     {
-        if (! isset($for) && ! isset($values['for'])) {
+        if (! isset($values['for'])) {
             return;
         }
 
-        $this->for = ltrim($for ?? $values['for'], '$');
+        $this->for = ltrim($values['for'], '$');
     }
 
     public function getTarget(): string

--- a/src/Annotations/InjectUser.php
+++ b/src/Annotations/InjectUser.php
@@ -19,7 +19,7 @@ use function ltrim;
  *   @Attribute("for", type = "string")
  * })
  */
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_PARAMETER)]
 class InjectUser implements ParameterAnnotationInterface
 {
     /** @var string */
@@ -28,13 +28,13 @@ class InjectUser implements ParameterAnnotationInterface
     /**
      * @param array<string, mixed> $values
      */
-    public function __construct(array $values = [], ?string $for = null)
+    public function __construct(array $values = [])
     {
-        if (! isset($for) && ! isset($values['for'])) {
+        if (! isset($values['for'])) {
             return;
         }
 
-        $this->for = ltrim($for ?? $values['for'], '$');
+        $this->for = ltrim($values['for'], '$');
     }
 
     public function getTarget(): string

--- a/src/Annotations/InjectUser.php
+++ b/src/Annotations/InjectUser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Annotations;
 
+use Attribute;
 use BadMethodCallException;
 
 use function ltrim;
@@ -18,6 +19,7 @@ use function ltrim;
  *   @Attribute("for", type = "string")
  * })
  */
+#[Attribute(Attribute::TARGET_METHOD)]
 class InjectUser implements ParameterAnnotationInterface
 {
     /** @var string */
@@ -26,13 +28,13 @@ class InjectUser implements ParameterAnnotationInterface
     /**
      * @param array<string, mixed> $values
      */
-    public function __construct(array $values = [])
+    public function __construct(array $values = [], ?string $for = null)
     {
-        if (! isset($values['for'])) {
+        if (! isset($for) && ! isset($values['for'])) {
             return;
         }
 
-        $this->for = ltrim($values['for'], '$');
+        $this->for = ltrim($for ?? $values['for'], '$');
     }
 
     public function getTarget(): string

--- a/src/Annotations/UseInputType.php
+++ b/src/Annotations/UseInputType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Annotations;
 
+use Attribute;
 use BadMethodCallException;
 
 use function is_string;
@@ -19,6 +20,7 @@ use function ltrim;
  *   @Attribute("inputType", type = "string"),
  * })
  */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class UseInputType implements ParameterAnnotationInterface
 {
     /** @var string|null */
@@ -31,7 +33,7 @@ class UseInputType implements ParameterAnnotationInterface
      *
      * @throws BadMethodCallException
      */
-    public function __construct($inputType = [])
+    public function __construct($inputType = [], ?string $for = null)
     {
         $values = $inputType;
         if (is_string($values)) {
@@ -41,11 +43,11 @@ class UseInputType implements ParameterAnnotationInterface
             throw new BadMethodCallException('The @UseInputType annotation must be passed an input type. For instance: "@UseInputType(for="$input", inputType="MyInputType")" in PHP 7+ or #[UseInputType("MyInputType")] in PHP 8+');
         }
         $this->inputType = $values['inputType'];
-        if (! isset($values['for'])) {
+        if (! isset($for) &&! isset($values['for'])) {
             return;
         }
 
-        $this->for = ltrim($values['for'], '$');
+        $this->for = ltrim($for ?? $values['for'], '$');
     }
 
     public function getTarget(): string

--- a/src/Annotations/UseInputType.php
+++ b/src/Annotations/UseInputType.php
@@ -20,7 +20,7 @@ use function ltrim;
  *   @Attribute("inputType", type = "string"),
  * })
  */
-#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PARAMETER)]
 class UseInputType implements ParameterAnnotationInterface
 {
     /** @var string|null */
@@ -33,7 +33,7 @@ class UseInputType implements ParameterAnnotationInterface
      *
      * @throws BadMethodCallException
      */
-    public function __construct($inputType = [], ?string $for = null)
+    public function __construct($inputType = [])
     {
         $values = $inputType;
         if (is_string($values)) {
@@ -43,11 +43,11 @@ class UseInputType implements ParameterAnnotationInterface
             throw new BadMethodCallException('The @UseInputType annotation must be passed an input type. For instance: "@UseInputType(for="$input", inputType="MyInputType")" in PHP 7+ or #[UseInputType("MyInputType")] in PHP 8+');
         }
         $this->inputType = $values['inputType'];
-        if (! isset($for) && ! isset($values['for'])) {
+        if (! isset($values['for'])) {
             return;
         }
 
-        $this->for = ltrim($for ?? $values['for'], '$');
+        $this->for = ltrim($values['for'], '$');
     }
 
     public function getTarget(): string

--- a/src/Annotations/UseInputType.php
+++ b/src/Annotations/UseInputType.php
@@ -43,7 +43,7 @@ class UseInputType implements ParameterAnnotationInterface
             throw new BadMethodCallException('The @UseInputType annotation must be passed an input type. For instance: "@UseInputType(for="$input", inputType="MyInputType")" in PHP 7+ or #[UseInputType("MyInputType")] in PHP 8+');
         }
         $this->inputType = $values['inputType'];
-        if (! isset($for) &&! isset($values['for'])) {
+        if (! isset($for) && ! isset($values['for'])) {
             return;
         }
 


### PR DESCRIPTION
Within recent updates GraphQLight supports native PHP 8 Attributes - which is amazing!

I stumbled upon a couple annotations which cannot be used as attributes yet, even though there're examples in the docs using the new approach. The ones in question are: `HideParameter`, `InjectUser` and `UseInputType`. Added support for them.