### PR TITLE
Add method overloading support

### DIFF
--- a/src/Utils/PropertyAccessor.php
+++ b/src/Utils/PropertyAccessor.php
@@ -31,6 +31,10 @@ class PropertyAccessor
             }
         }
 
+        if (method_exists($class, '__call')) {
+            return 'get' . $name;
+        }
+
         return null;
     }
 
@@ -42,7 +46,7 @@ class PropertyAccessor
         $name = ucfirst($propertyName);
 
         $methodName = 'set' . $name;
-        if (self::isPublicMethod($class, $methodName)) {
+        if (self::isPublicMethod($class, $methodName) || method_exists($class, '__call')) {
             return $methodName;
         }
 
@@ -105,6 +109,8 @@ class PropertyAccessor
     private static function isPublicMethod(string $class, string $methodName): bool
     {
         if (! method_exists($class, $methodName)) {
+            // If the class uses this overloading method, assume it wants to handle methods
+            // that don't exist
             return false;
         }
 

--- a/src/Utils/PropertyAccessor.php
+++ b/src/Utils/PropertyAccessor.php
@@ -109,8 +109,6 @@ class PropertyAccessor
     private static function isPublicMethod(string $class, string $methodName): bool
     {
         if (! method_exists($class, $methodName)) {
-            // If the class uses this overloading method, assume it wants to handle methods
-            // that don't exist
             return false;
         }
 


### PR DESCRIPTION
Currently it's not possible to use overloading magic methods.  They're kind of nasty, in general.  However, they're useful in certain cases.  One example where they're particularly useful, is when defining `#[Input]` type classes.  If a `#[Field]` property is not `public` you must provide a `setter`.  We could work around this, allowing the `InputType` mapper to set values on `private` and `protected` properties.  However, I'm not really convinced that's the best way to do it.  We should try to avoid side-stepping class intent.

This PR just provides support for `__call` if it's been defined, validating as having a getter or setter.