### PR TITLE
Actualize link to spec chapter about status codes

### DIFF
--- a/src/Http/HttpCodeDecider.php
+++ b/src/Http/HttpCodeDecider.php
@@ -14,7 +14,7 @@ class HttpCodeDecider implements HttpCodeDeciderInterface
     /**
      * Decides the HTTP status code based on the answer.
      *
-     * @see https://github.com/APIs-guru/graphql-over-http#status-codes
+     * @see https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#status-codes
      */
     public function decideHttpStatusCode(ExecutionResult $result): int
     {

--- a/src/Http/HttpCodeDeciderInterface.php
+++ b/src/Http/HttpCodeDeciderInterface.php
@@ -11,7 +11,7 @@ interface HttpCodeDeciderInterface
     /**
      * Decides the HTTP status code based on the answer.
      *
-     * @see https://github.com/APIs-guru/graphql-over-http#status-codes
+     * @see https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#status-codes
      */
     public function decideHttpStatusCode(ExecutionResult $result): int;
 }


### PR DESCRIPTION
The previous link redirects to (probably moved) the repository - https://github.com/graphql/graphql-over-http

And the new repository doesn't have an anchor `#status-codes` for the main repository page.