### PR TITLE
Add automatic conversion for DateTimeImmutable and Enum

### DIFF
--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -25,7 +25,13 @@ class DateTimeType extends ScalarType
      */
     public function serialize($value): string
     {
-        if (! $value instanceof DateTimeImmutable) {
+        if (is_string($value)) {
+            try {
+                $value = new DateTimeImmutable($value);
+            } catch (\Throwable $throwable) {
+                throw new InvariantViolation('DateTime is not an instance of DateTimeImmutable: ' . Utils::printSafe($value), 0, $throwable);
+            }
+        } else if (! $value instanceof DateTimeImmutable) {
             throw new InvariantViolation('DateTime is not an instance of DateTimeImmutable: ' . Utils::printSafe($value));
         }
 

--- a/src/Types/DateTimeType.php
+++ b/src/Types/DateTimeType.php
@@ -11,6 +11,9 @@ use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\Utils;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
+use Throwable;
+
+use function is_string;
 
 class DateTimeType extends ScalarType
 {
@@ -28,10 +31,10 @@ class DateTimeType extends ScalarType
         if (is_string($value)) {
             try {
                 $value = new DateTimeImmutable($value);
-            } catch (\Throwable $throwable) {
+            } catch (Throwable $throwable) {
                 throw new InvariantViolation('DateTime is not an instance of DateTimeImmutable: ' . Utils::printSafe($value), 0, $throwable);
             }
-        } else if (! $value instanceof DateTimeImmutable) {
+        } elseif (! $value instanceof DateTimeImmutable) {
             throw new InvariantViolation('DateTime is not an instance of DateTimeImmutable: ' . Utils::printSafe($value));
         }
 

--- a/tests/Types/DateTimeTypeTest.php
+++ b/tests/Types/DateTimeTypeTest.php
@@ -16,6 +16,7 @@ class DateTimeTypeTest extends TestCase
         $dateTimeType = new DateTimeType();
 
         $this->assertSame('2019-05-05T10:10:10+00:00', $dateTimeType->serialize(new DateTimeImmutable('2019-05-05T10:10:10+00:00')));
+        $this->assertSame('2021-11-01T10:00:00+00:00', $dateTimeType->serialize('2021-11-01 10:00:00'));
 
         $this->expectException(InvariantViolation::class);
         $dateTimeType->serialize('foo');

--- a/tests/Types/MyclabsEnumTypeTest.php
+++ b/tests/Types/MyclabsEnumTypeTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite\Types;
 
 use InvalidArgumentException;
+use MyCLabs\Enum\Enum;
 use PHPUnit\Framework\TestCase;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\ProductTypeEnum;
 
@@ -14,5 +15,13 @@ class MyclabsEnumTypeTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected a Myclabs Enum instance');
         $enumType->serialize('foo');
+    }
+
+    public function testConversion()
+    {
+        $enumType = new MyCLabsEnumType(ProductTypeEnum::class, 'foo');
+        /** @var Enum $result */
+        $result = $enumType->serialize('food');
+        $this->assertEquals('FOOD', $result);
     }
 }


### PR DESCRIPTION
We use GraphQLite in Yii 2, where ActiveRecord keeps DATETIME fields as strings. Maybe we can add automatic conversion from string values to DateTimeImmutable?

The same for Enum. Often there is a situation when existing class has enum properties as integers, and other source code contains a logic that depends on it, but it's better to use enums in GraphQL API.