### PR TITLE
#[Input] Type Improvements

### DIFF
--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -26,6 +26,7 @@ use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotationInterface;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotations;
 use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
 use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Annotations\TypeInterface;
 use Webmozart\Assert\Assert;
 
 use function array_diff_key;
@@ -262,7 +263,7 @@ class AnnotationReader
      *
      * @template T of object
      */
-    public function getTypeAnnotation(ReflectionClass $refClass): ?Type
+    public function getTypeAnnotation(ReflectionClass $refClass): ?TypeInterface
     {
         try {
             $type = $this->getClassAnnotation($refClass, Type::class)

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -93,207 +93,6 @@ class AnnotationReader
     }
 
     /**
-     * @param ReflectionClass<T> $refClass
-     *
-     * @template T of object
-     */
-    public function getTypeAnnotation(ReflectionClass $refClass): ?Type
-    {
-        try {
-            $type = $this->getClassAnnotation($refClass, Type::class);
-            if ($type !== null && $type->isSelfType()) {
-                $type->setClass($refClass->getName());
-            }
-        } catch (ClassNotFoundException $e) {
-            throw ClassNotFoundException::wrapException($e, $refClass->getName());
-        }
-
-        return $type;
-    }
-
-    /**
-     * @param ReflectionClass<T> $refClass
-     *
-     * @return Input[]
-     *
-     * @throws AnnotationException
-     *
-     * @template T of object
-     */
-    public function getInputAnnotations(ReflectionClass $refClass): array
-    {
-        try {
-            /** @var Input[] $inputs */
-            $inputs = $this->getClassAnnotations($refClass, Input::class, false);
-            foreach ($inputs as $input) {
-                $input->setClass($refClass->getName());
-            }
-        } catch (ClassNotFoundException $e) {
-            throw ClassNotFoundException::wrapException($e, $refClass->getName());
-        }
-
-        return $inputs;
-    }
-
-    /**
-     * @param ReflectionClass<T> $refClass
-     *
-     * @template T of object
-     */
-    public function getExtendTypeAnnotation(ReflectionClass $refClass): ?ExtendType
-    {
-        try {
-            $extendType = $this->getClassAnnotation($refClass, ExtendType::class);
-        } catch (ClassNotFoundException $e) {
-            throw ClassNotFoundException::wrapExceptionForExtendTag($e, $refClass->getName());
-        }
-
-        return $extendType;
-    }
-
-    /**
-     * @param class-string<AbstractRequest> $annotationClass
-     */
-    public function getRequestAnnotation(ReflectionMethod $refMethod, string $annotationClass): ?AbstractRequest
-    {
-        $queryAnnotation = $this->getMethodAnnotation($refMethod, $annotationClass);
-        assert($queryAnnotation instanceof AbstractRequest || $queryAnnotation === null);
-
-        return $queryAnnotation;
-    }
-
-    /**
-     * @param ReflectionClass<T> $refClass
-     *
-     * @return SourceFieldInterface[]
-     *
-     * @template T of object
-     */
-    public function getSourceFields(ReflectionClass $refClass): array
-    {
-        /** @var SourceFieldInterface[] $sourceFields */
-        $sourceFields = $this->getClassAnnotations($refClass, SourceFieldInterface::class);
-
-        return $sourceFields;
-    }
-
-    public function getFactoryAnnotation(ReflectionMethod $refMethod): ?Factory
-    {
-        $factoryAnnotation = $this->getMethodAnnotation($refMethod, Factory::class);
-        assert($factoryAnnotation instanceof Factory || $factoryAnnotation === null);
-
-        return $factoryAnnotation;
-    }
-
-    public function getDecorateAnnotation(ReflectionMethod $refMethod): ?Decorate
-    {
-        $decorateAnnotation = $this->getMethodAnnotation($refMethod, Decorate::class);
-        assert($decorateAnnotation instanceof Decorate || $decorateAnnotation === null);
-
-        return $decorateAnnotation;
-    }
-
-    /**
-     * Only used in unit tests/
-     *
-     * @deprecated Use getParameterAnnotationsPerParameter instead
-     *
-     * @throws AnnotationException
-     */
-    public function getParameterAnnotations(ReflectionParameter $refParameter): ParameterAnnotations
-    {
-        $method = $refParameter->getDeclaringFunction();
-        Assert::isInstanceOf($method, ReflectionMethod::class);
-        /** @var ParameterAnnotationInterface[] $parameterAnnotations */
-        $parameterAnnotations = $this->getMethodAnnotations($method, ParameterAnnotationInterface::class);
-        $name = $refParameter->getName();
-
-        $filteredAnnotations = array_values(array_filter($parameterAnnotations, static function (ParameterAnnotationInterface $parameterAnnotation) use ($name) {
-            return $parameterAnnotation->getTarget() === $name;
-        }));
-
-        return new ParameterAnnotations($filteredAnnotations);
-    }
-
-    /**
-     * @param ReflectionParameter[] $refParameters
-     *
-     * @return array<string, ParameterAnnotations>
-     *
-     * @throws AnnotationException
-     */
-    public function getParameterAnnotationsPerParameter(array $refParameters): array
-    {
-        if (empty($refParameters)) {
-            return [];
-        }
-        $firstParam = reset($refParameters);
-
-        $method = $firstParam->getDeclaringFunction();
-        Assert::isInstanceOf($method, ReflectionMethod::class);
-
-        /** @var ParameterAnnotationInterface[] $parameterAnnotations */
-        $parameterAnnotations = $this->getMethodAnnotations($method, ParameterAnnotationInterface::class);
-
-        /**
-         * @var array<string, array<int, ParameterAnnotations>>
-         */
-        $parameterAnnotationsPerParameter = [];
-        foreach ($parameterAnnotations as $parameterAnnotation) {
-            $parameterAnnotationsPerParameter[$parameterAnnotation->getTarget()][] = $parameterAnnotation;
-        }
-
-        // Let's check that the referenced parameters actually do exist:
-        $parametersByKey = [];
-        foreach ($refParameters as $refParameter) {
-            $parametersByKey[$refParameter->getName()] = true;
-        }
-        $diff = array_diff_key($parameterAnnotationsPerParameter, $parametersByKey);
-        if (! empty($diff)) {
-            foreach ($diff as $parameterName => $parameterAnnotations) {
-                throw InvalidParameterException::parameterNotFound($parameterName, get_class($parameterAnnotations[0]), $method);
-            }
-        }
-
-        // Now, let's add PHP 8 parameter attributes
-        if (PHP_MAJOR_VERSION >= 8) {
-            foreach ($refParameters as $refParameter) {
-                Assert::methodExists($refParameter, 'getAttributes');
-                $attributes = $refParameter->getAttributes();
-                $parameterAnnotationsPerParameter[$refParameter->getName()] = array_merge($parameterAnnotationsPerParameter[$refParameter->getName()] ?? [], array_map(
-                    static function ($attribute) {
-                        return $attribute->newInstance();
-                    },
-                    array_filter($attributes, static function ($annotation): bool {
-                        return is_a($annotation->getName(), ParameterAnnotationInterface::class, true);
-                    })
-                ));
-            }
-        }
-
-        return array_map(static function (array $parameterAnnotations) {
-            Assert::allIsInstanceOf($parameterAnnotations, ParameterAnnotationInterface::class);
-            return new ParameterAnnotations($parameterAnnotations);
-        }, $parameterAnnotationsPerParameter);
-    }
-
-    /**
-     * @param ReflectionMethod|ReflectionProperty $reflection
-     *
-     * @throws AnnotationException
-     */
-    public function getMiddlewareAnnotations($reflection): MiddlewareAnnotations
-    {
-        if ($reflection instanceof ReflectionMethod) {
-            $middlewareAnnotations = $this->getMethodAnnotations($reflection, MiddlewareAnnotationInterface::class);
-        } else {
-            $middlewareAnnotations = $this->getPropertyAnnotations($reflection, MiddlewareAnnotationInterface::class);
-        }
-
-        return new MiddlewareAnnotations($middlewareAnnotations);
-    }
-
-    /**
      * Returns a class annotation. Does not look in the parent class.
      *
      * @param ReflectionClass<object> $refClass
@@ -459,6 +258,214 @@ class AnnotationReader
     }
 
     /**
+     * @param ReflectionClass<T> $refClass
+     *
+     * @template T of object
+     */
+    public function getTypeAnnotation(ReflectionClass $refClass): ?Type
+    {
+        try {
+            $type = $this->getClassAnnotation($refClass, Type::class)
+                ?? $this->getClassAnnotation($refClass, Input::class);
+
+            if ($type !== null && $type->isSelfType()) {
+                $type->setClass($refClass->getName());
+            }
+        } catch (ClassNotFoundException $e) {
+            throw ClassNotFoundException::wrapException($e, $refClass->getName());
+        }
+
+        return $type;
+    }
+
+    /**
+     * @param ReflectionClass<T> $refClass
+     *
+     * @return Input[]
+     *
+     * @throws AnnotationException
+     *
+     * @template T of object
+     */
+    public function getInputAnnotations(ReflectionClass $refClass): array
+    {
+        try {
+            /** @var Input[] $inputs */
+            $inputs = $this->getClassAnnotations($refClass, Input::class, false);
+            foreach ($inputs as $input) {
+                $input->setClass($refClass->getName());
+            }
+        } catch (ClassNotFoundException $e) {
+            throw ClassNotFoundException::wrapException($e, $refClass->getName());
+        }
+
+        return $inputs;
+    }
+
+    /**
+     * @param ReflectionClass<T> $refClass
+     *
+     * @template T of object
+     */
+    public function getExtendTypeAnnotation(ReflectionClass $refClass): ?ExtendType
+    {
+        try {
+            $extendType = $this->getClassAnnotation($refClass, ExtendType::class);
+        } catch (ClassNotFoundException $e) {
+            throw ClassNotFoundException::wrapExceptionForExtendTag($e, $refClass->getName());
+        }
+
+        return $extendType;
+    }
+
+    public function getEnumTypeAnnotation(ReflectionClass $refClass): ?EnumType
+    {
+        return $this->getClassAnnotation($refClass, EnumType::class);
+    }
+
+    /**
+     * @param class-string<AbstractRequest> $annotationClass
+     */
+    public function getRequestAnnotation(ReflectionMethod $refMethod, string $annotationClass): ?AbstractRequest
+    {
+        $queryAnnotation = $this->getMethodAnnotation($refMethod, $annotationClass);
+        assert($queryAnnotation instanceof AbstractRequest || $queryAnnotation === null);
+
+        return $queryAnnotation;
+    }
+
+    /**
+     * @param ReflectionClass<T> $refClass
+     *
+     * @return SourceFieldInterface[]
+     *
+     * @template T of object
+     */
+    public function getSourceFields(ReflectionClass $refClass): array
+    {
+        /** @var SourceFieldInterface[] $sourceFields */
+        $sourceFields = $this->getClassAnnotations($refClass, SourceFieldInterface::class);
+
+        return $sourceFields;
+    }
+
+    public function getFactoryAnnotation(ReflectionMethod $refMethod): ?Factory
+    {
+        $factoryAnnotation = $this->getMethodAnnotation($refMethod, Factory::class);
+        assert($factoryAnnotation instanceof Factory || $factoryAnnotation === null);
+
+        return $factoryAnnotation;
+    }
+
+    public function getDecorateAnnotation(ReflectionMethod $refMethod): ?Decorate
+    {
+        $decorateAnnotation = $this->getMethodAnnotation($refMethod, Decorate::class);
+        assert($decorateAnnotation instanceof Decorate || $decorateAnnotation === null);
+
+        return $decorateAnnotation;
+    }
+
+    /**
+     * Only used in unit tests/
+     *
+     * @deprecated Use getParameterAnnotationsPerParameter instead
+     *
+     * @throws AnnotationException
+     */
+    public function getParameterAnnotations(ReflectionParameter $refParameter): ParameterAnnotations
+    {
+        $method = $refParameter->getDeclaringFunction();
+        Assert::isInstanceOf($method, ReflectionMethod::class);
+        /** @var ParameterAnnotationInterface[] $parameterAnnotations */
+        $parameterAnnotations = $this->getMethodAnnotations($method, ParameterAnnotationInterface::class);
+        $name = $refParameter->getName();
+
+        $filteredAnnotations = array_values(array_filter($parameterAnnotations, static function (ParameterAnnotationInterface $parameterAnnotation) use ($name) {
+            return $parameterAnnotation->getTarget() === $name;
+        }));
+
+        return new ParameterAnnotations($filteredAnnotations);
+    }
+
+    /**
+     * @param ReflectionParameter[] $refParameters
+     *
+     * @return array<string, ParameterAnnotations>
+     *
+     * @throws AnnotationException
+     */
+    public function getParameterAnnotationsPerParameter(array $refParameters): array
+    {
+        if (empty($refParameters)) {
+            return [];
+        }
+        $firstParam = reset($refParameters);
+
+        $method = $firstParam->getDeclaringFunction();
+        Assert::isInstanceOf($method, ReflectionMethod::class);
+
+        /** @var ParameterAnnotationInterface[] $parameterAnnotations */
+        $parameterAnnotations = $this->getMethodAnnotations($method, ParameterAnnotationInterface::class);
+
+        /**
+         * @var array<string, array<int, ParameterAnnotations>>
+         */
+        $parameterAnnotationsPerParameter = [];
+        foreach ($parameterAnnotations as $parameterAnnotation) {
+            $parameterAnnotationsPerParameter[$parameterAnnotation->getTarget()][] = $parameterAnnotation;
+        }
+
+        // Let's check that the referenced parameters actually do exist:
+        $parametersByKey = [];
+        foreach ($refParameters as $refParameter) {
+            $parametersByKey[$refParameter->getName()] = true;
+        }
+        $diff = array_diff_key($parameterAnnotationsPerParameter, $parametersByKey);
+        if (! empty($diff)) {
+            foreach ($diff as $parameterName => $parameterAnnotations) {
+                throw InvalidParameterException::parameterNotFound($parameterName, get_class($parameterAnnotations[0]), $method);
+            }
+        }
+
+        // Now, let's add PHP 8 parameter attributes
+        if (PHP_MAJOR_VERSION >= 8) {
+            foreach ($refParameters as $refParameter) {
+                Assert::methodExists($refParameter, 'getAttributes');
+                $attributes = $refParameter->getAttributes();
+                $parameterAnnotationsPerParameter[$refParameter->getName()] = array_merge($parameterAnnotationsPerParameter[$refParameter->getName()] ?? [], array_map(
+                    static function ($attribute) {
+                        return $attribute->newInstance();
+                    },
+                    array_filter($attributes, static function ($annotation): bool {
+                        return is_a($annotation->getName(), ParameterAnnotationInterface::class, true);
+                    })
+                ));
+            }
+        }
+
+        return array_map(static function (array $parameterAnnotations) {
+            Assert::allIsInstanceOf($parameterAnnotations, ParameterAnnotationInterface::class);
+            return new ParameterAnnotations($parameterAnnotations);
+        }, $parameterAnnotationsPerParameter);
+    }
+
+    /**
+     * @param ReflectionMethod|ReflectionProperty $reflection
+     *
+     * @throws AnnotationException
+     */
+    public function getMiddlewareAnnotations($reflection): MiddlewareAnnotations
+    {
+        if ($reflection instanceof ReflectionMethod) {
+            $middlewareAnnotations = $this->getMethodAnnotations($reflection, MiddlewareAnnotationInterface::class);
+        } else {
+            $middlewareAnnotations = $this->getPropertyAnnotations($reflection, MiddlewareAnnotationInterface::class);
+        }
+
+        return new MiddlewareAnnotations($middlewareAnnotations);
+    }
+
+    /**
      * Returns the method's annotations.
      *
      * @param class-string<T> $annotationClass
@@ -565,10 +572,5 @@ class AnnotationReader
         $this->propertyAnnotationsCache[$cacheKey] = $toAddAnnotations;
 
         return $toAddAnnotations;
-    }
-
-    public function getEnumTypeAnnotation(ReflectionClass $refClass): ?EnumType
-    {
-        return $this->getClassAnnotation($refClass, EnumType::class);
     }
 }

--- a/src/Annotations/Input.php
+++ b/src/Annotations/Input.php
@@ -23,20 +23,16 @@ use RuntimeException;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Input implements TypeInterface
 {
-    /** @var string|null */
-    private $class;
+    /** @var class-string<object>|null */
+    private ?string $class = null;
 
-    /** @var string|null */
-    private $name;
+    private ?string $name = null;
 
-    /** @var bool */
-    private $default;
+    private bool $default;
 
-    /** @var string|null */
-    private $description;
+    private ?string $description = null;
 
-    /** @var bool */
-    private $update;
+    private bool $update;
 
     /**
      * @param mixed[] $attributes
@@ -51,6 +47,8 @@ class Input implements TypeInterface
 
     /**
      * Returns the fully qualified class name of the targeted class.
+     *
+     * @return class-string<object>
      */
     public function getClass(): string
     {
@@ -61,6 +59,9 @@ class Input implements TypeInterface
         return $this->class;
     }
 
+    /**
+     * @param class-string<object> $class
+     */
     public function setClass(string $class): void
     {
         $this->class = $class;

--- a/src/Annotations/Input.php
+++ b/src/Annotations/Input.php
@@ -37,10 +37,15 @@ class Input implements TypeInterface
     /**
      * @param mixed[] $attributes
      */
-    public function __construct(array $attributes = [], ?string $name = null, ?bool $default = null, ?string $description = null, ?bool $update = null)
-    {
+    public function __construct(
+        array $attributes = [],
+        ?string $name = null,
+        ?bool $default = null,
+        ?string $description = null,
+        ?bool $update = null
+    ) {
         $this->name = $name ?? $attributes['name'] ?? null;
-        $this->default = $default ?? $attributes['default'] ?? true;
+        $this->default = $default ?? $attributes['default'] ?? $this->name === null;
         $this->description = $description ?? $attributes['description'] ?? null;
         $this->update = $update ?? $attributes['update'] ?? false;
     }

--- a/src/Annotations/Input.php
+++ b/src/Annotations/Input.php
@@ -21,7 +21,7 @@ use RuntimeException;
  * })
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-class Input
+class Input implements TypeInterface
 {
     /** @var string|null */
     private $class;
@@ -97,5 +97,14 @@ class Input
     public function isUpdate(): bool
     {
         return $this->update;
+    }
+
+    /**
+     * By default there isn't support for defining the type outside
+     * This is used by the @Type annotation with the "external" attribute.
+     */
+    public function isSelfType(): bool
+    {
+        return true;
     }
 }

--- a/src/Annotations/Input.php
+++ b/src/Annotations/Input.php
@@ -44,7 +44,7 @@ class Input implements TypeInterface
     public function __construct(array $attributes = [], ?string $name = null, ?bool $default = null, ?string $description = null, ?bool $update = null)
     {
         $this->name = $name ?? $attributes['name'] ?? null;
-        $this->default = $default ?? $attributes['default'] ?? $this->name === null;
+        $this->default = $default ?? $attributes['default'] ?? true;
         $this->description = $description ?? $attributes['description'] ?? null;
         $this->update = $update ?? $attributes['update'] ?? false;
     }

--- a/src/Annotations/Type.php
+++ b/src/Annotations/Type.php
@@ -27,7 +27,7 @@ use function ltrim;
  * })
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-class Type
+class Type implements TypeInterface
 {
     /** @var class-string<object>|null */
     private $class;

--- a/src/Annotations/TypeInterface.php
+++ b/src/Annotations/TypeInterface.php
@@ -15,4 +15,10 @@ interface TypeInterface
     public function isSelfType(): bool;
 
     public function setClass(string $className): void;
+
+    public function getClass(): string;
+
+    public function isDefault(): bool;
+
+    public function getName(): ?string;
 }

--- a/src/Annotations/TypeInterface.php
+++ b/src/Annotations/TypeInterface.php
@@ -16,6 +16,9 @@ interface TypeInterface
 
     public function setClass(string $className): void;
 
+    /**
+     * @return class-string<object>
+     */
     public function getClass(): string;
 
     public function isDefault(): bool;

--- a/src/Annotations/TypeInterface.php
+++ b/src/Annotations/TypeInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Annotations;
+
+/**
+ * Applies to all GraphQL "Type" annotations (Type and Input)
+ */
+interface TypeInterface
+{
+    /**
+     * If the Type is handled by itself.
+     */
+    public function isSelfType(): bool;
+
+    public function setClass(string $className): void;
+}

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -262,7 +262,8 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
      */
     public function canMapClassToType(string $className): bool
     {
-        return $this->getMaps()->getTypeByObjectClass($className) !== null;
+        return $this->getMaps()->getTypeByObjectClass($className) !== null
+            || $this->getMaps()->getInputByObjectClass($className) !== null;
     }
 
     /**
@@ -275,8 +276,11 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
     {
-        $typeClassName = $this->getMaps()->getTypeByObjectClass($className);
+        $inputTypeClassName = $this->getMaps()->getInputByObjectClass($className)
+            ? $this->getMaps()->getInputByObjectClass($className)[0]
+            : null;
 
+        $typeClassName = $this->getMaps()->getTypeByObjectClass($className) ?: $inputTypeClassName;
         if ($typeClassName === null) {
             throw CannotMapTypeException::createForType($className);
         }

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -329,7 +329,7 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
 
         $input = $this->getMaps()->getInputByObjectClass($className);
         if ($input !== null) {
-            [$typeName, $description, $isUpdate] = $input;
+            [$className, $typeName, $description, $isUpdate] = $input;
             return $this->inputTypeGenerator->mapInput($className, $typeName, $description, $isUpdate);
         }
 

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -276,6 +276,7 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
      */
     public function mapClassToType(string $className, ?OutputType $subType): MutableInterface
     {
+        /** @var class-string<object>|null $inputTypeClassName */
         $inputTypeClassName = $this->getMaps()->getInputByObjectClass($className)
             ? $this->getMaps()->getInputByObjectClass($className)[0]
             : null;
@@ -314,8 +315,6 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
      * Maps a PHP fully qualified class name to a GraphQL input type.
      *
      * @param class-string<object> $className
-     *
-     * @return ResolvableMutableInputInterface&InputObjectType
      *
      * @throws CannotMapTypeException
      */

--- a/src/Mappers/GlobTypeMapperCache.php
+++ b/src/Mappers/GlobTypeMapperCache.php
@@ -44,7 +44,7 @@ class GlobTypeMapperCache
             }
 
             if ($globAnnotationsCache->isDefault()) {
-                $objectClassName                             = $typeClassName;
+                $objectClassName = $typeClassName;
                 $this->mapClassToTypeArray[$objectClassName] = $className;
             }
 
@@ -75,7 +75,7 @@ class GlobTypeMapperCache
                     throw DuplicateMappingException::createForDefaultInput($refClass->getName());
                 }
 
-                $this->mapClassToInput[$inputClassName] = [$inputName, $description, $isUpdate];
+                $this->mapClassToInput[$inputClassName] = [$className, $description, $isUpdate];
             }
 
             $this->mapNameToInput[$inputName] = [$inputClassName, $description, $isUpdate];

--- a/src/Mappers/GlobTypeMapperCache.php
+++ b/src/Mappers/GlobTypeMapperCache.php
@@ -23,7 +23,7 @@ class GlobTypeMapperCache
     private $mapInputNameToFactory = [];
     /** @var array<string,array<int, array{0: class-string<object>, 1: string}>> Maps a GraphQL type name to one or many decorators (with the @Decorator annotation) */
     private $mapInputNameToDecorator = [];
-    /** @var array<class-string<object>,array{0: string, 1: string|null, 2: bool}> Maps a domain class to the input */
+    /** @var array<class-string<object>,array{0: class-string<object>, 1: string, 2: string|null, 3: bool}> Maps a domain class to the input */
     private $mapClassToInput = [];
     /** @var array<string,array{0: class-string<object>, 1: string|null, 2: bool}> Maps a GraphQL type name to the input */
     private $mapNameToInput = [];
@@ -145,7 +145,7 @@ class GlobTypeMapperCache
     }
 
     /**
-     * @return array{0: string, 1: string|null, 2: bool}|null
+     * @return array{0: class-string<object>, 1: string, 2: string|null, 3: bool}|null
      */
     public function getInputByObjectClass(string $className): ?array
     {

--- a/src/Mappers/GlobTypeMapperCache.php
+++ b/src/Mappers/GlobTypeMapperCache.php
@@ -75,7 +75,7 @@ class GlobTypeMapperCache
                     throw DuplicateMappingException::createForDefaultInput($refClass->getName());
                 }
 
-                $this->mapClassToInput[$inputClassName] = [$className, $description, $isUpdate];
+                $this->mapClassToInput[$inputClassName] = [$className, $inputName, $description, $isUpdate];
             }
 
             $this->mapNameToInput[$inputName] = [$inputClassName, $description, $isUpdate];

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -93,7 +93,14 @@ class TypeHandler implements ParameterHandlerInterface
         $docBlockReturnType = $this->getDocBlocReturnType($docBlockObj, $refMethod);
 
         try {
-            $type = $this->mapType($phpdocType, $docBlockReturnType, $returnType ? $returnType->allowsNull() : false, false, $refMethod, $docBlockObj);
+            $type = $this->mapType(
+                $phpdocType,
+                $docBlockReturnType,
+                $returnType ? $returnType->allowsNull() : false,
+                false,
+                $refMethod,
+                $docBlockObj
+            );
             assert($type instanceof GraphQLType && $type instanceof OutputType);
         } catch (CannotMapTypeExceptionInterface $e) {
             $e->addReturnInfo($refMethod);
@@ -173,7 +180,15 @@ class TypeHandler implements ParameterHandlerInterface
             try {
                 $declaringFunction = $parameter->getDeclaringFunction();
                 Assert::isInstanceOf($declaringFunction, ReflectionMethod::class, 'Parameter of a function passed. Only parameters of methods are supported.');
-                $type = $this->mapType($phpdocType, $paramTagType, $allowsNull || $parameter->isDefaultValueAvailable(), true, $declaringFunction, $docBlock, $parameter->getName());
+                $type = $this->mapType(
+                    $phpdocType,
+                    $paramTagType,
+                    $allowsNull || $parameter->isDefaultValueAvailable(),
+                    true,
+                    $declaringFunction,
+                    $docBlock,
+                    $parameter->getName()
+                );
                 Assert::isInstanceOf($type, InputType::class);
             } catch (CannotMapTypeExceptionInterface $e) {
                 $e->addParamInfo($parameter);
@@ -201,7 +216,13 @@ class TypeHandler implements ParameterHandlerInterface
      *
      * @throws CannotMapTypeException
      */
-    public function mapPropertyType(ReflectionProperty $refProperty, DocBlock $docBlock, bool $toInput, ?string $argumentName = null, ?bool $isNullable = null): GraphQLType
+    public function mapPropertyType(
+        ReflectionProperty $refProperty,
+        DocBlock $docBlock,
+        bool $toInput,
+        ?string $argumentName = null,
+        ?bool $isNullable = null
+    ): GraphQLType
     {
         $propertyType = null;
 
@@ -223,7 +244,15 @@ class TypeHandler implements ParameterHandlerInterface
             $isNullable = $propertyType ? $propertyType->allowsNull() : false;
         }
 
-        return $this->mapType($phpdocType, $docBlockPropertyType, $isNullable, $toInput, $refProperty, $docBlock, $argumentName);
+        return $this->mapType(
+            $phpdocType,
+            $docBlockPropertyType,
+            $isNullable,
+            $toInput,
+            $refProperty,
+            $docBlock,
+            $argumentName
+        );
     }
 
     /**
@@ -233,7 +262,14 @@ class TypeHandler implements ParameterHandlerInterface
      *
      * @throws CannotMapTypeException
      */
-    public function mapInputProperty(ReflectionProperty $refProperty, DocBlock $docBlock, ?string $argumentName = null, ?string $inputTypeName = null, $defaultValue = null, ?bool $isNullable = null): InputTypeProperty
+    public function mapInputProperty(
+        ReflectionProperty $refProperty,
+        DocBlock $docBlock,
+        ?string $argumentName = null,
+        ?string $inputTypeName = null,
+        $defaultValue = null,
+        ?bool $isNullable = null
+    ): InputTypeProperty
     {
         $docBlockComment = $docBlock->getSummary() . PHP_EOL . $docBlock->getDescription()->render();
 
@@ -285,7 +321,15 @@ class TypeHandler implements ParameterHandlerInterface
      *
      * @throws CannotMapTypeException
      */
-    private function mapType(Type $type, ?Type $docBlockType, bool $isNullable, bool $mapToInputType, $reflector, DocBlock $docBlockObj, ?string $argumentName = null): GraphQLType
+    private function mapType(
+        Type $type,
+        ?Type $docBlockType,
+        bool $isNullable,
+        bool $mapToInputType,
+        $reflector,
+        DocBlock $docBlockObj,
+        ?string $argumentName = null
+    ): GraphQLType
     {
         $graphQlType = null;
         if ($isNullable && ! $type instanceof Nullable) {

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
+use function array_flip;
+use function array_reverse;
+use function class_implements;
+use function get_parent_class;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
@@ -16,18 +20,15 @@ use TheCodingMachine\GraphQLite\AnnotationReader;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\InterfaceFromObjectType;
+use TheCodingMachine\GraphQLite\Types\MutableInputInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
+
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ObjectFromInterfaceType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use TypeError;
 use Webmozart\Assert\Assert;
-
-use function array_flip;
-use function array_reverse;
-use function class_implements;
-use function get_parent_class;
 
 /**
  * This class wraps a TypeMapperInterface into a RecursiveTypeMapperInterface.
@@ -409,8 +410,6 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
      *
      * @param class-string<object> $className
      *
-     * @return InputObjectType&ResolvableMutableInputInterface
-     *
      * @throws CannotMapTypeExceptionInterface
      */
     public function mapClassToInputType(string $className): ResolvableMutableInputInterface
@@ -451,7 +450,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
      * Returns an array containing all OutputTypes.
      * Needed for introspection because of interfaces.
      *
-     * @return array<string, OutputType>
+     * @return array<string, MutableInterface|MutableInputInterface>
      */
     public function getOutputTypes(): array
     {

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -43,7 +43,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
      *
      * @var array<class-string<object>,MappedClass>|null
      */
-    private array $mappedClasses;
+    private ?array $mappedClasses = null;
 
     /**
      * An array of interfaces OR object types if no interface matching.
@@ -65,7 +65,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
     private ?int $ttl = null;
 
     /** @var array<string, class-string<object>> An array mapping a GraphQL interface name to the PHP class name that triggered its generation. */
-    private array $interfaceToClassNameMap;
+    private ?array $interfaceToClassNameMap = null;
 
     private TypeRegistry $typeRegistry;
 

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use function array_flip;
-use function array_reverse;
-use function class_implements;
-use function get_parent_class;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
@@ -23,12 +19,16 @@ use TheCodingMachine\GraphQLite\Types\InterfaceFromObjectType;
 use TheCodingMachine\GraphQLite\Types\MutableInputInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
-
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ObjectFromInterfaceType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use TypeError;
 use Webmozart\Assert\Assert;
+
+use function array_flip;
+use function array_reverse;
+use function class_implements;
+use function get_parent_class;
 
 /**
  * This class wraps a TypeMapperInterface into a RecursiveTypeMapperInterface.

--- a/src/NamingStrategy.php
+++ b/src/NamingStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
-use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Annotations\TypeInterface;
 
 use function lcfirst;
 use function str_replace;
@@ -36,7 +36,7 @@ class NamingStrategy implements NamingStrategyInterface
     /**
      * Returns the GraphQL output object type name based on the type className and the Type annotation.
      */
-    public function getOutputTypeName(string $typeClassName, Type $type): string
+    public function getOutputTypeName(string $typeClassName, TypeInterface $type): string
     {
         $name = $type->getName();
         if ($name !== null) {

--- a/src/NamingStrategyInterface.php
+++ b/src/NamingStrategyInterface.php
@@ -6,7 +6,7 @@ namespace TheCodingMachine\GraphQLite;
 
 use TheCodingMachine\GraphQLite\Annotations\Factory;
 use TheCodingMachine\GraphQLite\Annotations\Input;
-use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Annotations\TypeInterface;
 
 /**
  * @unstable See https://graphqlite.thecodingmachine.io/docs/semver.html
@@ -28,7 +28,7 @@ interface NamingStrategyInterface
     /**
      * Returns the GraphQL output object type name based on the type className and the Type annotation.
      */
-    public function getOutputTypeName(string $typeClassName, Type $type): string;
+    public function getOutputTypeName(string $typeClassName, TypeInterface $type): string;
 
     /**
      * Returns the GraphQL input object type name based on the type className and the Input annotation.

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -358,7 +358,7 @@ class SchemaFactory
         $fieldMiddlewarePipe->pipe(new AuthorizationFieldMiddleware($authenticationService, $authorizationService));
 
         $compositeTypeMapper = new CompositeTypeMapper();
-        $recursiveTypeMapper = new RecursiveTypeMapper($compositeTypeMapper, $namingStrategy, $namespacedCache, $typeRegistry);
+        $recursiveTypeMapper = new RecursiveTypeMapper($compositeTypeMapper, $namingStrategy, $namespacedCache, $typeRegistry, $annotationReader);
 
         $topRootTypeMapper = new NullableTypeMapperAdapter();
 

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use TheCodingMachine\GraphQLite\Types\MutableInputInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
@@ -92,7 +93,11 @@ class TypeRegistry
     public function getMutableInterface(string $typeName): MutableInterface
     {
         $type = $this->getType($typeName);
-        if (! $type instanceof MutableInterface || (! $type instanceof MutableInterfaceType && ! $type instanceof MutableObjectType)) {
+        if (! $type instanceof MutableInterface
+            && ! $type instanceof MutableInputInterface
+            || (! $type instanceof MutableInterfaceType && ! $type instanceof MutableObjectType)
+        ) {
+            // dump($type);
             throw new GraphQLRuntimeException('Expected GraphQL type "' . $typeName . '" to be either a MutableObjectType or a MutableInterfaceType. Got a ' . get_class($type));
         }
 

--- a/src/Types/MutableInputInterface.php
+++ b/src/Types/MutableInputInterface.php
@@ -8,6 +8,8 @@ use GraphQL\Type\Definition\InputType;
 
 /**
  * An input object type to which we can add fields after instantiation.
+ *
+ * @property string $name
  */
 interface MutableInputInterface extends InputType
 {

--- a/src/Types/MutableInterface.php
+++ b/src/Types/MutableInterface.php
@@ -9,6 +9,8 @@ use GraphQL\Type\Definition\FieldDefinition;
 
 /**
  * GraphQL objects or interfaces that can be muted.
+ *
+ * @property string $name
  */
 interface MutableInterface
 {

--- a/src/Types/TypeAnnotatedInterfaceType.php
+++ b/src/Types/TypeAnnotatedInterfaceType.php
@@ -5,14 +5,10 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Types;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
-use ReflectionClass;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
-use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
-use TheCodingMachine\GraphQLite\Reflection\ReflectionInterfaceUtils;
-use function array_merge;
+
 use function get_class;
 use function gettype;
 use function is_object;

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -242,7 +242,7 @@ abstract class AbstractQueryProviderTest extends TestCase
                     throw CannotMapTypeException::createForDecorateName($typeName, $type);
                 }
 
-            }, new NamingStrategy(), new Psr16Cache($arrayAdapter), $this->getTypeRegistry());
+            }, new NamingStrategy(), new Psr16Cache($arrayAdapter), $this->getTypeRegistry(), $this->getAnnotationReader());
         }
         return $this->typeMapper;
     }

--- a/tests/Fixtures/Integration/Models/Post.php
+++ b/tests/Fixtures/Integration/Models/Post.php
@@ -9,8 +9,8 @@ use TheCodingMachine\GraphQLite\Annotations\Type;
 
 /**
  * @Type()
- * @Input()
- * @Input(name="UpdatePostInput", update=true)
+ * @Input(name="PostInput", default=true)
+ * @Input(name="UpdatePostInput", default=false, update=true)
  */
 class Post
 {
@@ -29,7 +29,7 @@ class Post
 
     /**
      * @Field(for={"Post", "PostInput"})
-     * @Field(for="PostUpdateInput", inputType="DateTime")
+     * @Field(for="UpdatePostInput", inputType="DateTime")
      * @var DateTimeInterface
      */
     public $publishedAt;

--- a/tests/Fixtures/Integration/Models/Post.php
+++ b/tests/Fixtures/Integration/Models/Post.php
@@ -10,7 +10,7 @@ use TheCodingMachine\GraphQLite\Annotations\Type;
 /**
  * @Type()
  * @Input(name="PostInput", default=true)
- * @Input(name="UpdatePostInput", default=false, update=true)
+ * @Input(name="UpdatePostInput", update=true)
  */
 class Post
 {

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1211,8 +1211,6 @@ class EndToEndTest extends TestCase
 
     /**
      * @requires PHP >= 8.1
-     *
-     * @group test-only
      */
     public function testEndToEndNativeEnums(): void
     {

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -172,7 +172,8 @@ class EndToEndTest extends TestCase
                     $container->get(TypeMapperInterface::class),
                     $container->get(NamingStrategyInterface::class),
                     new Psr16Cache($arrayAdapter),
-                    $container->get(TypeRegistry::class)
+                    $container->get(TypeRegistry::class),
+                    $container->get(AnnotationReader::class)
                 );
             },
             TypeMapperInterface::class => function(ContainerInterface $container) {

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -39,7 +39,13 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
             ClassB::class => $objectType
         ]);
 
-        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper, new NamingStrategy(), new Psr16Cache(new ArrayAdapter()), $this->getTypeRegistry());
+        $recursiveTypeMapper = new RecursiveTypeMapper(
+            $typeMapper,
+            new NamingStrategy(),
+            new Psr16Cache(new ArrayAdapter()),
+            $this->getTypeRegistry(),
+            $this->getAnnotationReader()
+        );
 
         $this->assertFalse($typeMapper->canMapClassToType(ClassC::class));
         $this->assertTrue($recursiveTypeMapper->canMapClassToType(ClassC::class));
@@ -61,7 +67,13 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
             ClassB::class => $objectType
         ]);
 
-        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper, new NamingStrategy(), new Psr16Cache(new ArrayAdapter()), $this->getTypeRegistry());
+        $recursiveTypeMapper = new RecursiveTypeMapper(
+            $typeMapper,
+            new NamingStrategy(),
+            new Psr16Cache(new ArrayAdapter()),
+            $this->getTypeRegistry(),
+            $this->getAnnotationReader()
+        );
 
         $this->assertTrue($recursiveTypeMapper->canMapNameToType('Foobar'));
         $this->assertSame($objectType, $recursiveTypeMapper->mapNameToType('Foobar'));
@@ -94,7 +106,13 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
             ClassB::class => $inputObjectType
         ]);
 
-        $recursiveTypeMapper = new RecursiveTypeMapper($typeMapper, new NamingStrategy(), new Psr16Cache(new ArrayAdapter()), $this->getTypeRegistry());
+        $recursiveTypeMapper = new RecursiveTypeMapper(
+            $typeMapper,
+            new NamingStrategy(),
+            new Psr16Cache(new ArrayAdapter()),
+            $this->getTypeRegistry(),
+            $this->getAnnotationReader()
+        );
 
         $this->assertFalse($recursiveTypeMapper->canMapClassToInputType(ClassC::class));
 
@@ -120,7 +138,13 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
 
 
             $compositeMapper = new CompositeTypeMapper();
-            $this->typeMapper = new RecursiveTypeMapper($compositeMapper, new NamingStrategy(), new Psr16Cache(new ArrayAdapter()), $this->getTypeRegistry());
+            $this->typeMapper = new RecursiveTypeMapper(
+                $compositeMapper,
+                new NamingStrategy(),
+                new Psr16Cache(new ArrayAdapter()),
+                $this->getTypeRegistry(),
+                $this->getAnnotationReader()
+            );
 
             $typeGenerator = new TypeGenerator($this->getAnnotationReader(), $namingStrategy, $this->getTypeRegistry(), $this->getRegistry(), $this->typeMapper, $this->getFieldsBuilder());
 
@@ -188,7 +212,13 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
         $compositeTypeMapper->addTypeMapper($typeMapper1);
         $compositeTypeMapper->addTypeMapper($typeMapper2);
 
-        $recursiveTypeMapper = new RecursiveTypeMapper($compositeTypeMapper, new NamingStrategy(), new Psr16Cache(new ArrayAdapter()), $this->getTypeRegistry());
+        $recursiveTypeMapper = new RecursiveTypeMapper(
+            $compositeTypeMapper,
+            new NamingStrategy(),
+            new Psr16Cache(new ArrayAdapter()),
+            $this->getTypeRegistry(),
+            $this->getAnnotationReader()
+        );
 
         $this->expectException(DuplicateMappingException::class);
         $this->expectExceptionMessage("The type 'Foobar' is created by 2 different classes: 'TheCodingMachine\GraphQLite\Fixtures\Interfaces\ClassB' and 'TheCodingMachine\GraphQLite\Fixtures\Interfaces\ClassA'");
@@ -200,7 +230,13 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
      */
     public function testMapNoTypes(): void
     {
-        $recursiveTypeMapper = new RecursiveTypeMapper(new CompositeTypeMapper(), new NamingStrategy(), new Psr16Cache(new ArrayAdapter()), $this->getTypeRegistry());
+        $recursiveTypeMapper = new RecursiveTypeMapper(
+            new CompositeTypeMapper(),
+            new NamingStrategy(),
+            new Psr16Cache(new ArrayAdapter()),
+            $this->getTypeRegistry(),
+            $this->getAnnotationReader()
+        );
 
         $this->expectException(CannotMapTypeException::class);
         $recursiveTypeMapper->mapNameToType('Foo');
@@ -215,7 +251,13 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
 
         $mapper = new GlobTypeMapper($this->getNamespaceFactory()->createNamespace('TheCodingMachine\GraphQLite\Fixtures\Integration'), $typeGenerator, $inputTypeGenerator, $this->getInputTypeUtils(), $this->getRegistry(), new \TheCodingMachine\GraphQLite\AnnotationReader(new AnnotationReader()), new NamingStrategy(), $this->getTypeMapper(), $cache);
 
-        $recursiveTypeMapper = new RecursiveTypeMapper($mapper, new NamingStrategy(), new Psr16Cache(new ArrayAdapter()), $this->getTypeRegistry());
+        $recursiveTypeMapper = new RecursiveTypeMapper(
+            $mapper,
+            new NamingStrategy(),
+            new Psr16Cache(new ArrayAdapter()),
+            $this->getTypeRegistry(),
+            $this->getAnnotationReader()
+        );
 
         $type = $recursiveTypeMapper->mapNameToType('FilterInput');
         $this->assertInstanceOf(ResolvableMutableInputObjectType::class, $type);

--- a/website/docs/annotations-reference.md
+++ b/website/docs/annotations-reference.md
@@ -66,8 +66,8 @@ Attribute      | Compulsory | Type   | Definition
 ---------------|------------|--------|--------
 name           | *no*       | string | The name of the GraphQL input type generated. If not passed, the name of the class with suffix "Input" is used. If the class ends with "Input", the "Input" suffix is not added.
 description    | *no*       | string | Description of the input type in the documentation. If not passed, PHP doc comment is used.
-default        | *no*       | bool   | Defaults to *true* if name is not specified. Whether the annotated PHP class should be mapped by default to this type.
-update         | *no*       | bool   | Determines if the the input represents a partial update. When set to *true* all input fields will become optional and won't have default values thus won't be set on resolve if they are not specified in the query/mutation.
+default        | *no*       | bool   | Name of the input type represented in your GraphQL schema. Defaults to `true` *only if* the name is not specified. If `name` is specified, this will default to `false`, so must also be included for `true` when `name` is used.
+update         | *no*       | bool   | Determines if the the input represents a partial update. When set to `true` all input fields will become optional and won't have default values thus won't be set on resolve if they are not specified in the query/mutation.  This primarily applies to nullable fields.
 
 
 ## @Field annotation

--- a/website/docs/annotations-reference.md
+++ b/website/docs/annotations-reference.md
@@ -7,7 +7,7 @@ sidebar_label: Annotations reference
 Note: all annotations are available both in a Doctrine annotation format (`@Query`) and in PHP 8 attribute format (`#[Query]`).
 See [Doctrine annotations vs PHP 8 attributes](doctrine-annotations-attributes.mdx) for more details.
 
-## @Query annotation
+## @Query
 
 The `@Query` annotation is used to declare a GraphQL query.
 
@@ -18,7 +18,7 @@ Attribute      | Compulsory | Type | Definition
 name           | *no*       | string | The name of the query. If skipped, the name of the method is used instead.
 [outputType](custom-types.mdx)     | *no*       | string | Forces the GraphQL output type of a query.
 
-## @Mutation annotation
+## @Mutation
 
 The `@Mutation` annotation is used to declare a GraphQL mutation.
 
@@ -29,7 +29,7 @@ Attribute      | Compulsory | Type | Definition
 name           | *no*       | string | The name of the mutation. If skipped, the name of the method is used instead.
 [outputType](custom-types.mdx)     | *no*       | string | Forces the GraphQL output type of a query.
 
-## @Type annotation
+## @Type
 
 The `@Type` annotation is used to declare a GraphQL object type.  This is used with standard output
 types, as well as enum types.  For input types, use the [@Input annotation](#input-annotation) directly on the input type or a [@Factory annoation](#factory-annotation) to make/return an input type.
@@ -43,7 +43,7 @@ name           | *no*       | string | The name of the GraphQL type generated. I
 default        | *no*       | bool   | Defaults to *true*. Whether the targeted PHP class should be mapped by default to this type.
 external       | *no*       | bool   | Whether this is an [external type declaration](external-type-declaration.mdx) or not. You usually do not need to use this attribute since this value defaults to true if a "class" attribute is set. This is only useful if you are declaring a type with no PHP class mapping using the "name" attribute.
 
-## @ExtendType annotation
+## @ExtendType
 
 The `@ExtendType` annotation is used to add fields to an existing GraphQL object type.
 
@@ -56,7 +56,7 @@ name           | see below  | string | The targeted GraphQL output type.
 
 One and only one of "class" and "name" parameter can be passed at the same time.
 
-## @Input annotation
+## @Input
 
 The `@Input` annotation is used to declare a GraphQL input type.
 
@@ -69,8 +69,7 @@ description    | *no*       | string | Description of the input type in the docu
 default        | *no*       | bool   | Name of the input type represented in your GraphQL schema. Defaults to `true` *only if* the name is not specified. If `name` is specified, this will default to `false`, so must also be included for `true` when `name` is used.
 update         | *no*       | bool   | Determines if the the input represents a partial update. When set to `true` all input fields will become optional and won't have default values thus won't be set on resolve if they are not specified in the query/mutation.  This primarily applies to nullable fields.
 
-
-## @Field annotation
+## @Field
 
 The `@Field` annotation is used to declare a GraphQL field.
 
@@ -86,7 +85,7 @@ description                   | *no*       | string        | Field description d
 [outputType](custom-types.mdx) | *no*       | string        | Forces the GraphQL output type of a query.
 [inputType](input-types.mdx)   | *no*       | string        | Forces the GraphQL input type of a query.
 
-## @SourceField annotation
+## @SourceField
 
 The `@SourceField` annotation is used to declare a GraphQL field.
 
@@ -103,7 +102,7 @@ annotations    | *no*       | array\<Annotations\>  | A set of annotations that 
 
 **Note**: `outputType` and `phpType` are mutually exclusive.
 
-## @MagicField annotation
+## @MagicField
 
 The `@MagicField` annotation is used to declare a GraphQL field that originates from a PHP magic property (using `__get` magic method).
 
@@ -120,7 +119,7 @@ annotations    | *no*       | array\<Annotations\>  | A set of annotations that 
 
 (*) **Note**: `outputType` and `phpType` are mutually exclusive. You MUST provide one of them.
 
-## @Logged annotation
+## @Logged
 
 The `@Logged` annotation is used to declare a Query/Mutation/Field is only visible to logged users.
 
@@ -128,7 +127,7 @@ The `@Logged` annotation is used to declare a Query/Mutation/Field is only visib
 
 This annotation allows no attributes.
 
-## @Right annotation
+## @Right
 
 The `@Right` annotation is used to declare a Query/Mutation/Field is only visible to users with a specific right.
 
@@ -138,7 +137,7 @@ Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 name           | *yes*       | string | The name of the right.
 
-## @FailWith annotation
+## @FailWith
 
 The `@FailWith` annotation is used to declare a default value to return in the user is not authorized to see a specific
 query / mutation / field (according to the `@Logged` and `@Right` annotations).
@@ -149,7 +148,7 @@ Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 value          | *yes*       | mixed | The value to return if the user is not authorized.
 
-## @HideIfUnauthorized annotation
+## @HideIfUnauthorized
 
 The `@HideIfUnauthorized` annotation is used to completely hide the query / mutation / field if the user is not authorized
 to access it (according to the `@Logged` and `@Right` annotations).
@@ -158,7 +157,7 @@ to access it (according to the `@Logged` and `@Right` annotations).
 
 `@HideIfUnauthorized` and `@FailWith` are mutually exclusive.
 
-## @InjectUser annotation
+## @InjectUser
 
 Use the `@InjectUser` annotation to inject an instance of the current user logged in into a parameter of your
 query / mutation / field.
@@ -169,7 +168,7 @@ Attribute      | Compulsory | Type   | Definition
 ---------------|------------|--------|--------
 *for*          | *yes*      | string | The name of the PHP parameter
 
-## @Security annotation
+## @Security
 
 The `@Security` annotation can be used to check fin-grained access rights.
 It is very flexible: it allows you to pass an expression that can contains custom logic.
@@ -182,7 +181,7 @@ Attribute      | Compulsory | Type   | Definition
 ---------------|------------|--------|--------
 *default*      | *yes*      | string | The security expression
 
-## @Factory annotation
+## @Factory
 
 The `@Factory` annotation is used to declare a factory that turns GraphQL input types into objects.
 
@@ -193,7 +192,7 @@ Attribute      | Compulsory | Type | Definition
 name           | *no*       | string | The name of the input type. If skipped, the name of class returned by the factory is used instead.
 default        | *no*       | bool | If `true`, this factory will be used by default for its PHP return type. If set to `false`, you must explicitly [reference this factory using the `@Parameter` annotation](input-types.mdx#declaring-several-input-types-for-the-same-php-class).
 
-## @UseInputType annotation
+## @UseInputType
 
 Used to override the GraphQL input type of a PHP parameter.
 
@@ -204,7 +203,7 @@ Attribute      | Compulsory | Type | Definition
 *for*          | *yes*      | string | The name of the PHP parameter
 *inputType*    | *yes*      | string | The GraphQL input type to force for this input field
 
-## @Decorate annotation
+## @Decorate
 
 The `@Decorate` annotation is used [to extend/modify/decorate an input type declared with the `@Factory` annotation](extend-input-type.mdx).
 
@@ -214,7 +213,7 @@ Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 name           | *yes*      | string | The GraphQL input type name extended by this decorator.
 
-## @Autowire annotation
+## @Autowire
 
 [Resolves a PHP parameter from the container](autowiring.mdx).
 
@@ -227,7 +226,7 @@ Attribute      | Compulsory | Type | Definition
 *for*          | *yes*      | string | The name of the PHP parameter
 *identifier*   | *no*       | string | The identifier of the service to fetch. This is optional. Please avoid using this attribute as this leads to a "service locator" anti-pattern.
 
-## @HideParameter annotation
+## @HideParameter
 
 Removes [an argument from the GraphQL schema](input-types.mdx#ignoring-some-parameters).
 
@@ -235,8 +234,7 @@ Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 *for*          | *yes*      | string | The name of the PHP parameter to hide
 
-
-## @Validate annotation
+## @Validate
 
 <div class="alert alert--info">This annotation is only available in the GraphQLite Laravel package</div>
 
@@ -255,7 +253,7 @@ Sample:
 @Validate(for="$email", rule="email|unique:users")
 ```
 
-## @Assertion annotation
+## @Assertion
 
 [Validates a user input](validation.mdx).
 
@@ -269,7 +267,7 @@ Attribute      | Compulsory | Type | Definition
 *for*          | *yes*      | string | The name of the PHP parameter
 *constraint*   | *yes       | annotation | One (or many) Symfony validation annotations.
 
-## ~~@EnumType annotation~~
+## ~~@EnumType~~
 
 *Deprecated: Use [PHP 8.1's native Enums](https://www.php.net/manual/en/language.types.enumerations.php) instead with a [@Type](#type-annotation).*
 


### PR DESCRIPTION
This PR started out by addressing an issue with nested InputTypes not being resolved and needing support within the `RecursiveTypeMapper`.  As this was resolved, other issues came to light and were resolved as well:

- Nested InputTypes are now supported, regardless of their loading order in type mappers.  So, if InputType `A` references InputType `B` , `B` will be resolved as well, even if it hasn't prior.  This is what the `RecursiveTypeMapper` does, only it was working with output Types.
- When the `Input` annotation was released, there was a known issue where a `Type` annotation also had to be used in some cases.  This issue should be resolved now.
- Input types are receiving some additional validation as part of their addition to the `RecursiveTypeMapper`

The current `Input` implementation is a bit shaky.  This PR provides more stability and better integration into type mapper processing.