### PR TITLE
Application/json is a valid graphql content-type

### DIFF
--- a/src/Http/WebonyxGraphqlMiddleware.php
+++ b/src/Http/WebonyxGraphqlMiddleware.php
@@ -34,7 +34,7 @@ final class WebonyxGraphqlMiddleware implements MiddlewareInterface
 {
     private StandardServer $standardServer;
     /** @var array<int,string> */
-    private array $graphqlHeaderList = ['application/graphql'];
+    private array $graphqlHeaderList = ['application/graphql', 'application/json'];
     /** @var array<int,string> */
     private array $allowedMethods = [
         'GET',


### PR DESCRIPTION
Altair, for example, sends all of it's requests using application/json in it's content-type. Adding this allows graphqlite to properly parse the json sent by Altair. Everything seems to work as expected the moment it's added to the whitelisted content-types.

```
# Unpatched

❯ curl 'http://figure.commishes.local:80/api/v1' -H 'Accept-Encoding: gzip, deflate, br' -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'Connection: keep-alive' -H 'Origin: moz-extension://6bd3578a-23f3-4834-bce9-724640c5fe8a' --data-binary '{"query":"# Welcome to Altair GraphQL Client.\n# You can send your request using CmdOrCtrl + Enter.\n\n# Enter your graphQL query here.\n\nquery ggb {\n  test\n}","variables":{}}' --compressed
Okay

# With content-type set to application/graphql but sending a json payload
❯ curl 'http://figure.commishes.local:80/api/v1' -H 'Accept-Encoding: gzip, deflate, br' -H 'Content-Type: application/graphql' -H 'Accept: application/json' -H 'Connection: keep-alive' -H 'Origin: moz-extension://6bd3578a-23f3-4834-bce9-724640c5fe8a' --data-binary '{"query":"# Welcome to Altair GraphQL Client.\n# You can send your request using CmdOrCtrl + Enter.\n\n# Enter your graphQL query here.\n\nquery ggb {\n  test\n}","variables":{}}' --compressed
{"errors":[{"message":"Syntax Error: Expected Name, found String \"query\"","locations":[{"line":1,"column":2}]}]}%                                                                           

# Patched
❯ curl 'http://figure.commishes.local:80/api/v1' -H 'Accept-Encoding: gzip, deflate, br' -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'Connection: keep-alive' -H 'Origin: moz-extension://6bd3578a-23f3-4834-bce9-724640c5fe8a' --data-binary '{"query":"# Welcome to Altair GraphQL Client.\n# You can send your request using CmdOrCtrl + Enter.\n\n# Enter your graphQL query here.\n\nquery ggb {\n  test\n}","variables":{}}' --compressed
{"errors":[{"message":"Cannot query field \"test\" on type \"Query\".","locations":[{"line":7,"column":3}]}]}%                                                                                


```