### PR TITLE
Fix authorization middleware on long running servers

### DIFF
--- a/src/InputField.php
+++ b/src/InputField.php
@@ -13,7 +13,6 @@ use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;
-use TheCodingMachine\GraphQLite\Middlewares\MissingAuthorizationException;
 use TheCodingMachine\GraphQLite\Middlewares\ResolverInterface;
 use TheCodingMachine\GraphQLite\Middlewares\SourceResolverInterface;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
@@ -121,25 +120,6 @@ final class InputField extends InputObjectField
     public function forConstructorHydration(): bool
     {
         return $this->forConstructorHydration;
-    }
-
-    /**
-     * @param bool $isNotLogged False if the user is logged (and the error is a 403), true if the error is unlogged (the error is a 401)
-     *
-     * @return InputField
-     */
-    public static function unauthorizedError(InputFieldDescriptor $fieldDescriptor, bool $isNotLogged): self
-    {
-        $callable = static function () use ($isNotLogged): void {
-            if ($isNotLogged) {
-                throw MissingAuthorizationException::unauthorized();
-            }
-            throw MissingAuthorizationException::forbidden();
-        };
-
-        $fieldDescriptor->setResolver($callable);
-
-        return self::fromDescriptor($fieldDescriptor);
     }
 
     private static function fromDescriptor(InputFieldDescriptor $fieldDescriptor): self

--- a/src/QueryField.php
+++ b/src/QueryField.php
@@ -15,7 +15,6 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use TheCodingMachine\GraphQLite\Context\ContextInterface;
 use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;
-use TheCodingMachine\GraphQLite\Middlewares\MissingAuthorizationException;
 use TheCodingMachine\GraphQLite\Middlewares\ResolverInterface;
 use TheCodingMachine\GraphQLite\Middlewares\SourceResolverInterface;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
@@ -143,6 +142,7 @@ final class QueryField extends FieldDefinition
         }
 
         $config += $additionalConfig;
+
         parent::__construct($config);
     }
 
@@ -179,25 +179,6 @@ final class QueryField extends FieldDefinition
     {
         $callable = static function () use ($value) {
             return $value;
-        };
-
-        $fieldDescriptor->setResolver($callable);
-
-        return self::fromDescriptor($fieldDescriptor);
-    }
-
-    /**
-     * @param bool $isNotLogged False if the user is logged (and the error is a 403), true if the error is unlogged (the error is a 401)
-     *
-     * @return QueryField
-     */
-    public static function unauthorizedError(QueryFieldDescriptor $fieldDescriptor, bool $isNotLogged): self
-    {
-        $callable = static function () use ($isNotLogged): void {
-            if ($isNotLogged) {
-                throw MissingAuthorizationException::unauthorized();
-            }
-            throw MissingAuthorizationException::forbidden();
         };
 
         $fieldDescriptor->setResolver($callable);

--- a/website/docs/annotations-reference.md
+++ b/website/docs/annotations-reference.md
@@ -150,6 +150,10 @@ value          | *yes*       | mixed | The value to return if the user is not au
 
 ## @HideIfUnauthorized
 
+<div class="alert alert--warning">This annotation only works when a Schema is used to handle exactly one use request. 
+If you serve your GraphQL API from long-running standalone servers (like Laravel Octane, Swoole, RoadRunner etc) and 
+share the same Schema instance between multiple requests, please avoid using @HideIfUnauthorized.</div>
+
 The `@HideIfUnauthorized` annotation is used to completely hide the query / mutation / field if the user is not authorized
 to access it (according to the `@Logged` and `@Right` annotations).
 

--- a/website/docs/authentication-authorization.mdx
+++ b/website/docs/authentication-authorization.mdx
@@ -231,7 +231,7 @@ By default, a user analysing the GraphQL schema can see all queries/mutations/ty
 Some will be available to him and some won't.
 
 If you want to add an extra level of security (or if you want your schema to be kept secret to unauthorized users),
-you can use the `@HideIfUnauthorized` annotation.
+you can use the `@HideIfUnauthorized` annotation. Beware of [it's limitations](annotations-reference.md).
 
 <Tabs
   defaultValue="php8"
@@ -292,4 +292,4 @@ class UserController
 While this is the most secured mode, it can have drawbacks when working with development tools
 (you need to be logged as admin to fetch the complete schema).
 
-<div class="alert alert--info">The "HideIfUnauthorized" mode was the default mode in GraphQLite 3 and is optionnal from GraphQLite 4+.</div>
+<div class="alert alert--info">The "HideIfUnauthorized" mode was the default mode in GraphQLite 3 and is optional from GraphQLite 4+.</div>

--- a/website/docs/field-middlewares.md
+++ b/website/docs/field-middlewares.md
@@ -63,7 +63,9 @@ class QueryFieldDescriptor
 
 The role of a middleware is to analyze the `QueryFieldDescriptor` and modify it (or to directly return a `FieldDefinition`).
 
-If you want the field to purely disappear, your middleware can return `null`.
+If you want the field to purely disappear, your middleware can return `null`, although this should be used with caution:
+field middlewares only get called once per Schema instance. If you use a long-running server (like Laravel Octane, Swoole, RoadRunner etc)
+and share the same Schema instance across requests, you will not be able to hide fields based on request data.
 
 ## Annotations parsing
 


### PR DESCRIPTION
Closes #562 

Feel free to make changes, especially to the docs.

I've also refactored `AuthorizationFieldMiddleware` to resolve authentication in a resolver callback, same way `SecurityFieldMiddleware` does, to avoid problems with regular `#[Logged]` and `#[Right]` annotations for my use case.