### PR TITLE
Doc: Fix UseInputType example as an attribute

### DIFF
--- a/website/versioned_docs/version-6.1/input-types.mdx
+++ b/website/versioned_docs/version-6.1/input-types.mdx
@@ -249,9 +249,7 @@ Let's say you want to force a parameter to be of type "ID", you can use this:
 
 ```php
 #[Factory]
-#[UseInputType(for: "$id", inputType:"ID!")]
-public function getProductById(string $id): Product
-{
+public function getProductById(#[UseInputType(inputType:"ID!")] string $id): Product {
     return $this->productRepository->findById($id);
 }
 ```


### PR DESCRIPTION
Hi,

A very small contribution about the documentation of UseInputType attribute.

The current documentation shows the use of `UseInputType` attribute in the same way than before with annotation by targeting method instead of parameter.

The `for` parameter doesn't exists in the Attribute (_unlike the annotation_), and the whole attribute should be moved just before the targeted parameter.