### PR TITLE
Allow constructor fields to use middleware

### DIFF
--- a/src/FailedResolvingInputType.php
+++ b/src/FailedResolvingInputType.php
@@ -10,9 +10,9 @@ use function sprintf;
 
 class FailedResolvingInputType extends RuntimeException
 {
-    public static function createForMissingConstructorParameter(string $class, string $parameter): self
+    public static function createForMissingConstructorParameter(string $original): self
     {
-        return new self(sprintf("Parameter '%s' is missing for class '%s' constructor. It should be mapped as required field.", $parameter, $class));
+        return new self(sprintf("%s. It should be mapped as required field.", $original));
     }
 
     public static function createForDecorator(string $class): self

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -38,7 +38,13 @@ use TheCodingMachine\GraphQLite\Middlewares\FieldHandlerInterface;
 use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewareInterface;
 use TheCodingMachine\GraphQLite\Middlewares\InputFieldHandlerInterface;
 use TheCodingMachine\GraphQLite\Middlewares\InputFieldMiddlewareInterface;
+use TheCodingMachine\GraphQLite\Middlewares\MagicPropertyResolver;
 use TheCodingMachine\GraphQLite\Middlewares\MissingMagicGetException;
+use TheCodingMachine\GraphQLite\Middlewares\ServiceResolver;
+use TheCodingMachine\GraphQLite\Middlewares\SourceConstructorParameterResolver;
+use TheCodingMachine\GraphQLite\Middlewares\SourceInputPropertyResolver;
+use TheCodingMachine\GraphQLite\Middlewares\SourceMethodResolver;
+use TheCodingMachine\GraphQLite\Middlewares\SourcePropertyResolver;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeParameterInterface;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\Parameters\PrefetchDataParameter;
@@ -370,14 +376,6 @@ class FieldsBuilder
                 $type = $this->typeMapper->mapReturnType($refMethod, $docBlockObj);
             }
 
-            $fieldDescriptor = new QueryFieldDescriptor(
-                name: $name,
-                type: $type,
-                comment: trim($description),
-                deprecationReason: $this->getDeprecationReason($docBlockObj),
-                refMethod: $refMethod,
-            );
-
             $parameters = $refMethod->getParameters();
             if ($injectSource === true) {
                 $firstParameter = array_shift($parameters);
@@ -398,19 +396,19 @@ class FieldsBuilder
                 $args = ['__graphqlite_prefectData' => $prefetchDataParameter, ...$args];
             }
 
-            $fieldDescriptor = $fieldDescriptor->withParameters($args);
+            $resolver = is_string($controller) ? new SourceMethodResolver($refMethod) : new ServiceResolver([$controller, $methodName]);
 
-            if (is_string($controller)) {
-                $fieldDescriptor = $fieldDescriptor->withTargetMethodOnSource($refMethod->getDeclaringClass()->getName(), $methodName);
-            } else {
-                $callable = [$controller, $methodName];
-                assert(is_callable($callable));
-                $fieldDescriptor = $fieldDescriptor->withCallable($callable);
-            }
-
-            $fieldDescriptor = $fieldDescriptor
-                ->withInjectSource($injectSource)
-                ->withMiddlewareAnnotations($this->annotationReader->getMiddlewareAnnotations($refMethod));
+            $fieldDescriptor = new QueryFieldDescriptor(
+                name: $name,
+                type: $type,
+                resolver: $resolver,
+                originalResolver: $resolver,
+                parameters: $args,
+                injectSource: $injectSource,
+                comment: trim($description),
+                deprecationReason: $this->getDeprecationReason($docBlockObj),
+                middlewareAnnotations: $this->annotationReader->getMiddlewareAnnotations($refMethod),
+            );
 
             $field = $this->fieldMiddleware->process($fieldDescriptor, new class implements FieldHandlerInterface {
                 public function handle(QueryFieldDescriptor $fieldDescriptor): FieldDefinition|null
@@ -480,25 +478,20 @@ class FieldsBuilder
                 assert($type instanceof OutputType);
             }
 
+            $resolver = is_string($controller) ?
+                new SourcePropertyResolver($refProperty) :
+                new ServiceResolver(fn () => PropertyAccessor::getValue($controller, $refProperty->getName()));
+
             $fieldDescriptor = new QueryFieldDescriptor(
                 name: $name,
                 type: $type,
+                resolver: $resolver,
+                originalResolver: $resolver,
+                injectSource: false,
                 comment: trim($description),
                 deprecationReason: $this->getDeprecationReason($docBlock),
-                refProperty: $refProperty,
+                middlewareAnnotations: $this->annotationReader->getMiddlewareAnnotations($refProperty),
             );
-
-            if (is_string($controller)) {
-                $fieldDescriptor = $fieldDescriptor->withTargetPropertyOnSource($refProperty->getDeclaringClass()->getName(), $refProperty->getName());
-            } else {
-                $fieldDescriptor = $fieldDescriptor->withCallable(static function () use ($controller, $refProperty) {
-                    return PropertyAccessor::getValue($controller, $refProperty->getName());
-                });
-            }
-
-            $fieldDescriptor = $fieldDescriptor
-                ->withInjectSource(false)
-                ->withMiddlewareAnnotations($this->annotationReader->getMiddlewareAnnotations($refProperty));
 
             $field = $this->fieldMiddleware->process($fieldDescriptor, new class implements FieldHandlerInterface {
                 public function handle(QueryFieldDescriptor $fieldDescriptor): FieldDefinition|null
@@ -597,15 +590,16 @@ class FieldsBuilder
                     $type = $this->typeMapper->mapReturnType($refMethod, $docBlockObj);
                 }
 
+                $resolver = new SourceMethodResolver($refMethod);
+
                 $fieldDescriptor = new QueryFieldDescriptor(
                     name: $sourceField->getName(),
                     type: $type,
+                    resolver: $resolver,
+                    originalResolver: $resolver,
                     parameters: $args,
-                    targetClass: $refMethod->getDeclaringClass()->getName(),
-                    targetMethodOnSource: $methodName,
                     comment: $description,
                     deprecationReason: $deprecationReason ?? null,
-                    refMethod: $refMethod,
                 );
             } else {
                 $outputType = $sourceField->getOutputType();
@@ -619,11 +613,13 @@ class FieldsBuilder
                     $type = $this->resolvePhpType($phpTypeStr, $refClass, $magicGefRefMethod);
                 }
 
+                $resolver = new MagicPropertyResolver($refClass->getName(), $sourceField->getSourceName() ?? $sourceField->getName());
+
                 $fieldDescriptor = new QueryFieldDescriptor(
                     name: $sourceField->getName(),
                     type: $type,
-                    targetClass: $refClass->getName(),
-                    magicProperty: $sourceField->getSourceName() ?? $sourceField->getName(),
+                    resolver: $resolver,
+                    originalResolver: $resolver,
                     comment: $sourceField->getDescription(),
                 );
             }
@@ -889,26 +885,21 @@ class FieldsBuilder
 
             assert($type instanceof InputType);
 
+            $resolver = new SourceMethodResolver($refMethod);
+
             $inputFieldDescriptor = new InputFieldDescriptor(
                 name: $name,
                 type: $type,
+                resolver: $resolver,
+                originalResolver: $resolver,
                 parameters: $args,
+                injectSource: $injectSource,
                 comment: trim($description),
-                refMethod: $refMethod,
+                middlewareAnnotations: $this->annotationReader->getMiddlewareAnnotations($refMethod),
                 isUpdate: $isUpdate,
+                hasDefaultValue: $isUpdate,
+                defaultValue: $args[$name]->getDefaultValue()
             );
-
-            $inputFieldDescriptor = $inputFieldDescriptor
-                ->withHasDefaultValue($isUpdate)
-                ->withDefaultValue($args[$name]->getDefaultValue());
-            $constructerParameters = $this->getClassConstructParameterNames($refClass);
-            if (!in_array($name, $constructerParameters)) {
-                $inputFieldDescriptor = $inputFieldDescriptor->withTargetMethodOnSource($refMethod->getDeclaringClass()->getName(), $methodName);
-            }
-
-            $inputFieldDescriptor = $inputFieldDescriptor
-                ->withInjectSource($injectSource)
-                ->withMiddlewareAnnotations($this->annotationReader->getMiddlewareAnnotations($refMethod));
 
             $field = $this->inputFieldMiddleware->process($inputFieldDescriptor, new class implements InputFieldHandlerInterface {
                 public function handle(InputFieldDescriptor $inputFieldDescriptor): InputField|null
@@ -965,53 +956,38 @@ class FieldsBuilder
                 $description = $inputProperty->getDescription();
             }
 
-            if (in_array($name, $constructerParameters)) {
-                $middlewareAnnotations = $this->annotationReader->getPropertyAnnotations($refProperty, MiddlewareAnnotationInterface::class);
-                if ($middlewareAnnotations !== []) {
-                    throw IncompatibleAnnotationsException::middlewareAnnotationsUnsupported();
-                }
-                // constructor hydrated
-                $field = new InputField(
-                    $name,
-                    $inputProperty->getType(),
-                    [$inputProperty->getName() => $inputProperty],
-                    null,
-                    null,
-                    trim($description),
-                    $isUpdate,
-                    $inputProperty->hasDefaultValue(),
-                    $inputProperty->getDefaultValue(),
-                );
-            } else {
-                $type = $inputProperty->getType();
-                if (!$inputType && $isUpdate && $type instanceof NonNull) {
-                    $type = $type->getWrappedType();
-                }
-                assert($type instanceof InputType);
-
-                // setters and properties
-                $inputFieldDescriptor = new InputFieldDescriptor(
-                    name: $inputProperty->getName(),
-                    type: $type,
-                    parameters: [$inputProperty->getName() => $inputProperty],
-                    targetClass: $refProperty->getDeclaringClass()->getName(),
-                    targetPropertyOnSource: $refProperty->getName(),
-                    injectSource: false,
-                    comment: trim($description),
-                    middlewareAnnotations: $this->annotationReader->getMiddlewareAnnotations($refProperty),
-                    refProperty: $refProperty,
-                    isUpdate: $isUpdate,
-                    hasDefaultValue: $inputProperty->hasDefaultValue(),
-                    defaultValue: $inputProperty->getDefaultValue(),
-                );
-
-                $field = $this->inputFieldMiddleware->process($inputFieldDescriptor, new class implements InputFieldHandlerInterface {
-                    public function handle(InputFieldDescriptor $inputFieldDescriptor): InputField|null
-                    {
-                        return InputField::fromFieldDescriptor($inputFieldDescriptor);
-                    }
-                });
+            $type = $inputProperty->getType();
+            if (!$inputType && $isUpdate && $type instanceof NonNull) {
+                $type = $type->getWrappedType();
             }
+            assert($type instanceof InputType);
+            $forConstructorHydration = in_array($name, $constructerParameters);
+            $resolver = $forConstructorHydration ?
+                new SourceConstructorParameterResolver($refProperty->getDeclaringClass()->getName(), $refProperty->getName()) :
+                new SourceInputPropertyResolver($refProperty);
+
+            // setters and properties
+            $inputFieldDescriptor = new InputFieldDescriptor(
+                name: $inputProperty->getName(),
+                type: $type,
+                resolver: $resolver,
+                originalResolver: $resolver,
+                parameters: [$inputProperty->getName() => $inputProperty],
+                injectSource: false,
+                forConstructorHydration: $forConstructorHydration,
+                comment: trim($description),
+                middlewareAnnotations: $this->annotationReader->getMiddlewareAnnotations($refProperty),
+                isUpdate: $isUpdate,
+                hasDefaultValue: $inputProperty->hasDefaultValue(),
+                defaultValue: $inputProperty->getDefaultValue(),
+            );
+
+            $field = $this->inputFieldMiddleware->process($inputFieldDescriptor, new class implements InputFieldHandlerInterface {
+                public function handle(InputFieldDescriptor $inputFieldDescriptor): InputField|null
+                {
+                    return InputField::fromFieldDescriptor($inputFieldDescriptor);
+                }
+            });
 
             if ($field === null) {
                 continue;

--- a/src/InputField.php
+++ b/src/InputField.php
@@ -32,16 +32,25 @@ final class InputField extends InputObjectField
     /** @var callable */
     private $resolve;
 
-    private bool $forConstructorHydration = false;
-
     /**
      * @param (Type&InputType) $type
      * @param array<string, ParameterInterface> $arguments Indexed by argument name.
      * @param mixed|null $defaultValue the default value set for this field
      * @param array{defaultValue?: mixed,description?: string|null,astNode?: InputValueDefinitionNode|null}|null $additionalConfig
      */
-    public function __construct(string $name, InputType $type, array $arguments, ResolverInterface|null $originalResolver, callable|null $resolver, string|null $comment, bool $isUpdate, bool $hasDefaultValue, mixed $defaultValue, array|null $additionalConfig = null)
-    {
+    public function __construct(
+        string $name,
+        InputType $type,
+        array $arguments,
+        ResolverInterface|null $originalResolver,
+        callable|null $resolver,
+        private bool $forConstructorHydration,
+        string|null $comment,
+        bool $isUpdate,
+        bool $hasDefaultValue,
+        mixed $defaultValue,
+        array|null $additionalConfig = null
+    ) {
         $config = [
             'name' => $name,
             'type' => $type,
@@ -52,28 +61,27 @@ final class InputField extends InputObjectField
             $config['defaultValue'] = $defaultValue;
         }
 
-        if ($originalResolver !== null && $resolver !== null) {
-            $this->resolve = function (object $source, array $args, $context, ResolveInfo $info) use ($arguments, $originalResolver, $resolver) {
+        $this->resolve = function (object|null $source, array $args, $context, ResolveInfo $info) use ($arguments, $originalResolver, $resolver) {
+            if ($this->forConstructorHydration) {
+                $toPassArgs = [
+                    $arguments[$this->name]->resolve($source, $args, $context, $info)
+                ];
+            } else {
                 $toPassArgs = $this->paramsToArguments($arguments, $source, $args, $context, $info, $resolver);
-                $result = $resolver($source, ...$toPassArgs);
+            }
 
-                try {
-                    $this->assertInputType($result);
-                } catch (TypeMismatchRuntimeException $e) {
-                    $e->addInfo($this->name, $originalResolver->toString());
-                    throw $e;
-                }
+            $result = $resolver($source, ...$toPassArgs);
 
-                return $result;
-            };
-        } else {
-            $this->forConstructorHydration = true;
-            $this->resolve = function (object|null $source, array $args, $context, ResolveInfo $info) use ($arguments) {
-                $result = $arguments[$this->name]->resolve($source, $args, $context, $info);
+            try {
                 $this->assertInputType($result);
-                return $result;
-            };
-        }
+            } catch (TypeMismatchRuntimeException $e) {
+                $e->addInfo($this->name, $originalResolver->toString());
+                throw $e;
+            }
+
+            return $result;
+        };
+
         if ($additionalConfig !== null) {
             if (isset($additionalConfig['astNode'])) {
                 $config['astNode'] = $additionalConfig['astNode'];
@@ -126,6 +134,7 @@ final class InputField extends InputObjectField
             $fieldDescriptor->getParameters(),
             $fieldDescriptor->getOriginalResolver(),
             $fieldDescriptor->getResolver(),
+            $fieldDescriptor->isForConstructorHydration(),
             $fieldDescriptor->getComment(),
             $fieldDescriptor->isUpdate(),
             $fieldDescriptor->hasDefaultValue(),

--- a/src/Middlewares/BadExpressionInSecurityException.php
+++ b/src/Middlewares/BadExpressionInSecurityException.php
@@ -16,7 +16,11 @@ class BadExpressionInSecurityException extends Exception
 {
     public static function wrapException(Throwable $e, QueryFieldDescriptor|InputFieldDescriptor $fieldDescriptor): self
     {
-        $refMethod = $fieldDescriptor->getRefMethod();
+        $originalResolver = $fieldDescriptor->getOriginalResolver();
+
+        assert($originalResolver instanceof SourceMethodResolver);
+
+        $refMethod = $originalResolver->methodReflection();
         $message = 'An error occurred while evaluating expression in @Security annotation of method "' . $refMethod?->getDeclaringClass()?->getName() . '::' . $refMethod?->getName() . '": ' . $e->getMessage();
 
         return new self($message, $e->getCode(), $e);

--- a/src/Middlewares/MagicPropertyResolver.php
+++ b/src/Middlewares/MagicPropertyResolver.php
@@ -21,6 +21,19 @@ final class MagicPropertyResolver implements ResolverInterface
     ) {
     }
 
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+        return $this->className;
+    }
+
+    public function propertyName(): string
+    {
+        return $this->propertyName;
+    }
+
     public function executionSource(object|null $source): object
     {
         if ($source === null) {

--- a/src/Middlewares/ServiceResolver.php
+++ b/src/Middlewares/ServiceResolver.php
@@ -22,6 +22,11 @@ final class ServiceResolver implements ResolverInterface
         $this->callable = $callable;
     }
 
+    public function callable(): callable
+    {
+        return $this->callable;
+    }
+
     public function executionSource(object|null $source): object
     {
         return $this->callable[0];

--- a/src/Middlewares/SourceConstructorParameterResolver.php
+++ b/src/Middlewares/SourceConstructorParameterResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Middlewares;
+
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
+
+/**
+ * Resolves field by returning the passed value, so it can later be used in construction of the input type.
+ *
+ * @internal
+ */
+class SourceConstructorParameterResolver implements ResolverInterface
+{
+    public function __construct(
+        private readonly string $className,
+        private readonly string $parameterName,
+    ) {
+    }
+
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+        return $this->className;
+    }
+
+    public function parameterName(): string
+    {
+        return $this->parameterName;
+    }
+
+    public function executionSource(object|null $source): object
+    {
+        return $source;
+    }
+
+    public function __invoke(object|null $source, mixed ...$args): mixed
+    {
+        return $args[0];
+    }
+
+    public function toString(): string
+    {
+        return $this->className . '::__construct($' . $this->parameterName . ')';
+    }
+}

--- a/src/Middlewares/SourceInputPropertyResolver.php
+++ b/src/Middlewares/SourceInputPropertyResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Middlewares;
 
+use ReflectionProperty;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\Utils\PropertyAccessor;
 
@@ -15,10 +16,14 @@ use TheCodingMachine\GraphQLite\Utils\PropertyAccessor;
 final class SourceInputPropertyResolver implements ResolverInterface
 {
     public function __construct(
-        private readonly string $className,
-        private readonly string $propertyName,
+        private readonly ReflectionProperty $propertyReflection,
     )
     {
+    }
+
+    public function propertyReflection(): ReflectionProperty
+    {
+        return $this->propertyReflection;
     }
 
     public function executionSource(object|null $source): object
@@ -36,13 +41,13 @@ final class SourceInputPropertyResolver implements ResolverInterface
             throw new GraphQLRuntimeException('You must provide a source for SourceInputPropertyResolver.');
         }
 
-        PropertyAccessor::setValue($source, $this->propertyName, ...$args);
+        PropertyAccessor::setValue($source, $this->propertyReflection->getName(), ...$args);
 
         return $args[0];
     }
 
     public function toString(): string
     {
-        return $this->className . '::' . $this->propertyName;
+        return $this->propertyReflection->getDeclaringClass()->getName() . '::' . $this->propertyReflection->getName();
     }
 }

--- a/src/Middlewares/SourceMethodResolver.php
+++ b/src/Middlewares/SourceMethodResolver.php
@@ -17,10 +17,14 @@ use function is_callable;
 final class SourceMethodResolver implements ResolverInterface
 {
     public function __construct(
-        private readonly string $className,
-        private readonly string $methodName,
+        private readonly \ReflectionMethod $methodReflection,
     )
     {
+    }
+
+    public function methodReflection(): \ReflectionMethod
+    {
+        return $this->methodReflection;
     }
 
     public function executionSource(object|null $source): object
@@ -38,7 +42,7 @@ final class SourceMethodResolver implements ResolverInterface
             throw new GraphQLRuntimeException('You must provide a source for SourceMethodResolver.');
         }
 
-        $callable = [$source, $this->methodName];
+        $callable = [$source, $this->methodReflection->getName()];
         assert(is_callable($callable));
 
         return $callable(...$args);
@@ -46,6 +50,6 @@ final class SourceMethodResolver implements ResolverInterface
 
     public function toString(): string
     {
-        return $this->className . '::' . $this->methodName . '()';
+        return $this->methodReflection->getDeclaringClass()->getName() . '::' . $this->methodReflection->getName() . '()';
     }
 }

--- a/src/Middlewares/SourcePropertyResolver.php
+++ b/src/Middlewares/SourcePropertyResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Middlewares;
 
+use ReflectionProperty;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\Utils\PropertyAccessor;
 
@@ -15,10 +16,14 @@ use TheCodingMachine\GraphQLite\Utils\PropertyAccessor;
 final class SourcePropertyResolver implements ResolverInterface
 {
     public function __construct(
-        private readonly string $className,
-        private readonly string $propertyName,
+        private readonly ReflectionProperty $propertyReflection,
     )
     {
+    }
+
+    public function propertyReflection(): ReflectionProperty
+    {
+        return $this->propertyReflection;
     }
 
     public function executionSource(object|null $source): object
@@ -36,11 +41,11 @@ final class SourcePropertyResolver implements ResolverInterface
             throw new GraphQLRuntimeException('You must provide a source for SourcePropertyResolver.');
         }
 
-        return PropertyAccessor::getValue($source, $this->propertyName, ...$args);
+        return PropertyAccessor::getValue($source, $this->propertyReflection->getName(), ...$args);
     }
 
     public function toString(): string
     {
-        return $this->className . '::' . $this->propertyName;
+        return $this->propertyReflection->getDeclaringClass()->getName() . '::' . $this->propertyReflection->getName();
     }
 }

--- a/src/QueryFieldDescriptor.php
+++ b/src/QueryFieldDescriptor.php
@@ -12,6 +12,7 @@ use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotations;
 use TheCodingMachine\GraphQLite\Middlewares\MagicPropertyResolver;
 use TheCodingMachine\GraphQLite\Middlewares\ResolverInterface;
 use TheCodingMachine\GraphQLite\Middlewares\ServiceResolver;
+use TheCodingMachine\GraphQLite\Middlewares\SourceInputPropertyResolver;
 use TheCodingMachine\GraphQLite\Middlewares\SourceMethodResolver;
 use TheCodingMachine\GraphQLite\Middlewares\SourcePropertyResolver;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
@@ -29,30 +30,21 @@ class QueryFieldDescriptor
 {
     use Cloneable;
 
-    private readonly ResolverInterface $originalResolver;
-    /** @var callable */
-    private readonly mixed $resolver;
-
     /**
      * @param array<string, ParameterInterface> $parameters
-     * @param callable $callable
+     * @param callable $resolver
      * @param bool $injectSource Whether we should inject the source as the first parameter or not.
      */
     public function __construct(
         private readonly string $name,
         private readonly OutputType&Type $type,
+        private readonly mixed $resolver,
+        private readonly SourcePropertyResolver|MagicPropertyResolver|SourceMethodResolver|ServiceResolver $originalResolver,
         private readonly array $parameters = [],
-        private readonly mixed $callable = null,
-        private readonly string|null $targetClass = null,
-        private readonly string|null $targetMethodOnSource = null,
-        private readonly string|null $targetPropertyOnSource = null,
-        private readonly string|null $magicProperty = null,
         private readonly bool $injectSource = false,
         private readonly string|null $comment = null,
         private readonly string|null $deprecationReason = null,
         private readonly MiddlewareAnnotations $middlewareAnnotations = new MiddlewareAnnotations([]),
-        private readonly ReflectionMethod|null $refMethod = null,
-        private readonly ReflectionProperty|null $refProperty = null,
     )
     {
     }
@@ -87,71 +79,6 @@ class QueryFieldDescriptor
     public function withParameters(array $parameters): self
     {
         return $this->with(parameters: $parameters);
-    }
-
-    /**
-     * Sets the callable targeting the resolver function if the resolver function is part of a service.
-     * This should not be used in the context of a field middleware.
-     * Use getResolver/setResolver if you want to wrap the resolver in another method.
-     */
-    public function withCallable(callable $callable): self
-    {
-        if (isset($this->originalResolver)) {
-            throw new GraphQLRuntimeException('You cannot modify the callable via withCallable because it was already used. You can still wrap the callable using getResolver/withResolver');
-        }
-
-        return $this->with(
-            callable: $callable,
-            targetClass: null,
-            targetMethodOnSource: null,
-            targetPropertyOnSource: null,
-            magicProperty: null,
-        );
-    }
-
-    public function withTargetMethodOnSource(string $className, string $targetMethodOnSource): self
-    {
-        if (isset($this->originalResolver)) {
-            throw new GraphQLRuntimeException('You cannot modify the target method via withTargetMethodOnSource because it was already used. You can still wrap the callable using getResolver/withResolver');
-        }
-
-        return $this->with(
-            callable: null,
-            targetClass: $className,
-            targetMethodOnSource: $targetMethodOnSource,
-            targetPropertyOnSource: null,
-            magicProperty: null,
-        );
-    }
-
-    public function withTargetPropertyOnSource(string $className, string|null $targetPropertyOnSource): self
-    {
-        if (isset($this->originalResolver)) {
-            throw new GraphQLRuntimeException('You cannot modify the target method via withTargetMethodOnSource because it was already used. You can still wrap the callable using getResolver/withResolver');
-        }
-
-        return $this->with(
-            callable: null,
-            targetClass: $className,
-            targetMethodOnSource: null,
-            targetPropertyOnSource: $targetPropertyOnSource,
-            magicProperty: null,
-        );
-    }
-
-    public function withMagicProperty(string $className, string $magicProperty): self
-    {
-        if (isset($this->originalResolver)) {
-            throw new GraphQLRuntimeException('You cannot modify the target method via withMagicProperty because it was already used. You can still wrap the callable using getResolver/withResolver');
-        }
-
-        return $this->with(
-            callable: null,
-            targetClass: $className,
-            targetMethodOnSource: null,
-            targetPropertyOnSource: null,
-            magicProperty: $magicProperty,
-        );
     }
 
     public function isInjectSource(): bool
@@ -203,55 +130,11 @@ class QueryFieldDescriptor
         return $this->with(middlewareAnnotations: $middlewareAnnotations);
     }
 
-    public function getRefMethod(): ReflectionMethod|null
-    {
-        return $this->refMethod;
-    }
-
-    public function withRefMethod(ReflectionMethod $refMethod): self
-    {
-        return $this->with(refMethod: $refMethod);
-    }
-
-    public function getRefProperty(): ReflectionProperty|null
-    {
-        return $this->refProperty;
-    }
-
-    public function withRefProperty(ReflectionProperty $refProperty): self
-    {
-        return $this->with(refProperty: $refProperty);
-    }
-
     /**
      * Returns the original callable that will be used to resolve the field.
      */
-    public function getOriginalResolver(): ResolverInterface
+    public function getOriginalResolver(): SourcePropertyResolver|MagicPropertyResolver|SourceMethodResolver|ServiceResolver
     {
-        if (isset($this->originalResolver)) {
-            return $this->originalResolver;
-        }
-
-        if (is_array($this->callable)) {
-            /** @var callable&array{0:object, 1:string} $callable */
-            $callable = $this->callable;
-            $this->originalResolver = new ServiceResolver($callable);
-        } elseif ($this->targetMethodOnSource !== null) {
-            assert($this->targetClass !== null);
-
-            $this->originalResolver = new SourceMethodResolver($this->targetClass, $this->targetMethodOnSource);
-        } elseif ($this->targetPropertyOnSource !== null) {
-            assert($this->targetClass !== null);
-
-            $this->originalResolver = new SourcePropertyResolver($this->targetClass, $this->targetPropertyOnSource);
-        } elseif ($this->magicProperty !== null) {
-            assert($this->targetClass !== null);
-
-            $this->originalResolver = new MagicPropertyResolver($this->targetClass, $this->magicProperty);
-        } else {
-            throw new GraphQLRuntimeException('The QueryFieldDescriptor should be passed either a resolve method (via withCallable) or a target method on source object (via withTargetMethodOnSource) or a magic property (via withMagicProperty).');
-        }
-
         return $this->originalResolver;
     }
 
@@ -261,10 +144,6 @@ class QueryFieldDescriptor
      */
     public function getResolver(): callable
     {
-        if (! isset($this->resolver)) {
-            $this->resolver = $this->getOriginalResolver();
-        }
-
         return $this->resolver;
     }
 

--- a/tests/QueryFieldDescriptorTest.php
+++ b/tests/QueryFieldDescriptorTest.php
@@ -8,61 +8,6 @@ use stdClass;
 
 class QueryFieldDescriptorTest extends TestCase
 {
-    public function testExceptionInSetCallable(): void
-    {
-        $descriptor = new QueryFieldDescriptor(
-            name: 'test',
-            type: Type::string(),
-            callable: [$this, 'testExceptionInSetCallable'],
-        );
-        $descriptor->getResolver();
-
-        $this->expectException(GraphQLRuntimeException::class);
-        $descriptor->withCallable([$this, 'testExceptionInSetCallable']);
-    }
-
-    public function testExceptionInSetTargetMethodOnSource(): void
-    {
-        $descriptor = new QueryFieldDescriptor(
-            name: 'test',
-            type: Type::string(),
-            targetClass: stdClass::class,
-            targetMethodOnSource: 'test'
-        );
-        $descriptor->getResolver();
-
-        $this->expectException(GraphQLRuntimeException::class);
-        $descriptor->withTargetMethodOnSource(stdClass::class, 'test');
-    }
-
-    public function testExceptionInSetTargetPropertyOnSource(): void
-    {
-        $descriptor = new QueryFieldDescriptor(
-            name: 'test',
-            type: Type::string(),
-            targetClass: stdClass::class,
-            targetPropertyOnSource: 'test',
-        );
-        $descriptor->getResolver();
-
-        $this->expectException(GraphQLRuntimeException::class);
-        $descriptor->withTargetPropertyOnSource(stdClass::class, 'test');
-    }
-
-    public function testExceptionInSetMagicProperty(): void
-    {
-        $descriptor = new QueryFieldDescriptor(
-            name: 'test',
-            type: Type::string(),
-            targetClass: stdClass::class,
-            magicProperty: 'test'
-        );
-        $descriptor->getResolver();
-
-        $this->expectException(GraphQLRuntimeException::class);
-        $descriptor->withMagicProperty(stdClass::class, 'test');
-    }
-
     public function testExceptionInGetOriginalResolver(): void
     {
         $descriptor = new QueryFieldDescriptor('test', Type::string());

--- a/tests/Types/InputTypeTest.php
+++ b/tests/Types/InputTypeTest.php
@@ -175,24 +175,6 @@ class InputTypeTest extends AbstractQueryProviderTest
         $this->assertEquals(200, $result->getBar());
     }
 
-    /**
-     * @group PR-466
-     */
-    public function testConstructorHydrationFailingWithMiddlewareAnnotations(): void
-    {
-        $this->expectException(IncompatibleAnnotationsException::class);
-
-        $input = new InputType(
-            TestConstructorAndPropertiesInvalid::class,
-            'TestConstructorAndPropertiesInvalidInput',
-            null,
-            false,
-            $this->getFieldsBuilder(),
-        );
-        $input->freeze();
-        $fields = $input->getFields();
-    }
-
     public function testFailsResolvingFieldWithoutRequiredConstructParam(): void
     {
         $input = new InputType(FooBar::class, 'FooBarInput', null, false, $this->getFieldsBuilder());
@@ -202,7 +184,7 @@ class InputTypeTest extends AbstractQueryProviderTest
         $resolveInfo = $this->createMock(ResolveInfo::class);
 
         $this->expectException(FailedResolvingInputType::class);
-        $this->expectExceptionMessage("Parameter 'foo' is missing for class 'TheCodingMachine\GraphQLite\Fixtures\Inputs\FooBar' constructor. It should be mapped as required field.");
+        $this->expectExceptionMessage("TheCodingMachine\GraphQLite\Fixtures\Inputs\FooBar::__construct(): Argument #1 (\$foo) not passed. It should be mapped as required field.");
 
         $input->resolve(null, $args, [], $resolveInfo);
     }


### PR DESCRIPTION
Hey @oojacoboo. This is a draft, but I wanted you to take a look first before I get to fix the tests and polish this. There are no new tests as of now.

This is the minimum fix needed to close #565 and allow constructor fields to have middleware, allowing this kind of code:

```php
#[Input]
class SomeType {
    public function __construct(
        #[Field]
        #[SomeMiddleware]
        public readonly string $field,
    ) {}
}
```

What I did is I refactored resolvers a bit to make sure a single input middleware could be used for both constructor and "set" properties. This is done by requiring resolvers to always return the value that will be set if a parameter is fed into a constructor, as opposed to being set directly through the property.