### PR TITLE
Improved description formatting for cost complexity

### DIFF
--- a/src/Middlewares/CostFieldMiddleware.php
+++ b/src/Middlewares/CostFieldMiddleware.php
@@ -63,7 +63,7 @@ class CostFieldMiddleware implements FieldMiddlewareInterface
 
     private function buildQueryComment(Cost $costAttribute): string
     {
-        return 'Cost: ' .
+        return "\nCost: " .
             implode(', ', [
                 'complexity = ' . $costAttribute->complexity,
                 'multipliers = [' . implode(', ', $costAttribute->multipliers) . ']',

--- a/tests/Integration/QueryComplexityTest.php
+++ b/tests/Integration/QueryComplexityTest.php
@@ -175,7 +175,7 @@ class QueryComplexityTest extends IntegrationTestCase
     public static function reportsQueryCostInIntrospectionProvider(): iterable
     {
         yield [
-            'Cost: complexity = 5, multipliers = [take], defaultMultiplier = 500',
+            '\nCost: complexity = 5, multipliers = [take], defaultMultiplier = 500',
             'Query',
             'articles',
         ];
@@ -187,13 +187,13 @@ class QueryComplexityTest extends IntegrationTestCase
         ];
 
         yield [
-            'Cost: complexity = 5, multipliers = [], defaultMultiplier = null',
+            '\nCost: complexity = 5, multipliers = [], defaultMultiplier = null',
             'Post',
             'comment',
         ];
 
         yield [
-            'Cost: complexity = 3, multipliers = [], defaultMultiplier = null',
+            '\nCost: complexity = 3, multipliers = [], defaultMultiplier = null',
             'Post',
             'author',
         ];

--- a/tests/Integration/QueryComplexityTest.php
+++ b/tests/Integration/QueryComplexityTest.php
@@ -175,7 +175,7 @@ class QueryComplexityTest extends IntegrationTestCase
     public static function reportsQueryCostInIntrospectionProvider(): iterable
     {
         yield [
-            '\nCost: complexity = 5, multipliers = [take], defaultMultiplier = 500',
+            "\nCost: complexity = 5, multipliers = [take], defaultMultiplier = 500",
             'Query',
             'articles',
         ];
@@ -187,13 +187,13 @@ class QueryComplexityTest extends IntegrationTestCase
         ];
 
         yield [
-            '\nCost: complexity = 5, multipliers = [], defaultMultiplier = null',
+            "\nCost: complexity = 5, multipliers = [], defaultMultiplier = null",
             'Post',
             'comment',
         ];
 
         yield [
-            '\nCost: complexity = 3, multipliers = [], defaultMultiplier = null',
+            "\nCost: complexity = 3, multipliers = [], defaultMultiplier = null",
             'Post',
             'author',
         ];

--- a/tests/Middlewares/CostFieldMiddlewareTest.php
+++ b/tests/Middlewares/CostFieldMiddlewareTest.php
@@ -109,17 +109,17 @@ class CostFieldMiddlewareTest extends TestCase
     public static function addsCostInDescriptionProvider(): iterable
     {
         yield [
-            '\nCost: complexity = 1, multipliers = [], defaultMultiplier = null',
+            "\nCost: complexity = 1, multipliers = [], defaultMultiplier = null",
             new Cost(),
         ];
 
         yield [
-            '\nCost: complexity = 5, multipliers = [take], defaultMultiplier = 500',
+            "\nCost: complexity = 5, multipliers = [take], defaultMultiplier = 500",
             new Cost(complexity: 5, multipliers: ['take'], defaultMultiplier: 500)
         ];
 
         yield [
-            '\nCost: complexity = 5, multipliers = [take, null], defaultMultiplier = null',
+            "\nCost: complexity = 5, multipliers = [take, null], defaultMultiplier = null",
             new Cost(complexity: 5, multipliers: ['take', 'null'], defaultMultiplier: null)
         ];
     }

--- a/tests/Middlewares/CostFieldMiddlewareTest.php
+++ b/tests/Middlewares/CostFieldMiddlewareTest.php
@@ -109,17 +109,17 @@ class CostFieldMiddlewareTest extends TestCase
     public static function addsCostInDescriptionProvider(): iterable
     {
         yield [
-            'Cost: complexity = 1, multipliers = [], defaultMultiplier = null',
+            '\nCost: complexity = 1, multipliers = [], defaultMultiplier = null',
             new Cost(),
         ];
 
         yield [
-            'Cost: complexity = 5, multipliers = [take], defaultMultiplier = 500',
+            '\nCost: complexity = 5, multipliers = [take], defaultMultiplier = 500',
             new Cost(complexity: 5, multipliers: ['take'], defaultMultiplier: 500)
         ];
 
         yield [
-            'Cost: complexity = 5, multipliers = [take, null], defaultMultiplier = null',
+            '\nCost: complexity = 5, multipliers = [take, null], defaultMultiplier = null',
             new Cost(complexity: 5, multipliers: ['take', 'null'], defaultMultiplier: null)
         ];
     }


### PR DESCRIPTION
This is a simple commit, we just add a new line prior to the cost complexity in the description.  I've tested this on multiple GraphQL clients and it seems to be working well.  The current formatting made it difficult to read and the cost complexity is jammed up against existing documentation.

@oprypkhantc let me know if you're aware of any issues where this formatting would be undesirable.