### PR TITLE
Fix bug with prefetching on different nesting levels

### DIFF
--- a/src/PrefetchBuffer.php
+++ b/src/PrefetchBuffer.php
@@ -22,7 +22,10 @@ class PrefetchBuffer
     /** @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field. */
     public function register(object $object, array $arguments): void
     {
-        $this->objects[$this->computeHash($arguments)][] = $object;
+        $hash = $this->computeHash($arguments);
+
+        $this->objects[$hash][] = $object;
+        unset($this->results[$hash]);
     }
 
     /** @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field. */
@@ -44,7 +47,8 @@ class PrefetchBuffer
     /** @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field. */
     public function purge(array $arguments): void
     {
-        unset($this->objects[$this->computeHash($arguments)]);
+        $hash = $this->computeHash($arguments);
+        unset($this->objects[$hash], $this->results[$hash]);
     }
 
     /** @param array<int,mixed> $arguments The input arguments passed from GraphQL to the field. */

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -103,8 +103,7 @@ class QueryField extends FieldDefinition
                 $prefetchBuffer->register($source, $args);
 
                 return new Deferred(function () use ($prefetchBuffer, $source, $args, $context, $info, $prefetchArgs, $prefetchMethodName, $arguments, $resolveFn, $originalResolver) {
-                    $sources = $prefetchBuffer->getObjectsByArguments($args);
-                    if (! $prefetchBuffer->hasResult($sources)) {
+                    if (! $prefetchBuffer->hasResult($args)) {
                         if ($originalResolver instanceof SourceResolverInterface) {
                             $originalResolver->setObject($source);
                         }
@@ -112,15 +111,17 @@ class QueryField extends FieldDefinition
                         // TODO: originalPrefetchResolver and prefetchResolver needed!!!
                         $prefetchCallable = [$originalResolver->getObject(), $prefetchMethodName];
 
+                        $sources = $prefetchBuffer->getObjectsByArguments($args);
+
                         assert(is_callable($prefetchCallable));
                         $toPassPrefetchArgs = $this->paramsToArguments($prefetchArgs, $source, $args, $context, $info, $prefetchCallable);
 
                         array_unshift($toPassPrefetchArgs, $sources);
                         assert(is_callable($prefetchCallable));
                         $prefetchResult = $prefetchCallable(...$toPassPrefetchArgs);
-                        $prefetchBuffer->storeResult($prefetchResult, $sources);
+                        $prefetchBuffer->storeResult($prefetchResult, $args);
                     } else {
-                        $prefetchResult = $prefetchBuffer->getResult($sources);
+                        $prefetchResult = $prefetchBuffer->getResult($args);
                     }
 
                     foreach ($arguments as $argument) {

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -103,7 +103,8 @@ class QueryField extends FieldDefinition
                 $prefetchBuffer->register($source, $args);
 
                 return new Deferred(function () use ($prefetchBuffer, $source, $args, $context, $info, $prefetchArgs, $prefetchMethodName, $arguments, $resolveFn, $originalResolver) {
-                    if (! $prefetchBuffer->hasResult($args)) {
+                    $sources = $prefetchBuffer->getObjectsByArguments($args);
+                    if (! $prefetchBuffer->hasResult($sources)) {
                         if ($originalResolver instanceof SourceResolverInterface) {
                             $originalResolver->setObject($source);
                         }
@@ -111,17 +112,15 @@ class QueryField extends FieldDefinition
                         // TODO: originalPrefetchResolver and prefetchResolver needed!!!
                         $prefetchCallable = [$originalResolver->getObject(), $prefetchMethodName];
 
-                        $sources = $prefetchBuffer->getObjectsByArguments($args);
-
                         assert(is_callable($prefetchCallable));
                         $toPassPrefetchArgs = $this->paramsToArguments($prefetchArgs, $source, $args, $context, $info, $prefetchCallable);
 
                         array_unshift($toPassPrefetchArgs, $sources);
                         assert(is_callable($prefetchCallable));
                         $prefetchResult = $prefetchCallable(...$toPassPrefetchArgs);
-                        $prefetchBuffer->storeResult($prefetchResult, $args);
+                        $prefetchBuffer->storeResult($prefetchResult, $sources);
                     } else {
-                        $prefetchResult = $prefetchBuffer->getResult($args);
+                        $prefetchResult = $prefetchBuffer->getResult($sources);
                     }
 
                     foreach ($arguments as $argument) {

--- a/tests/Fixtures/Integration/Controllers/BlogController.php
+++ b/tests/Fixtures/Integration/Controllers/BlogController.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Controllers;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Blog;
+
+class BlogController
+{
+    /** @return Blog[] */
+    #[Query]
+    public function getBlogs(): array
+    {
+        return [
+            new Blog(1),
+            new Blog(2),
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/Models/Blog.php
+++ b/tests/Fixtures/Integration/Models/Blog.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+#[Type]
+class Blog
+{
+    public function __construct(
+        private int $id,
+    ) {
+    }
+
+    #[Field(outputType: 'ID!')]
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param Post[][] $prefetchedPosts
+     * @return Post[]
+     */
+    #[Field(prefetchMethod: 'prefetchPosts')]
+    public function getPosts(array $prefetchedPosts): array
+    {
+        return $prefetchedPosts[$this->id] ?? [];
+    }
+
+    /**
+     * @param Blog[][] $prefetchedSubBlogs
+     * @return Blog[]
+     */
+    #[Field(prefetchMethod: 'prefetchSubBlogs')]
+    public function getSubBlogs(array $prefetchedSubBlogs): array
+    {
+        return $prefetchedSubBlogs[$this->id] ?? [];
+    }
+
+    /**
+     * @param self[] $blogs
+     * @return Post[][]
+     */
+    public function prefetchPosts(array $blogs): array
+    {
+        $posts = [];
+        foreach ($blogs as $blog) {
+            $blogId = $blog->getId();
+            $posts[$blogId][] = new Post("post-$blogId.1");
+            $posts[$blogId][] = new Post("post-$blogId.2");
+        }
+        return $posts;
+    }
+
+    /**
+     * @param self[] $blogs
+     * @return Blog[][]
+     */
+    public function prefetchSubBlogs(array $blogs): array
+    {
+        $subBlogs = [];
+        foreach ($blogs as $blog) {
+            $blogId = $blog->getId();
+            $subBlogId = $blogId * 10;
+            $subBlogs[$blogId][] = new Blog($subBlogId);
+        }
+        return $subBlogs;
+    }
+}

--- a/tests/Fixtures/Integration/Models/Comment.php
+++ b/tests/Fixtures/Integration/Models/Comment.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+#[Type]
+class Comment
+{
+    public function __construct(
+        private string $text
+    ) {
+    }
+
+    #[Field]
+    public function getText(): string
+    {
+        return $this->text;
+    }
+}

--- a/tests/Fixtures/Integration/Models/Post.php
+++ b/tests/Fixtures/Integration/Models/Post.php
@@ -98,6 +98,29 @@ class Post
     }
 
     /**
+     * @param Comment[][] $prefetchedComments
+     * @return Comment[]
+     */
+    #[Field(prefetchMethod: 'prefetchComments')]
+    public function getComments(array $prefetchedComments): array
+    {
+        return $prefetchedComments[$this->title] ?? [];
+    }
+
+    /**
+     * @param self[] $posts
+     * @return Comment[][]
+     */
+    public function prefetchComments(array $posts): array
+    {
+        $comments = [];
+        foreach ($posts as $post) {
+            $comments[$post->title][] = new Comment("comment for $post->title");
+        }
+        return $comments;
+    }
+
+    /**
      * @param string $inaccessible
      */
     private function setInaccessible(string $inaccessible): void


### PR DESCRIPTION
Fix bug of calling prefetch method only once with not all type objects when prefetching is on different nesting levels.

Running the new test without the fix shows that prefetchPosts is only called once with Blog 1 and 2. But it should be called with Blog 1, 2, 10, and 20. Therefor Blog 10 and 20 have no Posts, but they should (see expected results).
With this fix, prefetchPosts gets called two time. Once with Blog 1,2 and once with Blog 1,2,10,20. This solves the Problem, but is not the best solution. It wohl be better it gets called only once with all Blogs. But that i could not get working.