### PR TITLE
Update docusaurus and lock node to v16

### DIFF
--- a/.github/workflows/doc_generation.yml
+++ b/.github/workflows/doc_generation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Setup NodeJS"
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '16.x'
 
       - name: "Yarn install"
         run: yarn install

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {},
   "dependencies": {
     "@docusaurus/core": "2.2.0",
-    "@docusaurus/preset-classic": "2.0.0-beta.21",
+    "@docusaurus/preset-classic": "2.2.0",
     "clsx": "^1.1.1",
     "mdx-mermaid": "^1.2.3",
     "mermaid": "^8.12.0",


### PR DESCRIPTION
Get `docusaurus/preset-classic` in version sync with `docusaurus/core`.  However, there is a node incompatibility in the latest versions of `docusaurus/preset-classic`.  So, we're locking to v16 LTS for now.