### PR TITLE
Fix handling of native union types containing null

### DIFF
--- a/src/Mappers/Root/NullableTypeMapperAdapter.php
+++ b/src/Mappers/Root/NullableTypeMapperAdapter.php
@@ -126,7 +126,7 @@ class NullableTypeMapperAdapter implements RootTypeMapperInterface
             return null;
         }
         if ($type instanceof Nullable) {
-            return $type->getActualType();
+            return $this->getNonNullable($type->getActualType());
         }
         if ($type instanceof Compound) {
             $types = array_map([$this, 'getNonNullable'], iterator_to_array($type));

--- a/tests/Mappers/Root/NullableTypeMapperAdapterTest.php
+++ b/tests/Mappers/Root/NullableTypeMapperAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace TheCodingMachine\GraphQLite\Mappers\Root;
 
+use Generator;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\NonNull;
@@ -10,6 +11,7 @@ use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Nullable;
 use ReflectionMethod;
 use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
@@ -18,13 +20,27 @@ use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 
 class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
 {
-    public function testMultipleCompound(): void
+	/**
+	 * @dataProvider nullableVariationsProvider
+	 */
+    public function testMultipleCompound(callable $type): void
     {
         $compoundTypeMapper = $this->getRootTypeMapper();
 
-        $result = $compoundTypeMapper->toGraphQLOutputType($this->resolveType(TestObject::class.'|'.TestObject2::class.'|null'), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
+        $result = $compoundTypeMapper->toGraphQLOutputType($type(), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
         $this->assertNotInstanceOf(NonNull::class, $result);
     }
+
+	public function nullableVariationsProvider(): Generator
+	{
+		yield 'php documentor generated from phpdoc' => [
+			fn () => $this->resolveType(TestObject::class.'|'.TestObject2::class.'|null'),
+		];
+
+		yield 'type handler nullable wrapped native reflection union type' => [
+			fn () => new Nullable($this->resolveType(TestObject::class.'|'.TestObject2::class.'|null')),
+		];
+	}
 
     public function testOnlyNull(): void
     {

--- a/tests/Mappers/Root/NullableTypeMapperAdapterTest.php
+++ b/tests/Mappers/Root/NullableTypeMapperAdapterTest.php
@@ -20,9 +20,9 @@ use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 
 class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
 {
-	/**
-	 * @dataProvider nullableVariationsProvider
-	 */
+    /**
+     * @dataProvider nullableVariationsProvider
+     */
     public function testMultipleCompound(callable $type): void
     {
         $compoundTypeMapper = $this->getRootTypeMapper();
@@ -31,16 +31,16 @@ class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
         $this->assertNotInstanceOf(NonNull::class, $result);
     }
 
-	public function nullableVariationsProvider(): Generator
-	{
-		yield 'php documentor generated from phpdoc' => [
-			fn () => $this->resolveType(TestObject::class.'|'.TestObject2::class.'|null'),
-		];
+    public function nullableVariationsProvider(): Generator
+    {
+        yield 'php documentor generated from phpdoc' => [
+            fn () => $this->resolveType(TestObject::class . '|' . TestObject2::class . '|null'),
+        ];
 
-		yield 'type handler nullable wrapped native reflection union type' => [
-			fn () => new Nullable($this->resolveType(TestObject::class.'|'.TestObject2::class.'|null')),
-		];
-	}
+        yield 'type handler nullable wrapped native reflection union type' => [
+            fn () => new Nullable($this->resolveType(TestObject::class . '|' . TestObject2::class . '|null')),
+        ];
+    }
 
     public function testOnlyNull(): void
     {
@@ -85,6 +85,6 @@ class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
 
         $this->expectException(CannotMapTypeException::class);
         $this->expectExceptionMessage('a type mapper returned a GraphQL\\Type\\Definition\\NonNull instance.');
-        $typeMapper->toGraphQLOutputType($this->resolveType(TestObject::class.'|'.TestObject2::class.'|null'), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
+        $typeMapper->toGraphQLOutputType($this->resolveType(TestObject::class . '|' . TestObject2::class . '|null'), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
     }
 }


### PR DESCRIPTION
Closes #567

TypeHandler wraps native types in `Nullable` if they allow null, even if it's a union with `null` being one of the types. I figured a fix in `NullableTypeMapper` would be needed anyway, in case someone wrongfully does the same, and haven't touched the `TypeHandler` to avoid recursively iterating through types in it.