### PR TITLE
Bump doctrine/annotations to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "doctrine/annotations": "1.13.2",
+        "doctrine/annotations": "^2.0",
         "composer/package-versions-deprecated": "^1.8",
         "phpdocumentor/reflection-docblock": "^4.3 || ^5.0",
         "phpdocumentor/type-resolver": "^1.4",

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -224,13 +224,7 @@ class SchemaFactory
      */
     private function getDoctrineAnnotationReader(CacheItemPoolInterface $cache): Reader
     {
-        if ($this->doctrineAnnotationReader === null) {
-            AnnotationRegistry::registerLoader('class_exists');
-
-            return new PsrCachedReader(new DoctrineAnnotationReader(), $cache, true);
-        }
-
-        return $this->doctrineAnnotationReader;
+        return $this->doctrineAnnotationReader ?? new PsrCachedReader(new DoctrineAnnotationReader(), $cache, true);
     }
 
     public function setAuthenticationService(AuthenticationServiceInterface $authenticationService): self

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,9 +1,3 @@
 <?php
-
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
-$autoloader = require_once __DIR__ . '/../vendor/autoload.php';
-
-AnnotationRegistry::registerLoader('class_exists');
-
-return $autoloader;
+declare(strict_types=1);
+return require __DIR__ . '/../vendor/autoload.php';

--- a/tests/Fixtures/Annotations/ClassWithInvalidExtendTypeAnnotation.php
+++ b/tests/Fixtures/Annotations/ClassWithInvalidExtendTypeAnnotation.php
@@ -5,9 +5,8 @@ namespace TheCodingMachine\GraphQLite\Fixtures\Annotations;
 
 use TheCodingMachine\GraphQLite\Annotations\ExtendType;
 
-/**
- * @ExtendType(class="foo")
- */
+
+#[ExtendType(class: 'foo')]
 class ClassWithInvalidExtendTypeAnnotation
 {
 }

--- a/tests/Fixtures/BadClassType/TestType.php
+++ b/tests/Fixtures/BadClassType/TestType.php
@@ -5,9 +5,8 @@ namespace TheCodingMachine\GraphQLite\Fixtures\BadClassType;
 
 use TheCodingMachine\GraphQLite\Annotations\Type;
 
-/**
- * @Type(class=Foobar::class)
- */
+
+#[Type(class: 'Foobar')]
 class TestType
 {
 }


### PR DESCRIPTION
Fixes https://github.com/thecodingmachine/graphqlite/issues/579
There was some backward-incompatible exception messages with phpdoc-like annotation in tests, so I replaced it with attributes.