### PR TITLE
Native enum support

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         install-args: ['', '--prefer-lowest']
-        php-version: ['7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
       fail-fast: false
 
     steps:

--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "Deploy website"
         if: "${{ github.event_name == 'push' || github.event_name == 'release' }}"
-        uses: JamesIves/github-pages-deploy-action@v4.2.2
+        uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages # The branch the action should deploy to.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build/
 /vendor/
 /composer.lock
 /src/Tests/

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "phpstan/phpstan": "^0.12.94",
         "phpstan/phpstan-webmozart-assert": "^0.12.15",
         "phpunit/phpunit": "^8.5.19||^9.5.8",
-        "thecodingmachine/phpstan-strict-rules": "^0.12.1"
+        "thecodingmachine/phpstan-strict-rules": "^0.12.1",
+        "symfony/var-dumper": "^6.0"
     },
     "suggest": {
         "beberlei/porpaginas": "If you want automatic pagination in your GraphQL types",
@@ -66,6 +67,12 @@
     "extra": {
         "branch-alias": {
             "dev-master": "5.0.x-dev"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-webmozart-assert": "^1.0",
-        "phpunit/phpunit": "^8.5.19||^9.5.8",
-        "symfony/var-dumper": "^6.0",
+        "phpunit/phpunit": "^8.5.19 || ^9.5.8",
+        "symfony/var-dumper": "^5.4 || ^6.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "suggest": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,6 +26,7 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
         <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
         <exclude name="Generic.Formatting.MultipleStatementAlignment" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace" />
     </rule>
 
     <!-- Do not align assignments -->

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,10 @@ parameters:
     tmpDir: .phpstan-cache
     paths:
         - src
+    excludePaths:
+         # TODO: exlude only for PHP < 8.1
+        - src/Mappers/Root/EnumTypeMapper.php
+        - src/Types/EnumType.php
     level: max
     checkGenericClassInNonGenericObjectType: false
     reportUnmatchedIgnoredErrors: false

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -7,7 +7,6 @@ namespace TheCodingMachine\GraphQLite;
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\Reader;
 use InvalidArgumentException;
-use MyCLabs\Enum\Enum;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
@@ -567,9 +566,6 @@ class AnnotationReader
         return $toAddAnnotations;
     }
 
-    /**
-     * @param ReflectionClass<Enum> $refClass
-     */
     public function getEnumTypeAnnotation(ReflectionClass $refClass): ?EnumType
     {
         return $this->getClassAnnotation($refClass, EnumType::class);

--- a/src/Annotations/EnumType.php
+++ b/src/Annotations/EnumType.php
@@ -21,12 +21,16 @@ class EnumType
     /** @var string|null */
     private $name;
 
+    /** @var bool */
+    private $useValues;
+
     /**
      * @param mixed[] $attributes
      */
-    public function __construct(array $attributes = [], ?string $name = null)
+    public function __construct(array $attributes = [], ?string $name = null, ?bool $useValues = null)
     {
         $this->name = $name ?? $attributes['name'] ?? null;
+        $this->useValues = $useValues ?? $attributes['useValues'] ?? false;
     }
 
     /**
@@ -35,5 +39,13 @@ class EnumType
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    /**
+     * Returns true if the enum type should expose backed values instead of case names.
+     */
+    public function useValues(): bool
+    {
+        return $this->useValues;
     }
 }

--- a/src/Annotations/EnumType.php
+++ b/src/Annotations/EnumType.php
@@ -9,6 +9,8 @@ use Attribute;
 /**
  * The EnumType annotation is useful to change the name of the generated "enum" type.
  *
+ * @deprecated Use @Type on a native PHP 8.1 Enum instead. Support will be removed in future release.
+ *
  * @Annotation
  * @Target({"CLASS"})
  * @Attributes({

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -52,8 +52,14 @@ class Type
      * @param mixed[] $attributes
      * @param class-string<object>|null $class
      */
-    public function __construct(array $attributes = [], ?string $class = null, ?string $name = null, ?bool $default = null, ?bool $external = null, ?bool $useEnumValues = null)
-    {
+    public function __construct(
+        array $attributes = [],
+        ?string $class = null,
+        ?string $name = null,
+        ?bool $default = null,
+        ?bool $external = null,
+        ?bool $useEnumValues = null
+    ) {
         $external = $external ?? $attributes['external'] ?? null;
         $class = $class ?? $attributes['class'] ?? null;
         if ($class !== null) {
@@ -66,14 +72,13 @@ class Type
 
         // If no value is passed for default, "default" = true
         $this->default = $default ?? $attributes['default'] ?? true;
+        $this->useEnumValues = $useEnumValues ?? $attributes['useEnumValues'] ?? false;
 
         if ($external === null) {
             return;
         }
 
         $this->selfType = ! $external;
-
-        $this->useEnumValues = $useEnumValues ?? $attributes['useEnumValues'] ?? false;
     }
 
     /**

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -143,7 +143,7 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
         foreach ($classes as $className => $refClass) {
             // Enum's are processed through the EnumTypeMapper.  It may make more sense to handle
             // this through the individual type mappers implemeenting this abstract.
-            if (interface_exists(UnitEnum::class)) {
+            if (interface_exists(\UnitEnum::class)) {
                 if ($refClass->isEnum()) {
                     continue;
                 }

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -141,14 +141,6 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
         $classes = $this->getClassList();
 
         foreach ($classes as $className => $refClass) {
-            // Enum's are processed through the EnumTypeMapper.  It may make more sense to handle
-            // this through the individual type mappers implemeenting this abstract.
-            if (interface_exists(\UnitEnum::class)) {
-                if ($refClass->isEnum()) {
-                    continue;
-                }
-            }
-
             $annotationsCache = $this->mapClassToAnnotationsCache->get($refClass, function () use ($refClass, $className) {
                 $annotationsCache = new GlobAnnotationsCache();
 

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -31,6 +31,8 @@ use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use Webmozart\Assert\Assert;
 
+use function interface_exists;
+
 /**
  * Analyzes classes and uses the @Type annotation to find the types automatically.
  *
@@ -139,6 +141,14 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
         $classes = $this->getClassList();
 
         foreach ($classes as $className => $refClass) {
+            // Enum's are processed through the EnumTypeMapper.  It may make more sense to handle
+            // this through the individual type mappers implemeenting this abstract.
+            if (interface_exists(UnitEnum::class)) {
+                if ($refClass->isEnum()) {
+                    continue;
+                }
+            }
+
             $annotationsCache = $this->mapClassToAnnotationsCache->get($refClass, function () use ($refClass, $className) {
                 $annotationsCache = new GlobAnnotationsCache();
 

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -31,8 +31,6 @@ use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use Webmozart\Assert\Assert;
 
-use function interface_exists;
-
 /**
  * Analyzes classes and uses the @Type annotation to find the types automatically.
  *

--- a/src/Mappers/CompositeTypeMapper.php
+++ b/src/Mappers/CompositeTypeMapper.php
@@ -65,6 +65,7 @@ class CompositeTypeMapper implements TypeMapperInterface
                 return $typeMapper->mapClassToType($className, $subType);
             }
         }
+
         throw CannotMapTypeException::createForType($className);
     }
 

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -457,9 +457,6 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
 
             $types[$supportedClass] = $type;
 
-
-
-
             if (isset($typeNames[$type->name])) {
                 throw DuplicateMappingException::createForTypeName($type->name, $typeNames[$type->name], $supportedClass);
             }

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -114,6 +114,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
         if ($closestClassName === null) {
             throw CannotMapTypeException::createForType($className);
         }
+
         $type = $this->typeMapper->mapClassToType($closestClassName, $subType);
 
         // In the event this type was already part of cache, let's not extend it.
@@ -450,8 +451,13 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
         $types     = [];
         $typeNames = [];
         foreach ($this->typeMapper->getSupportedClasses() as $supportedClass) {
-            $type                   = $this->mapClassToType($supportedClass, null);
+            $type = $this->mapClassToType($supportedClass, null);
+
             $types[$supportedClass] = $type;
+
+
+
+
             if (isset($typeNames[$type->name])) {
                 throw DuplicateMappingException::createForTypeName($type->name, $typeNames[$type->name], $supportedClass);
             }

--- a/src/Mappers/Root/EnumTypeMapper.php
+++ b/src/Mappers/Root/EnumTypeMapper.php
@@ -47,8 +47,12 @@ class EnumTypeMapper implements RootTypeMapperInterface
     /**
      * @param NS[] $namespaces List of namespaces containing enums. Used when searching an enum by name.
      */
-    public function __construct(RootTypeMapperInterface $next, AnnotationReader $annotationReader, CacheInterface $cacheService, array $namespaces)
-    {
+    public function __construct(
+        RootTypeMapperInterface $next,
+        AnnotationReader $annotationReader,
+        CacheInterface $cacheService,
+        array $namespaces
+    ) {
         $this->next = $next;
         $this->annotationReader = $annotationReader;
         $this->cacheService = $cacheService;
@@ -61,8 +65,12 @@ class EnumTypeMapper implements RootTypeMapperInterface
      *
      * @return OutputType&GraphQLType
      */
-    public function toGraphQLOutputType(Type $type, ?OutputType $subType, $reflector, DocBlock $docBlockObj): OutputType
-    {
+    public function toGraphQLOutputType(
+        Type $type,
+        ?OutputType $subType,
+        $reflector,
+        DocBlock $docBlockObj
+    ): OutputType {
         $result = $this->map($type);
         if ($result === null) {
             return $this->next->toGraphQLOutputType($type, $subType, $reflector, $docBlockObj);
@@ -72,12 +80,20 @@ class EnumTypeMapper implements RootTypeMapperInterface
     }
 
     /**
-     * @param (InputType&GraphQLType)|null $subType
+     * Maps into the appropriate InputType
+     *
+     * @param InputType|GraphQLType|null $subType
      * @param ReflectionMethod|ReflectionProperty $reflector
      *
-     * @return InputType&GraphQLType
+     * @return InputType|GraphQLType
      */
-    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, $reflector, DocBlock $docBlockObj): InputType
+    public function toGraphQLInputType(
+        Type $type,
+        ?InputType $subType,
+        string $argumentName,
+        $reflector,
+        DocBlock $docBlockObj
+    ): InputType
     {
         $result = $this->map($type);
         if ($result === null) {

--- a/src/Mappers/Root/EnumTypeMapper.php
+++ b/src/Mappers/Root/EnumTypeMapper.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers\Root;
+
+use GraphQL\Type\Definition\InputType;
+use GraphQL\Type\Definition\NamedType;
+use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Object_;
+use ReflectionClass;
+use ReflectionEnum;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Contracts\Cache\CacheInterface;
+use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\Types\EnumType;
+use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
+use UnitEnum;
+
+use function assert;
+use function enum_exists;
+
+/**
+ * Maps an enum class to a GraphQL type (only available in PHP>=8.1)
+ */
+class EnumTypeMapper implements RootTypeMapperInterface
+{
+    /** @var array<class-string<UnitEnum>, EnumType> */
+    private $cache = [];
+    /** @var array<string, EnumType> */
+    private $cacheByName = [];
+    /** @var array<string, class-string<UnitEnum>> */
+    private $nameToClassMapping;
+    /** @var RootTypeMapperInterface */
+    private $next;
+    /** @var AnnotationReader */
+    private $annotationReader;
+    /** @var array|NS[] */
+    private $namespaces;
+    /** @var CacheInterface */
+    private $cacheService;
+
+    /**
+     * @param NS[] $namespaces List of namespaces containing enums. Used when searching an enum by name.
+     */
+    public function __construct(RootTypeMapperInterface $next, AnnotationReader $annotationReader, CacheInterface $cacheService, array $namespaces)
+    {
+        $this->next = $next;
+        $this->annotationReader = $annotationReader;
+        $this->cacheService = $cacheService;
+        $this->namespaces = $namespaces;
+    }
+
+    /**
+     * @param (OutputType&GraphQLType)|null $subType
+     * @param ReflectionMethod|ReflectionProperty $reflector
+     *
+     * @return OutputType&GraphQLType
+     */
+    public function toGraphQLOutputType(Type $type, ?OutputType $subType, $reflector, DocBlock $docBlockObj): OutputType
+    {
+        $result = $this->map($type);
+        if ($result === null) {
+            return $this->next->toGraphQLOutputType($type, $subType, $reflector, $docBlockObj);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param (InputType&GraphQLType)|null $subType
+     * @param ReflectionMethod|ReflectionProperty $reflector
+     *
+     * @return InputType&GraphQLType
+     */
+    public function toGraphQLInputType(Type $type, ?InputType $subType, string $argumentName, $reflector, DocBlock $docBlockObj): InputType
+    {
+        $result = $this->map($type);
+        if ($result === null) {
+            return $this->next->toGraphQLInputType($type, $subType, $argumentName, $reflector, $docBlockObj);
+        }
+
+        return $result;
+    }
+
+    private function map(Type $type): ?EnumType
+    {
+        if (! $type instanceof Object_) {
+            return null;
+        }
+        $fqsen = $type->getFqsen();
+        if ($fqsen === null) {
+            return null;
+        }
+
+        /** @var class-string<object> $enumClass */
+        $enumClass = (string) $fqsen;
+
+        return $this->mapByClassName($enumClass);
+    }
+
+    /**
+     * @param class-string $enumClass
+     */
+    private function mapByClassName(string $enumClass): ?EnumType
+    {
+        if (isset($this->cache[$enumClass])) {
+            return $this->cache[$enumClass];
+        }
+
+        if (! enum_exists($enumClass)) {
+            return null;
+        }
+
+        // phpcs:disable SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
+        /** @var class-string<UnitEnum> $enumClass */
+        // phpcs:enable SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
+
+        $reflectionEnum = new ReflectionEnum($enumClass);
+
+        $typeAnnotation = $this->annotationReader->getEnumTypeAnnotation($reflectionEnum);
+        $typeName = ($typeAnnotation !== null ? $typeAnnotation->getName() : null) ?? $reflectionEnum->getShortName();
+
+        // Expose values instead of names if specifically configured to and if enum is string-backed
+        $useValues = $typeAnnotation !== null &&
+            $typeAnnotation->useValues() &&
+            $reflectionEnum->isBacked() &&
+            (string) $reflectionEnum->getBackingType() === 'string';
+
+        $type = new EnumType($enumClass, $typeName, $useValues);
+
+        return $this->cacheByName[$typeName] = $this->cache[$enumClass] = $type;
+    }
+
+    private function getTypeName(ReflectionClass $reflectionClass): string
+    {
+        $typeAnnotation = $this->annotationReader->getEnumTypeAnnotation($reflectionClass);
+
+        return ($typeAnnotation !== null ? $typeAnnotation->getName() : null) ?? $reflectionClass->getShortName();
+    }
+
+    /**
+     * Returns a GraphQL type by name.
+     * If this root type mapper can return this type in "toGraphQLOutputType" or "toGraphQLInputType", it should
+     * also map these types by name in the "mapNameToType" method.
+     *
+     * @param string $typeName The name of the GraphQL type
+     */
+    public function mapNameToType(string $typeName): NamedType
+    {
+        // This is a hack to make sure "$schema->assertValid()" returns true.
+        // The mapNameToType will fail if the mapByClassName method was not called before.
+        // This is actually not an issue in real life scenarios where enum types are never queried by type name.
+        if (isset($this->cacheByName[$typeName])) {
+            return $this->cacheByName[$typeName];
+        }
+
+        $nameToClassMapping = $this->getNameToClassMapping();
+        if (isset($this->nameToClassMapping[$typeName])) {
+            $className = $nameToClassMapping[$typeName];
+            $type = $this->mapByClassName($className);
+            assert($type !== null);
+            return $type;
+        }
+
+        return $this->next->mapNameToType($typeName);
+    }
+
+    /**
+     * Go through all classes in the defined namespaces and loads the cache.
+     *
+     * @return array<string, class-string<UnitEnum>>
+     */
+    private function getNameToClassMapping(): array
+    {
+        if ($this->nameToClassMapping === null) {
+            $this->nameToClassMapping = $this->cacheService->get('enum_name_to_class', function () {
+                $nameToClassMapping = [];
+                foreach ($this->namespaces as $ns) {
+                    foreach ($ns->getClassList() as $className => $classRef) {
+                        if (! enum_exists($className)) {
+                            continue;
+                        }
+
+                        $nameToClassMapping[$this->getTypeName($classRef)] = $className;
+                    }
+                }
+                return $nameToClassMapping;
+            });
+        }
+
+        return $this->nameToClassMapping;
+    }
+}

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -28,6 +28,7 @@ use TheCodingMachine\GraphQLite\Mappers\PorpaginasTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompoundTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\EnumTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\FinalRootTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\IteratorTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\MyCLabsEnumTypeMapper;
@@ -50,10 +51,12 @@ use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use TheCodingMachine\GraphQLite\Utils\NamespacedCache;
 use TheCodingMachine\GraphQLite\Utils\Namespaces\NamespaceFactory;
+use UnitEnum;
 
 use function array_map;
 use function array_reverse;
 use function class_exists;
+use function interface_exists;
 use function md5;
 use function substr;
 
@@ -338,6 +341,11 @@ class SchemaFactory
 
         $errorRootTypeMapper = new FinalRootTypeMapper($recursiveTypeMapper);
         $rootTypeMapper = new BaseTypeMapper($errorRootTypeMapper, $recursiveTypeMapper, $topRootTypeMapper);
+
+        if (interface_exists(UnitEnum::class)) {
+            $rootTypeMapper = new EnumTypeMapper($rootTypeMapper, $annotationReader, $symfonyCache, $nsList);
+        }
+
         if (class_exists(Enum::class)) {
             $rootTypeMapper = new MyCLabsEnumTypeMapper($rootTypeMapper, $annotationReader, $symfonyCache, $nsList);
         }

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+use BackedEnum;
+use GraphQL\Type\Definition\EnumType as BaseEnumType;
+use InvalidArgumentException;
+use UnitEnum;
+
+use function assert;
+use function is_string;
+
+/**
+ * An extension of the EnumType to support native enums.
+ */
+class EnumType extends BaseEnumType
+{
+    /** @var bool */
+    private $useValues;
+
+    /**
+     * @param class-string<UnitEnum> $enumName
+     */
+    public function __construct(string $enumName, string $typeName, bool $useValues = false)
+    {
+        $this->useValues = $useValues;
+
+        $values = [];
+        foreach ($enumName::cases() as $case) {
+            /** @var UnitEnum $case */
+            $values[$this->serialize($case)] = ['value' => $case];
+        }
+
+        parent::__construct([
+            'name' => $typeName,
+            'values' => $values,
+        ]);
+    }
+
+    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+
+    /**
+     * @param mixed $value
+     */
+    public function serialize($value): string
+    {
+        if (! $value instanceof UnitEnum) {
+            throw new InvalidArgumentException('Expected a Myclabs Enum instance');
+        }
+
+        if (! $this->useValues) {
+            return $value->name;
+        }
+
+        assert($value instanceof BackedEnum);
+        assert(is_string($value->value));
+
+        return $value->value;
+    }
+}

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -76,6 +76,13 @@ final class NS
                 }
 
                 $refClass = new ReflectionClass($className);
+                // Enum's are not classes
+                if (interface_exists(\UnitEnum::class)) {
+                    if ($refClass->isEnum()) {
+                        continue;
+                    }
+                }
+
                 $this->classes[$className] = $refClass;
             }
         }

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -79,6 +79,7 @@ final class NS
                 $refClass = new ReflectionClass($className);
                 // Enum's are not classes
                 if (interface_exists(UnitEnum::class)) {
+                    // @phpstan-ignore-next-line - Remove this after minimum supported PHP version is >= 8.1
                     if ($refClass->isEnum()) {
                         continue;
                     }

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -78,7 +78,7 @@ final class NS
 
                 $refClass = new ReflectionClass($className);
                 // Enum's are not classes
-                if (interface_exists(UnitEnum::class)) {
+                if (interface_exists(\UnitEnum::class)) {
                     // @phpstan-ignore-next-line - Remove this after minimum supported PHP version is >= 8.1
                     if ($refClass->isEnum()) {
                         continue;

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -78,7 +78,7 @@ final class NS
 
                 $refClass = new ReflectionClass($className);
                 // Enum's are not classes
-                if (interface_exists(\UnitEnum::class)) {
+                if (interface_exists(UnitEnum::class)) {
                     if ($refClass->isEnum()) {
                         continue;
                     }

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -35,6 +35,7 @@ use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\BaseTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\CompoundTypeMapper;
+use TheCodingMachine\GraphQLite\Mappers\Root\EnumTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\FinalRootTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\IteratorTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Root\MyCLabsEnumTypeMapper;
@@ -60,6 +61,7 @@ use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use TheCodingMachine\GraphQLite\Utils\Namespaces\NamespaceFactory;
 use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
+use UnitEnum;
 use function array_reverse;
 
 abstract class AbstractQueryProviderTest extends TestCase
@@ -335,6 +337,9 @@ abstract class AbstractQueryProviderTest extends TestCase
         $errorRootTypeMapper = new FinalRootTypeMapper($this->getTypeMapper());
         $rootTypeMapper = new BaseTypeMapper($errorRootTypeMapper, $this->getTypeMapper(), $topRootTypeMapper);
         $rootTypeMapper = new MyCLabsEnumTypeMapper($rootTypeMapper, $this->getAnnotationReader(), $arrayAdapter, []);
+        if (interface_exists(UnitEnum::class)) {
+            $rootTypeMapper = new EnumTypeMapper($rootTypeMapper, $this->getAnnotationReader(), $arrayAdapter, []);
+        }
         $rootTypeMapper = new CompoundTypeMapper($rootTypeMapper, $topRootTypeMapper, $this->getTypeRegistry(), $this->getTypeMapper());
         $rootTypeMapper = new IteratorTypeMapper($rootTypeMapper, $topRootTypeMapper);
 

--- a/tests/Fixtures81/Integration/Controllers/ButtonController.php
+++ b/tests/Fixtures81/Integration/Controllers/ButtonController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures81\Integration\Controllers;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Fixtures81\Integration\Models\Button;
+use TheCodingMachine\GraphQLite\Fixtures81\Integration\Models\Color;
+use TheCodingMachine\GraphQLite\Fixtures81\Integration\Models\Position;
+use TheCodingMachine\GraphQLite\Fixtures81\Integration\Models\Size;
+
+class ButtonController
+{
+    /**
+     * @Query()
+     */
+    public function getButton(Color $color, Size $size, Position $state): Button
+    {
+        return new Button($color, $size, $state);
+    }
+}

--- a/tests/Fixtures81/Integration/Models/Button.php
+++ b/tests/Fixtures81/Integration/Models/Button.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures81\Integration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type
+ */
+class Button
+{
+    /**
+     * @var Color
+     */
+    private $color;
+
+    /**
+     * @var Size
+     */
+    private $size;
+
+    /**
+     * @var Position
+     */
+    private $state;
+
+    public function __construct(Color $color, Size $size, Position $state)
+    {
+        $this->color = $color;
+        $this->size  = $size;
+        $this->state = $state;
+    }
+
+    /**
+     * @Field
+     */
+    public function getColor(): Color
+    {
+        return $this->color;
+    }
+
+    /**
+     * @Field
+     */
+    public function getSize(): Size
+    {
+        return $this->size;
+    }
+
+    /**
+     * @Field
+     */
+    public function getState(): Position
+    {
+        return $this->state;
+    }
+}

--- a/tests/Fixtures81/Integration/Models/Color.php
+++ b/tests/Fixtures81/Integration/Models/Color.php
@@ -6,9 +6,10 @@ namespace TheCodingMachine\GraphQLite\Fixtures81\Integration\Models;
 
 use TheCodingMachine\GraphQLite\Annotations\Type;
 
-/**
- * @Type(useEnumValues=true)
- */
+#[Type(
+    name: 'Color',
+    useEnumValues: true,
+)]
 enum Color: string
 {
     case Green = 'green';

--- a/tests/Fixtures81/Integration/Models/Color.php
+++ b/tests/Fixtures81/Integration/Models/Color.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures81\Integration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\EnumType;
+
+/**
+ * @EnumType(useValues=true)
+ */
+enum Color: string
+{
+    case Green = 'green';
+    case Red   = 'red';
+}

--- a/tests/Fixtures81/Integration/Models/Position.php
+++ b/tests/Fixtures81/Integration/Models/Position.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures81\Integration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\EnumType;
+
+/**
+ * @EnumType
+ */
+enum Position: int
+{
+    case Off = 0;
+    case On  = 1;
+}

--- a/tests/Fixtures81/Integration/Models/Size.php
+++ b/tests/Fixtures81/Integration/Models/Size.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures81\Integration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\EnumType;
+
+/**
+ * @EnumType
+ */
+enum Size
+{
+    case S;
+    case M;
+    case L;
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1222,7 +1222,7 @@ class EndToEndTest extends TestCase
 
         $gql = '
             query {
-                button(color: Red, size: M, state: Off) {
+                button(color: red, size: M, state: Off) {
                     color
                     size
                     state
@@ -1237,7 +1237,7 @@ class EndToEndTest extends TestCase
 
         $this->assertSame([
             'button' => [
-                'color' => 'Red',
+                'color' => 'red',
                 'size' => 'M',
                 'state' => 'Off',
             ]

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1210,6 +1210,8 @@ class EndToEndTest extends TestCase
 
     /**
      * @requires PHP >= 8.1
+     *
+     * @group test-only
      */
     public function testEndToEndNativeEnums(): void
     {
@@ -1220,7 +1222,7 @@ class EndToEndTest extends TestCase
 
         $gql = '
             query {
-                button(color: red, size: M, state: Off) {
+                button(color: Red, size: M, state: Off) {
                     color
                     size
                     state
@@ -1235,7 +1237,7 @@ class EndToEndTest extends TestCase
 
         $this->assertSame([
             'button' => [
-                'color' => 'red',
+                'color' => 'Red',
                 'size' => 'M',
                 'state' => 'Off',
             ]

--- a/website/docs/annotations-reference.md
+++ b/website/docs/annotations-reference.md
@@ -38,7 +38,7 @@ types, as well as enum types.  For input types, use the [@Input annotation](#inp
 
 Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
-class          | *no*       | string | The targeted class. If no class is passed, the type applies to the current class. The current class is assumed to be an entity. If the "class" attribute is passed, [the class annotated with `@Type` is a service](external-type-declaration.mdx).
+class          | *no*       | string | The targeted class/enum for the actual type. If no "class" attribute is passed, the type applies to the current class/enum. The current class/enum is assumed to be an entity (not service). If the "class" attribute *is passed*, [the class/enum annotated with `@Type` becomes a service](external-type-declaration.mdx).
 name           | *no*       | string | The name of the GraphQL type generated. If not passed, the name of the class is used. If the class ends with "Type", the "Type" suffix is removed
 default        | *no*       | bool   | Defaults to *true*. Whether the targeted PHP class should be mapped by default to this type.
 external       | *no*       | bool   | Whether this is an [external type declaration](external-type-declaration.mdx) or not. You usually do not need to use this attribute since this value defaults to true if a "class" attribute is set. This is only useful if you are declaring a type with no PHP class mapping using the "name" attribute.

--- a/website/docs/annotations-reference.md
+++ b/website/docs/annotations-reference.md
@@ -31,7 +31,8 @@ name           | *no*       | string | The name of the mutation. If skipped, the
 
 ## @Type annotation
 
-The `@Type` annotation is used to declare a GraphQL object type.
+The `@Type` annotation is used to declare a GraphQL object type.  This is used with standard output
+types, as well as enum types.  For input types, use the [@Input annotation](#input-annotation) directly on the input type or a [@Factory annoation](#factory-annotation) to make/return an input type.
 
 **Applies on**: classes.
 
@@ -268,7 +269,9 @@ Attribute      | Compulsory | Type | Definition
 *for*          | *yes*      | string | The name of the PHP parameter
 *constraint*   | *yes       | annotation | One (or many) Symfony validation annotations.
 
-## @EnumType annotation
+## ~~@EnumType annotation~~
+
+*Deprecated: Use [PHP 8.1's native Enums](https://www.php.net/manual/en/language.types.enumerations.php) instead with a [@Type](#type-annotation).*
 
 The `@EnumType` annotation is used to change the name of a "Enum" type.
 Note that if you do not want to change the name, the annotation is optionnal. Any object extending `MyCLabs\Enum\Enum`

--- a/website/docs/type-mapping.mdx
+++ b/website/docs/type-mapping.mdx
@@ -423,13 +423,61 @@ public function companyOrContact(int $id)
 
 ## Enum types
 
-<small>Available in GraphQLite 4.0+</small>
+PHP 8.1 introduced native support for Enums.  GraphQLite now also supports native enums as of version 5.1.
 
-PHP has no native support for enum types. Hopefully, there are a number of PHP libraries that emulate enums in PHP.
-The most commonly used library is [myclabs/php-enum](https://github.com/myclabs/php-enum) and GraphQLite comes with
-native support for it.
+```php
+#[Type]
+enum Status: string
+{
+    case ON = 'on';
+    case OFF = 'off';
+    case PENDING = 'pending';
+}
+```
 
-You will first need to install [myclabs/php-enum](https://github.com/myclabs/php-enum):
+```php
+/**
+ * @return User[]
+ */
+#[Query]
+public function users(Status $status): array
+{
+    if ($status === Status::ON) {
+        // Your logic
+    }
+    // ...
+}
+```
+
+```graphql
+query users($status: Status!) {}
+    users(status: $status) {
+        id
+    }
+}
+```
+
+By default, the name of the GraphQL enum type will be the name of the class. If you have a naming conflict (two classes
+that live in different namespaces with the same class name), you can solve it using the `name` property on the `@Type` annotation:
+
+```php
+namespace Model\User;
+
+#[Type(name: "UserStatus")]
+enum Status: string
+{
+    // ...
+}
+```
+
+
+### Enum types with myclabs/php-enum
+
+<div class="alert alert--danger">
+    This implementation is now deprecated and will be removed in the future.  You are advised to use native enums instead.
+</div>
+
+*Prior to version 5.1, GraphQLite only supported Enums through the 3rd party library, [myclabs/php-enum](https://github.com/myclabs/php-enum).  If you'd like to use this implementation you'll first need to add this library as a dependency to your application.*
 
 ```bash
 $ composer require myclabs/php-enum
@@ -556,12 +604,6 @@ class StatusEnum extends Enum
 in your project. By default, GraphQLite will look for "Enum" classes in the namespaces declared for the types. For this
 reason, <strong>your enum classes MUST be in one of the namespaces declared for the types in your GraphQLite
 configuration file.</strong></div>
-
-
-<div class="alert alert--info">There are many enumeration library in PHP and you might be using another library.
-If you want to add support for your own library, this is not extremely difficult to do. You need to register a custom
-"RootTypeMapper" with GraphQLite. You can learn more about <em>type mappers</em> in the <a href="internals">"internals" documentation</a>
-and <a href="https://github.com/thecodingmachine/graphqlite/blob/master/src/Mappers/Root/MyCLabsEnumTypeMapper.php">copy/paste and adapt the root type mapper used for myclabs/php-enum</a>.</div>
 
 ## Deprecation of fields
 


### PR DESCRIPTION
This aims to provide support for native enums, introduced with PHP 8.1.

Backed enums using `string` values will base their names on their case values. Non-backed enums, and `int`-backed enums, will instead use their case names.

I'm actually wondering about this last rule: should perhaps the `int`-backed enums be compatible with type `Int` instead of `String`? But then, introspection won't be able to hint allowed values, will it?

Any suggestions?