### PR TITLE
Fix - Update doc deployment job

### DIFF
--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -1,5 +1,5 @@
 # Generate the complete documentation then upload to the website under the master section
-name: "Doc generation on master"
+name: "Doc generation"
 
 on:
   pull_request: ~
@@ -35,6 +35,7 @@ jobs:
         working-directory: "website"
 
       - name: "Deploy website"
+        if: "${{ github.event_name == 'push' || github.event_name == 'release' }}"
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At f2165e08193f2a440533f1dabf6e2b195b288bd4, @dependabot upgraded [`JamesIves/github-pages-deploy-action`](/JamesIves/github-pages-deploy-action) from `3.7.1` to `4.1.5`.

However, since `4.0.0`, argument `GITHUB_TOKEN` has been renamed to `token` (and all arguments are now lowercase).

I also took the liberty of removing the triggering of documentation deployment on Pull Requests, which seems to be an error.