### PR TITLE
Preserve type already added

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -79,7 +79,7 @@ class Schema extends \GraphQL\Type\Schema
         if (is_callable($preservedType)) {
             $preservedType = $preservedType();
         }
-        $config->setTypes([...$preservedType, ...$recursiveTypeMapper->getOutputTypes()]);
+        $config->setTypes(array_merge($preservedType, $recursiveTypeMapper->getOutputTypes()));
     
 
         $config->setTypeLoader(static function (string $name) use ($query, $mutation, $rootTypeMapper) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -74,9 +74,13 @@ class Schema extends \GraphQL\Type\Schema
         $config->setQuery($query);
         $config->setMutation($mutation);
 
-        $config->setTypes(static function () use ($recursiveTypeMapper) {
-            return $recursiveTypeMapper->getOutputTypes();
-        });
+
+        $preservedType = $config->getTypes();
+        if (is_callable($preservedType)) {
+            $preservedType = $preservedType();
+        }
+        $config->setTypes([...$preservedType, ...$recursiveTypeMapper->getOutputTypes()]);
+    
 
         $config->setTypeLoader(static function (string $name) use ($query, $mutation, $rootTypeMapper) {
             // We need to find a type FROM a GraphQL type name


### PR DESCRIPTION
Hello,

With this PR this code will preserve MyCustomInputType

```php
        $factory = new SchemaFactory();
        $factory->setSchemaConfig(SchemaConfig::create([
            'types' => [
                MyCustomInputType::getInstance()
            ]
        ]));

       $schema = $factory->createSchema();
```