### PR TITLE
Determine union type name via naming strategy

### DIFF
--- a/src/Mappers/Root/CompoundTypeMapper.php
+++ b/src/Mappers/Root/CompoundTypeMapper.php
@@ -23,6 +23,7 @@ use ReflectionProperty;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\UnionType;
 
@@ -38,8 +39,13 @@ use function iterator_to_array;
  */
 class CompoundTypeMapper implements RootTypeMapperInterface
 {
-    public function __construct(private RootTypeMapperInterface $next, private RootTypeMapperInterface $topRootTypeMapper, private TypeRegistry $typeRegistry, private RecursiveTypeMapperInterface $recursiveTypeMapper)
-    {
+    public function __construct(
+        private RootTypeMapperInterface $next,
+        private RootTypeMapperInterface $topRootTypeMapper,
+        private NamingStrategyInterface $namingStrategy,
+        private TypeRegistry $typeRegistry,
+        private RecursiveTypeMapperInterface $recursiveTypeMapper,
+    ) {
     }
 
     public function toGraphQLOutputType(Type $type, OutputType|null $subType, ReflectionMethod|ReflectionProperty $reflector, DocBlock $docBlockObj): OutputType
@@ -144,7 +150,7 @@ class CompoundTypeMapper implements RootTypeMapperInterface
                 throw CannotMapTypeException::createForBadTypeInUnion($unionTypes);
             }
 
-            $graphQlType = new UnionType($nonNullableUnionTypes, $this->recursiveTypeMapper);
+            $graphQlType = new UnionType($nonNullableUnionTypes, $this->recursiveTypeMapper, $this->namingStrategy);
             $graphQlType = $this->typeRegistry->getOrRegisterType($graphQlType);
             assert($graphQlType instanceof UnionType);
         }

--- a/src/NamingStrategy.php
+++ b/src/NamingStrategy.php
@@ -8,6 +8,7 @@ use TheCodingMachine\GraphQLite\Annotations\Factory;
 use TheCodingMachine\GraphQLite\Annotations\Input;
 use TheCodingMachine\GraphQLite\Annotations\TypeInterface;
 
+use function implode;
 use function lcfirst;
 use function str_ends_with;
 use function str_replace;
@@ -108,5 +109,15 @@ class NamingStrategy implements NamingStrategyInterface
         }
 
         return $methodName;
+    }
+
+    /**
+     * Returns the name of a GraphQL union type based on the included types.
+     *
+     * @param string[] $typeNames The list of GraphQL type names
+     */
+    public function getUnionTypeName(array $typeNames): string
+    {
+        return 'Union' . implode('', $typeNames);
     }
 }

--- a/src/NamingStrategyInterface.php
+++ b/src/NamingStrategyInterface.php
@@ -44,4 +44,11 @@ interface NamingStrategyInterface
      * Returns the name of a GraphQL input field from the name of the annotated method.
      */
     public function getInputFieldNameFromMethodName(string $methodName): string;
+
+    /**
+     * Returns the name of a GraphQL union type based on the included types.
+     *
+     * @param string[] $typeNames The list of GraphQL type names
+     */
+    public function getUnionTypeName(array $typeNames): string;
 }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -407,7 +407,7 @@ class SchemaFactory
             }
         }
 
-        $rootTypeMapper = new CompoundTypeMapper($rootTypeMapper, $topRootTypeMapper, $typeRegistry, $recursiveTypeMapper);
+        $rootTypeMapper = new CompoundTypeMapper($rootTypeMapper, $topRootTypeMapper, $namingStrategy, $typeRegistry, $recursiveTypeMapper);
         $rootTypeMapper = new IteratorTypeMapper($rootTypeMapper, $topRootTypeMapper);
 
         $topRootTypeMapper->setNext($rootTypeMapper);

--- a/src/Types/UnionType.php
+++ b/src/Types/UnionType.php
@@ -7,22 +7,31 @@ namespace TheCodingMachine\GraphQLite\Types;
 use GraphQL\Type\Definition\ObjectType;
 use InvalidArgumentException;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
+use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 
+use function array_map;
 use function gettype;
 use function is_object;
 
 class UnionType extends \GraphQL\Type\Definition\UnionType
 {
     /** @param array<int,ObjectType> $types */
-    public function __construct(array $types, RecursiveTypeMapperInterface $typeMapper)
+    public function __construct(
+        array $types,
+        RecursiveTypeMapperInterface $typeMapper,
+        NamingStrategyInterface $namingStrategy,
+    )
     {
-        $name = 'Union';
+        // Make sure all types are object types
         foreach ($types as $type) {
-            $name .= $type->name;
             if (! $type instanceof ObjectType) {
                 throw InvalidTypesInUnionException::notObjectType();
             }
         }
+
+        $typeNames = array_map(static fn (ObjectType $type) => $type->name, $types);
+        $name = $namingStrategy->getUnionTypeName($typeNames);
+
         parent::__construct([
             'name' => $name,
             'types' => $types,

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -351,6 +351,7 @@ abstract class AbstractQueryProviderTest extends TestCase
         $rootTypeMapper = new CompoundTypeMapper(
             $rootTypeMapper,
             $topRootTypeMapper,
+            new NamingStrategy(),
             $this->getTypeRegistry(),
             $this->getTypeMapper()
         );

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -296,7 +296,7 @@ class EndToEndTest extends TestCase
                 if (interface_exists(UnitEnum::class)) {
                     $rootTypeMapper = new EnumTypeMapper($rootTypeMapper, $container->get(AnnotationReader::class), new ArrayAdapter(), [ $container->get(NamespaceFactory::class)->createNamespace('TheCodingMachine\\GraphQLite\\Fixtures81\\Integration\\Models') ]);
                 }
-                $rootTypeMapper = new CompoundTypeMapper($rootTypeMapper, $container->get(RootTypeMapperInterface::class), $container->get(TypeRegistry::class), $container->get(RecursiveTypeMapperInterface::class));
+                $rootTypeMapper = new CompoundTypeMapper($rootTypeMapper, $container->get(RootTypeMapperInterface::class), $container->get(NamingStrategyInterface::class), $container->get(TypeRegistry::class), $container->get(RecursiveTypeMapperInterface::class));
                 $rootTypeMapper = new IteratorTypeMapper($rootTypeMapper, $container->get(RootTypeMapperInterface::class));
                 return $rootTypeMapper;
             },

--- a/tests/Mappers/Root/CompoundTypeMapperTest.php
+++ b/tests/Mappers/Root/CompoundTypeMapperTest.php
@@ -11,6 +11,7 @@ use ReflectionMethod;
 use RuntimeException;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
+use TheCodingMachine\GraphQLite\NamingStrategy;
 
 class CompoundTypeMapperTest extends AbstractQueryProviderTest
 {
@@ -19,6 +20,7 @@ class CompoundTypeMapperTest extends AbstractQueryProviderTest
         $compoundTypeMapper = new CompoundTypeMapper(
             new FinalRootTypeMapper($this->getTypeMapper()),
             new FinalRootTypeMapper($this->getTypeMapper()),
+            new NamingStrategy(),
             $this->getTypeRegistry(),
             $this->getTypeMapper()
         );
@@ -32,6 +34,7 @@ class CompoundTypeMapperTest extends AbstractQueryProviderTest
         $compoundTypeMapper = new CompoundTypeMapper(
             new FinalRootTypeMapper($this->getTypeMapper()),
             new FinalRootTypeMapper($this->getTypeMapper()),
+            new NamingStrategy(),
             $this->getTypeRegistry(),
             $this->getTypeMapper()
         );

--- a/tests/NamingStrategyTest.php
+++ b/tests/NamingStrategyTest.php
@@ -9,7 +9,6 @@ use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 
 class NamingStrategyTest extends TestCase
 {
-
     public function testGetInputTypeName(): void
     {
         $namingStrategy = new NamingStrategy();
@@ -42,5 +41,14 @@ class NamingStrategyTest extends TestCase
 
         $name = $namingStrategy->getOutputTypeName(TestObject::class, $type);
         $this->assertSame('foo', $name);
+    }
+
+    public function testGetUnionTypeName(): void
+    {
+        $namingStrategy = new NamingStrategy();
+
+        $typeNames = ['Some', 'Arbitrary', 'Type', 'Names'];
+        $name = $namingStrategy->getUnionTypeName($typeNames);
+        $this->assertSame('UnionSomeArbitraryTypeNames', $name);
     }
 }

--- a/tests/Types/UnionTypeTest.php
+++ b/tests/Types/UnionTypeTest.php
@@ -8,12 +8,13 @@ use PHPUnit\Framework\TestCase;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
+use TheCodingMachine\GraphQLite\NamingStrategy;
 
 class UnionTypeTest extends AbstractQueryProviderTest
 {
     public function testConstructor(): void
     {
-        $unionType = new UnionType([$this->getTestObjectType(), $this->getTestObjectType2()], $this->getTypeMapper());
+        $unionType = new UnionType([$this->getTestObjectType(), $this->getTestObjectType2()], $this->getTypeMapper(), new NamingStrategy());
         $resolveInfo = $this->getMockBuilder(ResolveInfo::class)->disableOriginalConstructor()->getMock();
         $type = $unionType->resolveType(new TestObject('foo'), null, $resolveInfo);
         $this->assertSame($this->getTestObjectType(), $type);
@@ -23,7 +24,7 @@ class UnionTypeTest extends AbstractQueryProviderTest
 
     public function testException(): void
     {
-        $unionType = new UnionType([$this->getTestObjectType(), $this->getTestObjectType2()], $this->getTypeMapper());
+        $unionType = new UnionType([$this->getTestObjectType(), $this->getTestObjectType2()], $this->getTypeMapper(), new NamingStrategy());
         $this->expectException(\InvalidArgumentException::class);
         $resolveInfo = $this->getMockBuilder(ResolveInfo::class)->disableOriginalConstructor()->getMock();
         $unionType->resolveType('foo', null, $resolveInfo);
@@ -32,6 +33,6 @@ class UnionTypeTest extends AbstractQueryProviderTest
     public function testException2(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        new UnionType([new StringType()], $this->getTypeMapper());
+        new UnionType([new StringType()], $this->getTypeMapper(), new NamingStrategy());
     }
 }


### PR DESCRIPTION
Hey there,

this PR moves the hardcoded naming logic of union types constructed from compound PHP types from the UnionType class to NamingStrategy.

I have chosen to pass in the type names that the union consist of as input. If you feel it makes more sense to inject the underlying type objects, let me know.