### PR TITLE
Enum descriptions and deprecation support

### DIFF
--- a/src/Mappers/Root/EnumTypeMapper.php
+++ b/src/Mappers/Root/EnumTypeMapper.php
@@ -10,6 +10,7 @@ use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use MyCLabs\Enum\Enum;
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Object_;
 use ReflectionClass;
@@ -119,7 +120,22 @@ class EnumTypeMapper implements RootTypeMapperInterface
             $reflectionEnum->isBacked() &&
             (string) $reflectionEnum->getBackingType() === 'string';
 
-        $type = new EnumType($enumClass, $typeName, $useValues);
+        $docBlockFactory = DocBlockFactory::createInstance();
+
+        $docComment = $reflectionEnum->getDocComment();
+        $enumDescription = $docComment ? $docBlockFactory->create($docComment)->getSummary() : null;
+
+        $enumCaseDescriptions = [];
+        foreach ($reflectionEnum->getCases() as $reflectionEnumCase) {
+            $docComment = $reflectionEnumCase->getDocComment();
+            if ($docComment) {
+                $enumCaseDescription = $docBlockFactory->create($docComment)->getSummary();
+                $enumCaseDescriptions[$reflectionEnumCase->getName()] = $enumCaseDescription;
+            }
+        }
+
+        /** @var array<string, string> $enumCaseDescriptions */
+        $type = new EnumType($enumClass, $typeName, $enumDescription, $enumCaseDescriptions, $useValues);
 
         return $this->cacheByName[$type->name] = $this->cache[$enumClass] = $type;
     }

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -20,12 +20,14 @@ class EnumType extends BaseEnumType
     /**
      * @param class-string<UnitEnum> $enumName
      * @param array<string, string> $caseDescriptions
+     * @param array<string, string> $caseDeprecationReasons
      */
     public function __construct(
         string $enumName,
         string $typeName,
         ?string $description,
         array $caseDescriptions,
+        array $caseDeprecationReasons,
         private readonly bool $useValues = false,
     ) {
         $typeValues = [];
@@ -35,6 +37,7 @@ class EnumType extends BaseEnumType
                 'name' => $key,
                 'value' => $case,
                 'description' => $caseDescriptions[$case->name] ?? null,
+                'deprecationReason' => $caseDeprecationReasons[$case->name] ?? null,
             ];
         }
 

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -38,7 +38,7 @@ class EnumType extends BaseEnumType
     public function serialize($value): string
     {
         if (! $value instanceof UnitEnum) {
-            throw new InvalidArgumentException('Expected a Myclabs Enum instance');
+            throw new InvalidArgumentException('Expected a UnitEnum instance');
         }
 
         if (! $this->useValues) {

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -17,19 +17,34 @@ use function is_string;
  */
 class EnumType extends BaseEnumType
 {
-    /** @param class-string<UnitEnum> $enumName */
-    public function __construct(string $enumName, string $typeName, private readonly bool $useValues = false)
-    {
-        $values = [];
+    /**
+     * @param class-string<UnitEnum> $enumName
+     * @param array<string, string> $caseDescriptions
+     */
+    public function __construct(
+        string $enumName,
+        string $typeName,
+        ?string $description,
+        array $caseDescriptions,
+        private readonly bool $useValues = false,
+    ) {
+        $typeValues = [];
         foreach ($enumName::cases() as $case) {
-            /** @var UnitEnum $case */
-            $values[$this->serialize($case)] = ['value' => $case];
+            $key = $this->serialize($case);
+            $typeValues[$key] = [
+                'name' => $key,
+                'value' => $case,
+                'description' => $caseDescriptions[$case->name] ?? null,
+            ];
         }
 
-        parent::__construct([
-            'name' => $typeName,
-            'values' => $values,
-        ]);
+        parent::__construct(
+            [
+                'name' => $typeName,
+                'values' => $typeValues,
+                'description' => $description,
+            ]
+        );
     }
 
     // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint


### PR DESCRIPTION
This PR adds support for docblock descriptions for native enums and enum cases, as well as deprecation tag support for cases.

This enum
```php
/**
 * This is the description of the enum itself
 */
enum TestEnum
{
    /**
     * This is a case description
     */
    case FOO;

    /**
     * This is another case description
     * @deprecated it should not be used anymore
     */
    case BAR;
}
```

results in the following type description in the schema:
```json
{
  "kind": "ENUM",
  "name": "TestEnum",
  "description": "This is the description of the enum itself",
  "specifiedByUrl": null,
  "fields": null,
  "inputFields": null,
  "interfaces": null,
  "enumValues": [
    {
      "name": "BAR",
      "description": "This is another case description",
      "isDeprecated": true,
      "deprecationReason": "it should not be used anymore"
    },
    {
      "name": "FOO",
      "description": "This is a case description",
      "isDeprecated": false,
      "deprecationReason": null
    }
  ],
  "possibleTypes": null
}
```

GraphiQL output
![image](https://github.com/thecodingmachine/graphqlite/assets/2145319/a86dad58-90e4-4853-95ca-544c73e8edeb)
![image](https://github.com/thecodingmachine/graphqlite/assets/2145319/7eea7a37-c3eb-4998-aa05-24d8907ffdfc)
