### PR TITLE
fix Enum not resolved in first level input arguments

### DIFF
--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -30,6 +30,7 @@ use TheCodingMachine\GraphQLite\Types\MutableInterfaceType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 
+use UnitEnum;
 use function assert;
 
 /**
@@ -114,6 +115,13 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
         $classes = $this->getClassList();
 
         foreach ($classes as $className => $refClass) {
+            // Enum's are not types
+            if (interface_exists(UnitEnum::class)) {
+                // @phpstan-ignore-next-line - Remove this after minimum supported PHP version is >= 8.1
+                if ($refClass->isEnum()) {
+                    continue;
+                }
+            }
             $annotationsCache = $this->mapClassToAnnotationsCache->get($refClass, function () use ($refClass, $className) {
                 $annotationsCache = new GlobAnnotationsCache();
 
@@ -186,6 +194,13 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
 
         $classes = $this->getClassList();
         foreach ($classes as $refClass) {
+            // Enum's are not types
+            if (interface_exists(UnitEnum::class)) {
+                // @phpstan-ignore-next-line - Remove this after minimum supported PHP version is >= 8.1
+                if ($refClass->isEnum()) {
+                    continue;
+                }
+            }
             $annotationsCache = $this->mapClassToExtendAnnotationsCache->get($refClass, function () use ($refClass) {
                 $extendAnnotationsCache = new GlobExtendAnnotationsCache();
 

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -116,11 +116,8 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
 
         foreach ($classes as $className => $refClass) {
             // Enum's are not types
-            if (interface_exists(UnitEnum::class)) {
-                // @phpstan-ignore-next-line - Remove this after minimum supported PHP version is >= 8.1
-                if ($refClass->isEnum()) {
-                    continue;
-                }
+            if ($refClass->isEnum()) {
+                continue;
             }
             $annotationsCache = $this->mapClassToAnnotationsCache->get($refClass, function () use ($refClass, $className) {
                 $annotationsCache = new GlobAnnotationsCache();
@@ -195,11 +192,8 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
         $classes = $this->getClassList();
         foreach ($classes as $refClass) {
             // Enum's are not types
-            if (interface_exists(UnitEnum::class)) {
-                // @phpstan-ignore-next-line - Remove this after minimum supported PHP version is >= 8.1
-                if ($refClass->isEnum()) {
-                    continue;
-                }
+            if ($refClass->isEnum()) {
+                continue;
             }
             $annotationsCache = $this->mapClassToExtendAnnotationsCache->get($refClass, function () use ($refClass) {
                 $extendAnnotationsCache = new GlobExtendAnnotationsCache();

--- a/src/Mappers/Root/EnumTypeMapper.php
+++ b/src/Mappers/Root/EnumTypeMapper.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type as GraphQLType;
+use MyCLabs\Enum\Enum;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Object_;
@@ -94,12 +95,13 @@ class EnumTypeMapper implements RootTypeMapperInterface
     /** @param class-string $enumClass */
     private function mapByClassName(string $enumClass): EnumType|null
     {
-        if (isset($this->cache[$enumClass])) {
-            return $this->cache[$enumClass];
-        }
-
         if (! enum_exists($enumClass)) {
             return null;
+        }
+        /** @var class-string<Enum> $enumClass */
+        $enumClass = ltrim($enumClass, '\\');
+        if (isset($this->cache[$enumClass])) {
+            return $this->cache[$enumClass];
         }
 
         // phpcs:disable SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
@@ -119,7 +121,7 @@ class EnumTypeMapper implements RootTypeMapperInterface
 
         $type = new EnumType($enumClass, $typeName, $useValues);
 
-        return $this->cacheByName[$typeName] = $this->cache[$enumClass] = $type;
+        return $this->cacheByName[$type->name] = $this->cache[$enumClass] = $type;
     }
 
     private function getTypeName(ReflectionClass $reflectionClass): string
@@ -178,7 +180,6 @@ class EnumTypeMapper implements RootTypeMapperInterface
                 return $nameToClassMapping;
             });
         }
-
         return $this->nameToClassMapping;
     }
 }

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -61,13 +61,6 @@ final class NS
                 }
 
                 $refClass = new ReflectionClass($className);
-                // Enum's are not classes
-                if (interface_exists(UnitEnum::class)) {
-                    // @phpstan-ignore-next-line - Remove this after minimum supported PHP version is >= 8.1
-                    if ($refClass->isEnum()) {
-                        continue;
-                    }
-                }
 
                 $this->classes[$className] = $refClass;
             }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1175,7 +1175,6 @@ class EndToEndTest extends TestCase
         $this->assertSame(['echoProductType' => 'NON_FOOD'], $this->getSuccessResult($result));
     }
 
-    /** @requires PHP >= 8.1 */
     public function testEndToEndMutationNativeEnums(): void
     {
         $schema = $this->mainContainer->get(Schema::class);
@@ -1232,7 +1231,6 @@ class EndToEndTest extends TestCase
         ], $this->getSuccessResult($result));
     }
 
-    /** @requires PHP >= 8.1 */
     public function testEndToEndNativeEnums(): void
     {
         $schema = $this->mainContainer->get(Schema::class);

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1176,6 +1176,63 @@ class EndToEndTest extends TestCase
     }
 
     /** @requires PHP >= 8.1 */
+    public function testEndToEndMutationNativeEnums(): void
+    {
+        $schema = $this->mainContainer->get(Schema::class);
+        assert($schema instanceof Schema);
+
+        $gql = '
+        mutation($size:Size!) {
+            singleEnum(size: $size)
+        }
+        ';
+        $result = GraphQL::executeQuery(
+            $schema,
+            $gql,
+            variableValues: [
+                'size' => Size::L->name,
+            ],
+        );
+
+        $this->assertSame([
+            'singleEnum' => 'L',
+        ], $this->getSuccessResult($result));
+    }
+
+    public function testEndToEndInputVars(): void
+    {
+        $schema = $this->mainContainer->get(Schema::class);
+        assert($schema instanceof Schema);
+
+        $queryString = '
+            mutation ($contact: ContactInput!) {
+                saveContact(contact: $contact) {
+                    name,
+                    birthDate
+                }
+            }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            $queryString,
+            variableValues: [
+                'contact' => [
+                    'name' => "foo",
+                    'birthDate' => "1942-12-24T00:00:00+00:00"
+                ]
+            ]
+        );
+
+        $this->assertSame([
+            'saveContact' => [
+                'name' => 'foo',
+                'birthDate' => '1942-12-24T00:00:00+00:00'
+            ],
+        ], $this->getSuccessResult($result));
+    }
+
+    /** @requires PHP >= 8.1 */
     public function testEndToEndNativeEnums(): void
     {
         $schema = $this->mainContainer->get(Schema::class);


### PR DESCRIPTION
Fixes  #536

The mentioned merge in the ticket above doesn't actually fix this.

Due to a missing ltrim not being carried over from the MyClabsEnumTypeMapper the FQCN of the enum most of the time had a leading backslash resulting it not being found in the cache or duplication once with and once without leading backslash.

Excluding of enums for Types is not done on the NS getClassList method but rather later in the AbstractTypeMapper so EnumTypeMapper can actually find Enums (this whole implementation was previously working by accident)

The existing TestCase only worked because the same Enum was used as Input directly without passing them as variables, removing that testcase resulted in the singleEnum mutation to fail with the typical "check your typemapper configuration".

We also added a additional TestCase to use variables for Types since variables are probably what a client like ApolloClient would send, but allmost all testcases just have the raw values directly in the document which bypasses a lot of graphql-php validation rules.