### PR TITLE
Add config example with PHP 8 attributes to input types docs

### DIFF
--- a/website/docs/input-types.mdx
+++ b/website/docs/input-types.mdx
@@ -412,11 +412,29 @@ public function createLocation(float $latitude, float $longitude): Location
 
 In case you want to override the input type name, you can use the "name" attribute of the @Factory annotation:
 
+<Tabs
+  defaultValue="php8"
+  values={[
+    {label: 'PHP 8', value: 'php8'},
+    {label: 'PHP 7', value: 'php7'},
+  ]}>
+  <TabItem value="php8">
+
+```php
+#[Factory(name: 'MyNewInputName', default: true)]
+```
+
+  </TabItem>
+  <TabItem value="php7">
+
 ```php
 /**
  * @Factory(name="MyNewInputName", default=true)
  */
 ```
+
+  </TabItem>
+</Tabs>
 
 Note that you need to add the "default" attribute is you want your factory to be used by default (more on this in
 the next chapter).

--- a/website/versioned_docs/version-4.1/input-types.mdx
+++ b/website/versioned_docs/version-4.1/input-types.mdx
@@ -224,11 +224,29 @@ public function createLocation(float $latitude, float $longitude): Location
 
 In case you want to override the input type name, you can use the "name" attribute of the @Factory annotation:
 
+<Tabs
+  defaultValue="php8"
+  values={[
+    {label: 'PHP 8', value: 'php8'},
+    {label: 'PHP 7', value: 'php7'},
+  ]}>
+  <TabItem value="php8">
+
+```php
+#[Factory(name: 'MyNewInputName', default: true)]
 ```
+
+  </TabItem>
+  <TabItem value="php7">
+
+```php
 /**
  * @Factory(name="MyNewInputName", default=true)
  */
 ```
+
+  </TabItem>
+</Tabs>
 
 Note that you need to add the "default" attribute is you want your factory to be used by default (more on this in
 the next chapter).

--- a/website/versioned_docs/version-4.2/input-types.mdx
+++ b/website/versioned_docs/version-4.2/input-types.mdx
@@ -225,11 +225,29 @@ public function createLocation(float $latitude, float $longitude): Location
 
 In case you want to override the input type name, you can use the "name" attribute of the @Factory annotation:
 
+<Tabs
+  defaultValue="php8"
+  values={[
+    {label: 'PHP 8', value: 'php8'},
+    {label: 'PHP 7', value: 'php7'},
+  ]}>
+  <TabItem value="php8">
+
+```php
+#[Factory(name: 'MyNewInputName', default: true)]
+```
+
+  </TabItem>
+  <TabItem value="php7">
+
 ```php
 /**
  * @Factory(name="MyNewInputName", default=true)
  */
 ```
+
+  </TabItem>
+</Tabs>
 
 Note that you need to add the "default" attribute is you want your factory to be used by default (more on this in
 the next chapter).

--- a/website/versioned_docs/version-4.3/input-types.mdx
+++ b/website/versioned_docs/version-4.3/input-types.mdx
@@ -225,11 +225,29 @@ public function createLocation(float $latitude, float $longitude): Location
 
 In case you want to override the input type name, you can use the "name" attribute of the @Factory annotation:
 
+<Tabs
+  defaultValue="php8"
+  values={[
+    {label: 'PHP 8', value: 'php8'},
+    {label: 'PHP 7', value: 'php7'},
+  ]}>
+  <TabItem value="php8">
+
+```php
+#[Factory(name: 'MyNewInputName', default: true)]
+```
+
+  </TabItem>
+  <TabItem value="php7">
+
 ```php
 /**
  * @Factory(name="MyNewInputName", default=true)
  */
 ```
+
+  </TabItem>
+</Tabs>
 
 Note that you need to add the "default" attribute is you want your factory to be used by default (more on this in
 the next chapter).

--- a/website/versioned_docs/version-5.0/input-types.mdx
+++ b/website/versioned_docs/version-5.0/input-types.mdx
@@ -225,11 +225,29 @@ public function createLocation(float $latitude, float $longitude): Location
 
 In case you want to override the input type name, you can use the "name" attribute of the @Factory annotation:
 
+<Tabs
+  defaultValue="php8"
+  values={[
+    {label: 'PHP 8', value: 'php8'},
+    {label: 'PHP 7', value: 'php7'},
+  ]}>
+  <TabItem value="php8">
+
+```php
+#[Factory(name: 'MyNewInputName', default: true)]
+```
+
+  </TabItem>
+  <TabItem value="php7">
+
 ```php
 /**
  * @Factory(name="MyNewInputName", default=true)
  */
 ```
+
+  </TabItem>
+</Tabs>
 
 Note that you need to add the "default" attribute is you want your factory to be used by default (more on this in
 the next chapter).


### PR DESCRIPTION
Unfortunately, I don't know how to check the built result.

Copied tabs markup from example from the same page