### PR TITLE
Annotate SchemaFactory setDoctrineAnnotationReader as deprecated

### DIFF
--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -211,6 +211,9 @@ class SchemaFactory
         return $this;
     }
 
+    /**
+     * @deprecated Use PHP8 Attributes instead
+     */
     public function setDoctrineAnnotationReader(Reader $annotationReader): self
     {
         $this->doctrineAnnotationReader = $annotationReader;


### PR DESCRIPTION
Support for Doctrine annotations has been deprecated for some time.  This is just providing some additional IDE/code insight.