### PR TITLE
Use @param tags from constructor with property promotion

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -9,7 +9,6 @@ use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\OutputType;
-use GraphQL\Type\Definition\Type;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -89,7 +88,12 @@ class FieldsBuilder
         private readonly InputFieldMiddlewareInterface $inputFieldMiddleware,
     )
     {
-        $this->typeMapper = new TypeHandler($this->argumentResolver, $this->rootTypeMapper, $this->typeResolver);
+        $this->typeMapper = new TypeHandler(
+            $this->argumentResolver,
+            $this->rootTypeMapper,
+            $this->typeResolver,
+            $this->cachedDocBlockFactory,
+        );
     }
 
     /**

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\OutputType;
+use GraphQL\Type\Definition\Type;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
 use Psr\SimpleCache\InvalidArgumentException;

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -126,22 +126,35 @@ class TypeHandler implements ParameterHandlerInterface
         $varTags = $docBlock->getTagsByName('var');
 
         if (! $varTags) {
-            return null;
-        }
-
-        if (count($varTags) > 1) {
             // If we don't have any @var tags, was this property promoted, and if so, do we have an
             // @param tag on the constructor docblock?  If so, use that for the type.
             if ($refProperty->isPromoted()) {
-                $docBlock = $this->cachedDocBlockFactory->getDocBlock($refProperty->getDeclaringClass()->getConstructor());
+                $refConstructor = $refProperty->getDeclaringClass()->getConstructor();
+                if (! $refConstructor) {
+                    return null;
+                }
+
+                $docBlock = $this->cachedDocBlockFactory->getDocBlock($refConstructor);
                 $paramTags = $docBlock->getTagsByName('param');
                 foreach ($paramTags as $paramTag) {
+                    if (! method_exists($paramTag, 'getVariableName')) {
+                        continue;
+                    }
+
+                    if (! method_exists($paramTag, 'getType')) {
+                        continue;
+                    }
+
                     if ($paramTag->getVariableName() === $refProperty->getName()) {
                         return $paramTag->getType();
                     }
                 }
             }
-            
+
+            return null;
+        }
+
+        if (count($varTags) > 1) {
             throw InvalidDocBlockRuntimeException::tooManyVarTags($refProperty);
         }
 

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use InvalidArgumentException;
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\DocBlock\Tags\Return_;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
 use phpDocumentor\Reflection\Fqsen;
@@ -137,11 +138,7 @@ class TypeHandler implements ParameterHandlerInterface
                 $docBlock = $this->cachedDocBlockFactory->getDocBlock($refConstructor);
                 $paramTags = $docBlock->getTagsByName('param');
                 foreach ($paramTags as $paramTag) {
-                    if (! method_exists($paramTag, 'getVariableName')) {
-                        continue;
-                    }
-
-                    if (! method_exists($paramTag, 'getType')) {
+                    if (! $paramTag instanceof Param) {
                         continue;
                     }
 

--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -41,6 +41,7 @@ use TheCodingMachine\GraphQLite\Parameters\DefaultValueParameter;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeProperty;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 use TheCodingMachine\GraphQLite\Types\ArgumentResolver;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
 
@@ -66,6 +67,7 @@ class TypeHandler implements ParameterHandlerInterface
         private readonly ArgumentResolver $argumentResolver,
         private readonly RootTypeMapperInterface $rootTypeMapper,
         private readonly TypeResolver $typeResolver,
+        private readonly CachedDocBlockFactory $cachedDocBlockFactory,
     )
     {
         $this->phpDocumentorTypeResolver = new PhpDocumentorTypeResolver();
@@ -128,6 +130,18 @@ class TypeHandler implements ParameterHandlerInterface
         }
 
         if (count($varTags) > 1) {
+            // If we don't have any @var tags, was this property promoted, and if so, do we have an
+            // @param tag on the constructor docblock?  If so, use that for the type.
+            if ($refProperty->isPromoted()) {
+                $docBlock = $this->cachedDocBlockFactory->getDocBlock($refProperty->getDeclaringClass()->getConstructor());
+                $paramTags = $docBlock->getTagsByName('param');
+                foreach ($paramTags as $paramTag) {
+                    if ($paramTag->getVariableName() === $refProperty->getName()) {
+                        return $paramTag->getType();
+                    }
+                }
+            }
+            
             throw InvalidDocBlockRuntimeException::tooManyVarTags($refProperty);
         }
 

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -277,6 +277,15 @@ abstract class AbstractQueryProviderTest extends TestCase
         return $this->parameterMiddlewarePipe;
     }
 
+    protected function getCachedDocBlockFactory(): CachedDocBlockFactory
+    {
+        $arrayAdapter = new ArrayAdapter();
+        $arrayAdapter->setLogger(new ExceptionLogger());
+        $psr16Cache = new Psr16Cache($arrayAdapter);
+
+        return new CachedDocBlockFactory($psr16Cache);
+    }
+
     protected function buildFieldsBuilder(): FieldsBuilder
     {
         $arrayAdapter = new ArrayAdapter();
@@ -308,7 +317,7 @@ abstract class AbstractQueryProviderTest extends TestCase
             $this->getTypeMapper(),
             $this->getArgumentResolver(),
             $this->getTypeResolver(),
-            new CachedDocBlockFactory($psr16Cache),
+            $this->getCachedDocBlockFactory(),
             new NamingStrategy(),
             $this->buildRootTypeMapper(),
             $parameterMiddlewarePipe,

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -212,8 +212,6 @@ class FieldsBuilderTest extends AbstractQueryProviderTest
 
         $this->expectException(CannotMapTypeException::class);
 
-        // Techncially at this point, we already know it's working, since an exception would have been
-        // thrown otherwise, requiring the generic type to be specified.
         $fieldsBuilder->getInputFields(
             PropertyPromotionInputTypeWithoutGenericDoc::class,
             'PropertyPromotionInputTypeWithoutGenericDocInput',

--- a/tests/Fixtures80/PropertyPromotionInputType.php
+++ b/tests/Fixtures80/PropertyPromotionInputType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures80;
+
+use TheCodingMachine\GraphQLite\Annotations as GraphQLite;
+
+#[GraphQLite\Input]
+class PropertyPromotionInputType
+{
+
+    /**
+     * Constructor
+     *
+     * @param array<int> $amounts
+     */
+    public function __construct(
+        #[GraphQLite\Field]
+        public array $amounts,
+    ) {}
+}

--- a/tests/Fixtures80/PropertyPromotionInputTypeWithoutGenericDoc.php
+++ b/tests/Fixtures80/PropertyPromotionInputTypeWithoutGenericDoc.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures80;
+
+use TheCodingMachine\GraphQLite\Annotations as GraphQLite;
+
+#[GraphQLite\Input]
+class PropertyPromotionInputTypeWithoutGenericDoc
+{
+
+    /**
+     * We expect this to fail since the array must have a generic type `array<int>`
+     */
+    public function __construct(
+        #[GraphQLite\Field]
+        public array $amounts,
+    ) {}
+}

--- a/tests/Mappers/Parameters/TypeMapperTest.php
+++ b/tests/Mappers/Parameters/TypeMapperTest.php
@@ -22,7 +22,12 @@ class TypeMapperTest extends AbstractQueryProviderTest
 
     public function testMapScalarUnionException(): void
     {
-        $typeMapper = new TypeHandler($this->getArgumentResolver(), $this->getRootTypeMapper(), $this->getTypeResolver());
+        $typeMapper = new TypeHandler(
+            $this->getArgumentResolver(),
+            $this->getRootTypeMapper(),
+            $this->getTypeResolver(),
+            $this->getCachedDocBlockFactory(),
+        );
 
         $cachedDocBlockFactory = new CachedDocBlockFactory(new Psr16Cache(new ArrayAdapter()));
 
@@ -39,9 +44,14 @@ class TypeMapperTest extends AbstractQueryProviderTest
      */
     public function testMapObjectUnionWorks(): void
     {
-        $typeMapper = new TypeHandler($this->getArgumentResolver(), $this->getRootTypeMapper(), $this->getTypeResolver());
+        $cachedDocBlockFactory = $this->getCachedDocBlockFactory();
 
-        $cachedDocBlockFactory = new CachedDocBlockFactory(new Psr16Cache(new ArrayAdapter()));
+        $typeMapper = new TypeHandler(
+            $this->getArgumentResolver(),
+            $this->getRootTypeMapper(),
+            $this->getTypeResolver(),
+            $cachedDocBlockFactory,
+        );
 
         $refMethod = new ReflectionMethod(UnionOutputType::class, 'objectUnion');
         $docBlockObj = $cachedDocBlockFactory->getDocBlock($refMethod);
@@ -61,9 +71,14 @@ class TypeMapperTest extends AbstractQueryProviderTest
      */
     public function testMapObjectNullableUnionWorks(): void
     {
-        $typeMapper = new TypeHandler($this->getArgumentResolver(), $this->getRootTypeMapper(), $this->getTypeResolver());
+        $cachedDocBlockFactory = $this->getCachedDocBlockFactory();
 
-        $cachedDocBlockFactory = new CachedDocBlockFactory(new Psr16Cache(new ArrayAdapter()));
+        $typeMapper = new TypeHandler(
+            $this->getArgumentResolver(),
+            $this->getRootTypeMapper(),
+            $this->getTypeResolver(),
+            $cachedDocBlockFactory,
+        );
 
         $refMethod = new ReflectionMethod(UnionOutputType::class, 'nullableObjectUnion');
         $docBlockObj = $cachedDocBlockFactory->getDocBlock($refMethod);
@@ -82,9 +97,14 @@ class TypeMapperTest extends AbstractQueryProviderTest
 
     public function testHideParameter(): void
     {
-        $typeMapper = new TypeHandler($this->getArgumentResolver(), $this->getRootTypeMapper(), $this->getTypeResolver());
+        $cachedDocBlockFactory = $this->getCachedDocBlockFactory();
 
-        $cachedDocBlockFactory = new CachedDocBlockFactory(new Psr16Cache(new ArrayAdapter()));
+        $typeMapper = new TypeHandler(
+            $this->getArgumentResolver(),
+            $this->getRootTypeMapper(),
+            $this->getTypeResolver(),
+            $cachedDocBlockFactory,
+        );
 
         $refMethod = new ReflectionMethod($this, 'withDefaultValue');
         $refParameter = $refMethod->getParameters()[0];
@@ -101,9 +121,14 @@ class TypeMapperTest extends AbstractQueryProviderTest
 
     public function testParameterWithDescription(): void
     {
-        $typeMapper = new TypeHandler($this->getArgumentResolver(), $this->getRootTypeMapper(), $this->getTypeResolver());
+        $cachedDocBlockFactory = $this->getCachedDocBlockFactory();
 
-        $cachedDocBlockFactory = new CachedDocBlockFactory(new Psr16Cache(new ArrayAdapter()));
+        $typeMapper = new TypeHandler(
+            $this->getArgumentResolver(),
+            $this->getRootTypeMapper(),
+            $this->getTypeResolver(),
+            $cachedDocBlockFactory,
+        );
 
         $refMethod = new ReflectionMethod($this, 'withParamDescription');
         $docBlockObj = $cachedDocBlockFactory->getDocBlock($refMethod);
@@ -117,9 +142,14 @@ class TypeMapperTest extends AbstractQueryProviderTest
 
     public function testHideParameterException(): void
     {
-        $typeMapper = new TypeHandler($this->getArgumentResolver(), $this->getRootTypeMapper(), $this->getTypeResolver());
+        $cachedDocBlockFactory = $this->getCachedDocBlockFactory();
 
-        $cachedDocBlockFactory = new CachedDocBlockFactory(new Psr16Cache(new ArrayAdapter()));
+        $typeMapper = new TypeHandler(
+            $this->getArgumentResolver(),
+            $this->getRootTypeMapper(),
+            $this->getTypeResolver(),
+            $cachedDocBlockFactory,
+        );
 
         $refMethod = new ReflectionMethod($this, 'withoutDefaultValue');
         $refParameter = $refMethod->getParameters()[0];


### PR DESCRIPTION
When using property promotion, particularly with input types, you're required to define the generic type details for lists (array, collection, etc) using a variable docblock.  Not only is this ugly, it requires duplicate docblock definitions for internal docblock usage and is entirely unnecessary.

This PR adds support for constructor docblock generic type definitions with property promotion.

Example:

```php
/**
 * Constructor
 * 
 * @param array<string> $array
 */
#[Input]
public function __construct(
    #[Field]
    public array $array
) {}
```

As opposed to:

```php
#[Input]
public function __construct(
    /** @var array<string> */
    #[Field]
    public array $array
) {}
```

The additional support is fully BC.