### PR TITLE
Muatation namespace

### DIFF
--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -22,6 +22,7 @@ use TheCodingMachine\GraphQLite\Annotations\Factory;
 use TheCodingMachine\GraphQLite\Annotations\Input;
 use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotationInterface;
 use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotations;
+use TheCodingMachine\GraphQLite\Annotations\MuatationNamespace;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotationInterface;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotations;
 use TheCodingMachine\GraphQLite\Annotations\SourceFieldInterface;
@@ -277,6 +278,16 @@ class AnnotationReader
         }
 
         return $type;
+    }
+
+    /**
+     * @param ReflectionClass<T> $refClass
+     *
+     * @template T of object
+     */
+    public function getNamespaceAnnotation(ReflectionClass $refClass): ?MuatationNamespace
+    {
+        return $this->getClassAnnotation($refClass, MuatationNamespace::class);
     }
 
     /**

--- a/src/Annotations/MuatationNamespace.php
+++ b/src/Annotations/MuatationNamespace.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Annotations;
+
+use Attribute;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ * @Attributes({
+ *   @Attribute("name", type = "string"),
+ * })
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class MuatationNamespace
+{
+
+    /** @var string|null */
+    private $name;
+
+    /**
+     * @param mixed[] $attributes
+     */
+    public function __construct(array $attributes = [], ?string $name = null)
+    {
+        $this->name = $name ?? $attributes['name'] ?? null;
+    }
+
+    /**
+     * Returns the GraphQL name for this type.
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -121,7 +121,17 @@ class FieldsBuilder
      */
     public function getMutations(object $controller): array
     {
-        return $this->getFieldsByAnnotations($controller, Mutation::class, false);
+//        return $this->getFieldsByAnnotations($controller, Mutation::class, false);
+        $refClass = new ReflectionClass($controller);
+        $namespace = $this->annotationReader->getNamespaceAnnotation($refClass);
+        if(!$namespace){
+            return $this->getFieldsByAnnotations($controller, Mutation::class, false);
+        } else {
+            dump($namespace);
+            $muatations = $this->getFieldsByAnnotations($controller, Mutation::class, false);
+            dump($muatations);
+            return $muatations;
+        }
     }
 
     /**

--- a/tests/Fixtures/MutationNamespaces/Controllers/RenameController.php
+++ b/tests/Fixtures/MutationNamespaces/Controllers/RenameController.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\MutationNamespaces\Controllers;
+
+
+use TheCodingMachine\GraphQLite\Annotations\MuatationNamespace;
+use TheCodingMachine\GraphQLite\Annotations\Mutation;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Types\ID;
+
+
+/**
+ * @MuatationNamespace(name="CustomNS")
+ */
+class RenameController
+{
+    /**
+     * @Query()
+     */
+    public function custom(ID $id): ID
+    {
+        return new ID("myID");
+    }
+
+    /**
+     * @Mutation()
+     */
+    public function create(ID $id): ID
+    {
+        return new ID("myID");
+    }
+
+    /**
+     * @Mutation()
+     */
+    public function update(ID $id): ID
+    {
+        return new ID("myID");
+    }
+
+    /**
+     * @Mutation()
+     */
+    public function delete(ID $id): ID
+    {
+        return new ID("myID");
+    }
+}

--- a/tests/Fixtures/MutationNamespaces/Controllers/UserController.php
+++ b/tests/Fixtures/MutationNamespaces/Controllers/UserController.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace TheCodingMachine\GraphQLite\Fixtures\MutationNamespaces\Controllers;
+
+
+use TheCodingMachine\GraphQLite\Annotations\MuatationNamespace;
+use TheCodingMachine\GraphQLite\Annotations\Mutation;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Types\ID;
+
+
+/**
+ * @MuatationNamespace()
+ */
+class UserController
+{
+    /**
+     * @Query()
+     */
+    public function user(ID $id): ID
+    {
+        return new ID("myID");
+    }
+
+    /**
+     * @Mutation()
+     */
+    public function create(ID $id): ID
+    {
+        return new ID("myID");
+    }
+
+    /**
+     * @Mutation()
+     */
+    public function update(ID $id): ID
+    {
+        return new ID("myID");
+    }
+
+    /**
+     * @Mutation()
+     */
+    public function delete(ID $id): ID
+    {
+        return new ID("myID");
+    }
+}

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -2056,9 +2056,12 @@ class EndToEndTest extends TestCase
         $schemaFactory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Types');
 
         $schema = $schemaFactory->createSchema();
-        $schemaExport = SchemaPrinter::doPrint($schema);
-        dump($schemaExport);
+//        $schemaExport = SchemaPrinter::doPrint($schema);
         $errors = $schema->validate();
         $this->assertSame([], $errors);
+        $this->assertSame("UserMutations",$schema->getMutationType()->getField("user")->getType()->name);
+        $this->assertCount(3, $schema->getMutationType()->getField("user")->getType()->config["fields"]());
+        $this->assertSame("CustomNS",$schema->getMutationType()->getField("rename")->getType()->name);
+        $this->assertCount(3, $schema->getMutationType()->getField("rename")->getType()->config["fields"]());
     }
 }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use GraphQL\Error\DebugFlag;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\GraphQL;
+use GraphQL\Utils\SchemaPrinter;
 use Mouf\Picotainer\Picotainer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -2044,5 +2045,20 @@ class EndToEndTest extends TestCase
         $this->expectException(ValidationException::class);
         $result = GraphQL::executeQuery($schema, $queryString);
         $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
+    }
+
+    public function testMuatationNamespaces(): void
+    {
+        $arrayAdapter = new ArrayAdapter();
+        $arrayAdapter->setLogger(new ExceptionLogger());
+        $schemaFactory = new SchemaFactory(new Psr16Cache($arrayAdapter), new BasicAutoWiringContainer(new EmptyContainer()));
+        $schemaFactory->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\MutationNamespaces\\Controllers');
+        $schemaFactory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Types');
+
+        $schema = $schemaFactory->createSchema();
+        $schemaExport = SchemaPrinter::doPrint($schema);
+        dump($schemaExport);
+        $errors = $schema->validate();
+        $this->assertSame([], $errors);
     }
 }


### PR DESCRIPTION
This PR adds the ability to turn a `Controller` into a Mutation Namespace as described in #440

The specific Implementation adds a `MutationNamespace` Attribute/Annotation which can optionally be added to a Controller to wrap all its mutations into a Mutation Namespace.

This would look something like this:
```php
#[GQL\MutationNamespace]
class UserController {
    #[GQL\Query]
    public function user()...

    #[GQL\Mutation]
    public function create()...

    #[GQL\Mutation]
    public function update()...

    #[GQL\Mutation]
    public function delete()...
```
Which turns into:
```sdl
UserMutations {
   create()...
   update()....
   delete()...
}
```
There is a optional `name` parameter on the `MutationNamespace` Attribute to rename automatically generated Namespace.
The automatically generated Namespace is the `Classname` - `Controller` + `Muatations` which turns UserController into UserMutations.

All queries in the Controller are completely unaffected.