### PR TITLE
Fix magic call

### DIFF
--- a/tests/Fixtures/Types/GetterSetterType.php
+++ b/tests/Fixtures/Types/GetterSetterType.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+
+class GetterSetterType
+{
+    public function __construct(
+        #[Field]
+        public string $one = '',
+        #[Field]
+        public string $two = '',
+        #[Field]
+        public bool $three = false,
+        #[Field]
+        public string $four = '',
+    )
+    {
+    }
+
+    public function getTwo(string $arg = ''): string
+    {
+        return $arg;
+    }
+
+    public function setTwo(string $value): void
+    {
+        $this->two = $value . ' set';
+    }
+
+    public function isThree(string $arg = ''): bool
+    {
+        return $arg === 'foo';
+    }
+
+    private function getFour(string $arg = ''): string
+    {
+        throw new \RuntimeException('Should not be called');
+    }
+
+    private function setFour(string $value, string $arg): void
+    {
+        throw new \RuntimeException('Should not be called');
+    }
+}

--- a/tests/Fixtures/Types/MagicGetterSetterType.php
+++ b/tests/Fixtures/Types/MagicGetterSetterType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Types;
+
+class MagicGetterSetterType extends GetterSetterType
+{
+    private string $magic;
+
+    public function __get(string $name)
+    {
+        return $this->magic;
+    }
+
+    public function __call(string $name, array $arguments)
+    {
+        $this->magic = 'magic';
+
+        return 'magic';
+    }
+}

--- a/tests/Utils/PropertyAccessorTest.php
+++ b/tests/Utils/PropertyAccessorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Utils;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Post;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Preferences;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Product;
+use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\TrickyProduct;
+use TheCodingMachine\GraphQLite\Fixtures\Types\GetterSetterType;
+use TheCodingMachine\GraphQLite\Fixtures\Types\MagicGetterSetterType;
+
+class PropertyAccessorTest extends TestCase
+{
+    /**
+     * @dataProvider findGetterProvider
+     */
+    public function testFindGetter(mixed $expected, string $class, string $propertyName): void
+    {
+        self::assertSame($expected, PropertyAccessor::findGetter($class, $propertyName));
+    }
+
+    public static function findGetterProvider(): iterable
+    {
+        yield 'regular property' => [null, MagicGetterSetterType::class, 'one'];
+        yield 'getter' => ['getTwo', MagicGetterSetterType::class, 'two'];
+        yield 'isser' => ['isThree', MagicGetterSetterType::class, 'three'];
+        yield 'private getter' => [null, MagicGetterSetterType::class, 'four'];
+        yield 'undefined property' => [null, MagicGetterSetterType::class, 'twenty'];
+    }
+
+    /**
+     * @dataProvider findSetterProvider
+     */
+    public function testFindSetter(mixed $expected, string $class, string $propertyName): void
+    {
+        self::assertSame($expected, PropertyAccessor::findSetter($class, $propertyName));
+    }
+
+    public static function findSetterProvider(): iterable
+    {
+        yield 'regular property' => [null, MagicGetterSetterType::class, 'one'];
+        yield 'setter' => ['setTwo', MagicGetterSetterType::class, 'two'];
+        yield 'private setter' => [null, MagicGetterSetterType::class, 'four'];
+        yield 'undefined property' => [null, MagicGetterSetterType::class, 'twenty'];
+    }
+
+    /**
+     * @dataProvider getValueProvider
+     */
+    public function testGetValue(mixed $expected, object $object, string $propertyName, array $args = []): void
+    {
+        if ($expected instanceof Exception) {
+            $this->expectExceptionObject($expected);
+        }
+
+        self::assertSame($expected, PropertyAccessor::getValue($object, $propertyName, ...$args));
+    }
+
+    public static function getValueProvider(): iterable
+    {
+        yield 'regular property' => ['result', new MagicGetterSetterType(one: 'result'), 'one'];
+        yield 'getter' => ['result', new MagicGetterSetterType(), 'two', ['result']];
+        yield 'isser #1' => [true, new MagicGetterSetterType(), 'three', ['foo']];
+        yield 'isser #2' => [false, new MagicGetterSetterType(), 'three', ['bar']];
+        yield 'private getter' => ['result', new MagicGetterSetterType(four: 'result'), 'four'];
+        yield 'magic getter' => ['magic', new MagicGetterSetterType(), 'twenty'];
+        yield 'undefined property' => [AccessPropertyException::createForUnreadableProperty(GetterSetterType::class, 'twenty'), new GetterSetterType(), 'twenty'];
+    }
+
+    /**
+     * @dataProvider setValueProvider
+     */
+    public function testSetValue(mixed $expected, object $object, string $propertyName, mixed $value): void
+    {
+        if ($expected instanceof Exception) {
+            $this->expectExceptionObject($expected);
+        }
+
+        PropertyAccessor::setValue($object, $propertyName, $value);
+
+        self::assertSame($expected, $object->{$propertyName});
+    }
+
+    public static function setValueProvider(): iterable
+    {
+        yield 'regular property' => ['result', new MagicGetterSetterType(one: 'result'), 'one', 'result'];
+        yield 'setter' => ['result set', new MagicGetterSetterType(), 'two', 'result'];
+        yield 'private setter' => ['result', new MagicGetterSetterType(four: 'result'), 'four', 'result'];
+        yield 'magic setter' => ['magic', new MagicGetterSetterType(), 'twenty', 'result'];
+        yield 'undefined property' => [AccessPropertyException::createForUnwritableProperty(GetterSetterType::class, 'twenty'), new GetterSetterType(), 'twenty', 'result'];
+    }
+}


### PR DESCRIPTION
Closes #638

While fixing this I thought it'd probably be better to explicitly mark field getter and setters with an annotation instead of automatically detecting them with `get`, `set` and `is` prefixes, but maybe just waiting till PHP 8.4 is a better call: by PHP 8.4 we'll hopefully have property accessors so we can drop support for getters/setters/issers and magic `__call` altogether.

For now, this is just a fix of precedence - now "real" properties always take precedence over `__call` calls.