### PR TITLE
Fix name of imported type from webonyx for formatter

### DIFF
--- a/src/Exceptions/WebonyxErrorHandler.php
+++ b/src/Exceptions/WebonyxErrorHandler.php
@@ -16,11 +16,11 @@ use function array_map;
  * A custom error handler and error formatter for Webonyx that can read the GraphQLAggregateExceptionInterface
  * and the GraphQLExceptionInterface.
  *
- * @phpstan-import-type SerializableError from ExecutionResult
+ * @phpstan-import-type SerializableErrors from ExecutionResult
  */
 final class WebonyxErrorHandler
 {
-    /** @return SerializableError */
+    /** @return SerializableErrors */
     public static function errorFormatter(Throwable $error): array
     {
         $formattedError = FormattedError::createFromException($error);


### PR DESCRIPTION
`SerializableError` was a representation of one error, but the formatter returns an array of errors

https://github.com/webonyx/graphql-php/blob/29b5b613bd3ee34f227650f856ee8dd4ce151b88/src/Executor/ExecutionResult.php#L17-L23