### PR TITLE
Make type namespaces available in RootTypeMapperFactoryContext

### DIFF
--- a/src/Mappers/Root/RootTypeMapperFactoryContext.php
+++ b/src/Mappers/Root/RootTypeMapperFactoryContext.php
@@ -11,6 +11,7 @@ use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
 use TheCodingMachine\GraphQLite\TypeRegistry;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
+use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
 
 /**
  * A context class containing a number of classes created on the fly by SchemaFactory.
@@ -18,6 +19,9 @@ use TheCodingMachine\GraphQLite\Types\TypeResolver;
  */
 final class RootTypeMapperFactoryContext
 {
+    /**
+     * @param iterable<NS> $typeNamespaces
+     */
     public function __construct(
         private readonly AnnotationReader $annotationReader,
         private readonly TypeResolver $typeResolver,
@@ -26,6 +30,7 @@ final class RootTypeMapperFactoryContext
         private readonly RecursiveTypeMapperInterface $recursiveTypeMapper,
         private readonly ContainerInterface $container,
         private readonly CacheInterface $cache,
+        private readonly iterable $typeNamespaces,
         private readonly int|null $globTTL,
         private readonly int|null $mapTTL = null,
     ) {
@@ -64,6 +69,12 @@ final class RootTypeMapperFactoryContext
     public function getCache(): CacheInterface
     {
         return $this->cache;
+    }
+
+    /** @return iterable<NS> */
+    public function getTypeNamespaces(): iterable
+    {
+        return $this->typeNamespaces;
     }
 
     public function getGlobTTL(): int|null

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -399,6 +399,7 @@ class SchemaFactory
                 $recursiveTypeMapper,
                 $this->container,
                 $namespacedCache,
+                $nsList,
                 $this->globTTL,
             );
 

--- a/tests/RootTypeMapperFactoryContextTest.php
+++ b/tests/RootTypeMapperFactoryContextTest.php
@@ -8,6 +8,7 @@ use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperFactoryContext;
+use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
 
 class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
 {
@@ -18,6 +19,7 @@ class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
         $namingStrategy = new NamingStrategy();
         $container = new EmptyContainer();
         $arrayCache = new Psr16Cache(new ArrayAdapter());
+        $nsList = [$this->getNamespaceFactory()->createNamespace('namespace')];
 
         $context = new RootTypeMapperFactoryContext(
             $this->getAnnotationReader(),
@@ -27,6 +29,7 @@ class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
             $this->getTypeMapper(),
             $container,
             $arrayCache,
+            $nsList,
             self::GLOB_TTL_SECONDS
         );
 
@@ -37,6 +40,8 @@ class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
         $this->assertSame($this->getTypeMapper(), $context->getRecursiveTypeMapper());
         $this->assertSame($container, $context->getContainer());
         $this->assertSame($arrayCache, $context->getCache());
+        $this->assertSame($nsList, $context->getTypeNamespaces());
+        $this->assertContainsOnlyInstancesOf(NS::class, $context->getTypeNamespaces());
         $this->assertSame(self::GLOB_TTL_SECONDS, $context->getGlobTTL());
         $this->assertNull($context->getMapTTL());
     }


### PR DESCRIPTION
Sometimes you need access to the type namespaces to resolve a type name to a class. The enum root type mappers that ship with Graphqlite work like this. Custom root type mappers do not have access to this information currently though, because it is missing in the factory context.

Built-in enum type mappers receive the list of namespaces:
```php
if (interface_exists(UnitEnum::class)) {
    $rootTypeMapper = new EnumTypeMapper($rootTypeMapper, $annotationReader, $symfonyCache, $nsList);
}

if (class_exists(Enum::class)) {
    $rootTypeMapper = new MyCLabsEnumTypeMapper($rootTypeMapper, $annotationReader, $symfonyCache, $nsList);
}
```

`RootTypeMapperFactoryContext` is missing this info though:
```php
$rootSchemaFactoryContext = new RootTypeMapperFactoryContext(
    $annotationReader,
    $typeResolver,
    $namingStrategy,
    $typeRegistry,
    $recursiveTypeMapper,
    $this->container,
    $namespacedCache,
    $this->globTTL,
);
```

I have a custom root type mapper for another enum library and am forced to pass in the type namespaces again:
```php
->addTypeNamespace('My\\Custom\\Ns\\')
->addRootTypeMapperFactory(new MarcMabeEnumTypeMapperFactory(['My\\Custom\\Ns\\']))
```

This PR adds the list of namespaces to the factory context so that root type mapper factories can pass it on to the created mapper instance.