### PR TITLE
Docs > Fix bundle class name

### DIFF
--- a/docs/symfony-bundle.md
+++ b/docs/symfony-bundle.md
@@ -52,7 +52,7 @@ class AppKernel extends Kernel
     {
         $bundles = array(
             // other bundles...
-            new TheCodingMachine\GraphQLite\Bundle\GraphQLiteBundle,
+            new TheCodingMachine\GraphQLite\Bundle\GraphqliteBundle,
         );
     }
 }

--- a/docs/symfony-bundle.md
+++ b/docs/symfony-bundle.md
@@ -52,7 +52,7 @@ class AppKernel extends Kernel
     {
         $bundles = array(
             // other bundles...
-            new TheCodingMachine\GraphQLite\Bundle\GraphqliteBundle,
+            new TheCodingMachine\Graphqlite\Bundle\GraphqliteBundle,
         );
     }
 }


### PR DESCRIPTION
Otherwise I get an error: 

```
Attempted to load class "GraphqliteBundle" from namespace "TheCodingMachine\GraphQLite\Bundle".
Did you forget a "use" statement for "TheCodingMachine\Graphqlite\Bundle\GraphqliteBundle"?
```