### PR TITLE
Fix AnnotationReader returning Input classes as Type classes.

### DIFF
--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -235,8 +235,7 @@ class AnnotationReader
     public function getTypeAnnotation(ReflectionClass $refClass): TypeInterface|null
     {
         try {
-            $type = $this->getClassAnnotation($refClass, Type::class)
-                ?? $this->getClassAnnotation($refClass, Input::class);
+            $type = $this->getClassAnnotation($refClass, Type::class);
 
             if ($type !== null && $type->isSelfType()) {
                 $type->setClass($refClass->getName());


### PR DESCRIPTION
This fixes the issue described in #531 that would result in error "Cached type in registry is not the type returned by type mapper" when using Input types in mutations via variables.