### PR TITLE
Added TARGET_PARAMETER for PHP8 Attributes

### DIFF
--- a/src/Annotations/Field.php
+++ b/src/Annotations/Field.php
@@ -18,7 +18,7 @@ use Attribute;
  *   @Attribute("inputType", type = "string"),
  * })
  */
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 class Field extends AbstractRequest
 {
     /** @var string|null */


### PR DESCRIPTION
As discussed in the [RFC of constructor property promotion](https://wiki.php.net/rfc/constructor_promotion#attributes) this would allow the #[Field] attribute to be used in function parameters but would automatically be picked up by graphqlite because it would find a Field Attribute with ReflectionProperty.

Would resolve #354 