### PR TITLE
Change private properties to protected in GraphQLException

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
     level: 8
     checkGenericClassInNonGenericObjectType: false
     reportUnmatchedIgnoredErrors: false
+    treatPhpDocTypesAsCertain: false
     ignoreErrors:
         - "#PHPDoc tag \\@throws with type Psr\\\\Container\\\\ContainerExceptionInterface is not subtype of Throwable#"
         - "#Parameter .* of class ReflectionMethod constructor expects string(\\|null)?, object\\|string given.#"

--- a/src/Exceptions/GraphQLException.php
+++ b/src/Exceptions/GraphQLException.php
@@ -10,8 +10,13 @@ use Throwable;
 class GraphQLException extends Exception implements GraphQLExceptionInterface
 {
     /** @param array<string, mixed> $extensions */
-    public function __construct(string $message, int $code = 0, Throwable|null $previous = null, private string $category = 'Exception', private array $extensions = [])
-    {
+    public function __construct(
+        string $message,
+        int $code = 0,
+        Throwable|null $previous = null,
+        protected string $category = 'Exception',
+        protected array $extensions = [],
+    ) {
         parent::__construct($message, $code, $previous);
     }
 

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -30,7 +30,7 @@ use function str_replace;
  */
 final class GlobControllerQueryProvider implements QueryProviderInterface
 {
-    /** @var array<string,string>|null */
+    /** @var array<int,string>|null */
     private array|null $instancesList = null;
     private ClassNameMapper $classNameMapper;
     private AggregateControllerQueryProvider|null $aggregateControllerQueryProvider = null;
@@ -73,9 +73,11 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
     private function getInstancesList(): array
     {
         if ($this->instancesList === null) {
-            $this->instancesList = $this->cacheContract->get('globQueryProvider', function () {
-                return $this->buildInstancesList();
-            });
+            $this->instancesList = $this->cacheContract->get(
+                'globQueryProvider',
+                fn () => $this->buildInstancesList(),
+            );
+
             if (! is_array($this->instancesList)) {
                 throw new InvalidArgumentException('The instance list returned is not an array. There might be an issue with your PSR-16 cache implementation.');
             }

--- a/src/Mappers/Root/MyCLabsEnumTypeMapper.php
+++ b/src/Mappers/Root/MyCLabsEnumTypeMapper.php
@@ -34,18 +34,36 @@ class MyCLabsEnumTypeMapper implements RootTypeMapperInterface
     /** @var array<string, EnumType> */
     private array $cacheByName = [];
 
+    /** @var array<string, class-string<Enum>> */
+    private array|null $nameToClassMapping = null;
+
     /** @param NS[] $namespaces List of namespaces containing enums. Used when searching an enum by name. */
-    public function __construct(private readonly RootTypeMapperInterface $next, private readonly AnnotationReader $annotationReader, private readonly CacheInterface $cacheService, private readonly array $namespaces)
-    {
+    public function __construct(
+        private readonly RootTypeMapperInterface $next,
+        private readonly AnnotationReader $annotationReader,
+        private readonly CacheInterface $cacheService,
+        private readonly array $namespaces,
+    ) {
     }
 
-    public function toGraphQLOutputType(Type $type, OutputType|null $subType, ReflectionMethod|ReflectionProperty $reflector, DocBlock $docBlockObj): OutputType&\GraphQL\Type\Definition\Type
+    public function toGraphQLOutputType(
+        Type $type,
+        OutputType|null $subType,
+        ReflectionMethod|ReflectionProperty $reflector,
+        DocBlock $docBlockObj,
+    ): OutputType&\GraphQL\Type\Definition\Type
     {
         $result = $this->map($type);
         return $result ?? $this->next->toGraphQLOutputType($type, $subType, $reflector, $docBlockObj);
     }
 
-    public function toGraphQLInputType(Type $type, InputType|null $subType, string $argumentName, ReflectionMethod|ReflectionProperty $reflector, DocBlock $docBlockObj): InputType&\GraphQL\Type\Definition\Type
+    public function toGraphQLInputType(
+        Type $type,
+        InputType|null $subType,
+        string $argumentName,
+        ReflectionMethod|ReflectionProperty $reflector,
+        DocBlock $docBlockObj,
+    ): InputType&\GraphQL\Type\Definition\Type
     {
         $result = $this->map($type);
         return $result ?? $this->next->toGraphQLInputType($type, $subType, $argumentName, $reflector, $docBlockObj);
@@ -130,9 +148,6 @@ class MyCLabsEnumTypeMapper implements RootTypeMapperInterface
 
         return $this->next->mapNameToType($typeName);
     }
-
-    /** @var array<string, class-string<Enum>> */
-    private array|null $nameToClassMapping = null;
 
     /**
      * Go through all classes in the defined namespaces and loads the cache.

--- a/src/Mappers/Root/MyCLabsEnumTypeMapper.php
+++ b/src/Mappers/Root/MyCLabsEnumTypeMapper.php
@@ -101,6 +101,7 @@ class MyCLabsEnumTypeMapper implements RootTypeMapperInterface
         return $this->cacheByName[$type->name] = $this->cache[$enumClass] = $type;
     }
 
+
     private function getTypeName(ReflectionClass $refClass): string
     {
         $enumType = $this->annotationReader->getEnumTypeAnnotation($refClass);
@@ -165,6 +166,7 @@ class MyCLabsEnumTypeMapper implements RootTypeMapperInterface
                             continue;
                         }
 
+                        /** @var class-string<Enum> $className */
                         $nameToClassMapping[$this->getTypeName($classRef)] = $className;
                     }
                 }

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -30,15 +30,20 @@ final class NS
     private array|null $classes = null;
 
     /** @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation) */
-    public function __construct(private readonly string $namespace, private readonly CacheInterface $cache, private readonly ClassNameMapper $classNameMapper, private readonly int|null $globTTL, private readonly bool $recursive)
-    {
+    public function __construct(
+        private readonly string $namespace,
+        private readonly CacheInterface $cache,
+        private readonly ClassNameMapper $classNameMapper,
+        private readonly int|null $globTTL,
+        private readonly bool $recursive,
+    ) {
     }
 
     /**
      * Returns the array of globbed classes.
      * Only instantiable classes are returned.
      *
-     * @return array<string,ReflectionClass<object>> Key: fully qualified class name
+     * @return array<class-string,ReflectionClass<object>> Key: fully qualified class name
      */
     public function getClassList(): array
     {

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -50,8 +50,8 @@ final class NS
         if ($this->classes === null) {
             $this->classes = [];
             $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->globTTL, $this->classNameMapper, $this->recursive);
+            /** @var array<class-string, string> $classes Override class-explorer lib */
             $classes = $explorer->getClassMap();
-            /** @var class-string $className */
             foreach ($classes as $className => $phpFile) {
                 if (! class_exists($className, false) && ! interface_exists($className, false)) {
                     // Let's try to load the file if it was not imported yet.
@@ -72,6 +72,7 @@ final class NS
             }
         }
 
+        // @phpstan-ignore-next-line - Not sure why we cannot annotate the $classes above
         return $this->classes;
     }
 

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -50,6 +50,7 @@ final class NS
         if ($this->classes === null) {
             $this->classes = [];
             $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->globTTL, $this->classNameMapper, $this->recursive);
+            /** @var array<class-string, string> $classes Override class-explorer lib */
             $classes = $explorer->getClassMap();
             foreach ($classes as $className => $phpFile) {
                 if (! class_exists($className, false) && ! interface_exists($className, false)) {

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -50,8 +50,8 @@ final class NS
         if ($this->classes === null) {
             $this->classes = [];
             $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->globTTL, $this->classNameMapper, $this->recursive);
-            /** @var array<class-string, string> $classes Override class-explorer lib */
             $classes = $explorer->getClassMap();
+            /** @var class-string $className */
             foreach ($classes as $className => $phpFile) {
                 if (! class_exists($className, false) && ! interface_exists($className, false)) {
                     // Let's try to load the file if it was not imported yet.


### PR DESCRIPTION
By locking down these properties, especially the `extensions` property, you're unable to modify the extensions after the construction of an Exception.  There are many use cases where this may be necessary and there isn't any known need to be so restrictive with access to these properties.  It's very common to extend this base `GraphQLException` class and custom Exceptions need more freedom to compose objects according to business logic.