### PR TITLE
Provider name needs to be quoted for vendor:publish

### DIFF
--- a/docs/laravel-package.md
+++ b/docs/laravel-package.md
@@ -17,7 +17,7 @@ $ composer require thecodingmachine/graphqlite-laravel
 If you want to publish the configuration (in order to edit it), run:
 
 ```console
-$ php artisan vendor:publish --provider=TheCodingMachine\GraphQLite\Laravel\Providers\GraphQLiteServiceProvider
+$ php artisan vendor:publish --provider="TheCodingMachine\GraphQLite\Laravel\Providers\GraphQLiteServiceProvider"
 ```
 
 You can then configure the library by editing `config/graphqlite.php`.


### PR DESCRIPTION
Without the quotes around the provider name, nothing is published.