### PR TITLE
Support `doctrine/annotations` 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "doctrine/annotations": "^2.0",
+        "doctrine/annotations": "^1.14 || ^2.0",
         "composer/package-versions-deprecated": "^1.8",
         "phpdocumentor/reflection-docblock": "^4.3 || ^5.0",
         "phpdocumentor/type-resolver": "^1.4",


### PR DESCRIPTION
There are some package libraries that aren't quite up to date to `doctrine/annotations` 2.  I don't see any need to not support 1.x for now.  This causes dependency tree issues.