### PR TITLE
Documenting new command in the Laravel package

### DIFF
--- a/website/docs/laravel-package-advanced.mdx
+++ b/website/docs/laravel-package-advanced.mdx
@@ -328,3 +328,16 @@ class User extends Model
 ```
 
 </div>
+
+## Export the schema from the CLI
+
+The extension comes with a special command: `graphqlite:export-schema`.
+
+Usage:
+
+```console
+$ ./artisan graphqlite:export-schema --output=schema.graphql
+```
+
+This will export your GraphQL schema in SDL format. You can use this exported schema to import it in other
+tools (like graphql-codegen).


### PR DESCRIPTION
Hey guys!

I added a new command in the Laravel package to export the schema. This can be useful in other tools (like graphql-codegen).

This PR adds the documentation.

The orginal PR is here: https://github.com/thecodingmachine/graphqlite-laravel/pull/44