### PR TITLE
fix: RecursiveTypeMapper returns exception which can't be handled by StandardServer

### DIFF
--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
+use GraphQL\Error\Error;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Utils\Utils;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use RuntimeException;
@@ -520,7 +522,6 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
 
             return $this->mapClassToInterfaceOrType($className, null);
         }
-
-        throw CannotMapTypeException::createForName($typeName);
+        throw Error::createLocatedError("Unknown type ".Utils::printSafe($typeName));
     }
 }

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -520,6 +520,7 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
 
             return $this->mapClassToInterfaceOrType($className, null);
         }
+
         throw TypeNotFoundException::createError($typeName);
     }
 }

--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Mappers;
 
-use GraphQL\Error\Error;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
-use GraphQL\Utils\Utils;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use RuntimeException;
@@ -522,6 +520,6 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
 
             return $this->mapClassToInterfaceOrType($className, null);
         }
-        throw Error::createLocatedError("Unknown type ".Utils::printSafe($typeName));
+        throw TypeNotFoundException::createError($typeName);
     }
 }

--- a/src/Mappers/TypeNotFoundException.php
+++ b/src/Mappers/TypeNotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Mappers;
+
+use GraphQL\Error\Error;
+use GraphQL\Utils\Utils;
+
+/**
+ * TypeNotFoundException thrown when RecursiveTypeMapper fails to find a type.
+ *
+ * While CannotMapTypeException is more about error with configuration this exception can occur when request
+ * contains a type which is unknown to the server.
+ * Should not be handled by the user, webonyx/graphql-php will transform this under 'errors' key in the response.
+ */
+class TypeNotFoundException extends Error
+{
+    public static function createError(string $typeName): Error
+    {
+        return static::createLocatedError('Unknown type ' . Utils::printSafe($typeName));
+    }
+}

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -3,7 +3,6 @@
 namespace TheCodingMachine\GraphQLite\Mappers;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use GraphQL\Error\Error;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
@@ -94,7 +93,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
         $this->assertSame('ClassA', $recursiveMapper->mapNameToType('ClassA')->name);
         $this->assertSame('ClassAInterface', $recursiveMapper->mapNameToType('ClassAInterface')->name);
 
-        $this->expectException(Error::class);
+        $this->expectException(TypeNotFoundException::class);
         $recursiveMapper->mapNameToType('NotExists');
     }
 
@@ -247,7 +246,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
             $this->getAnnotationReader()
         );
 
-        $this->expectException(Error::class);
+        $this->expectException(TypeNotFoundException::class);
         $recursiveTypeMapper->mapNameToType('Foo');
     }
 

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite\Mappers;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use GraphQL\Error\Error;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\ObjectType;
@@ -93,7 +94,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
         $this->assertSame('ClassA', $recursiveMapper->mapNameToType('ClassA')->name);
         $this->assertSame('ClassAInterface', $recursiveMapper->mapNameToType('ClassAInterface')->name);
 
-        $this->expectException(CannotMapTypeException::class);
+        $this->expectException(Error::class);
         $recursiveMapper->mapNameToType('NotExists');
     }
 
@@ -233,6 +234,8 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
 
     /**
      * Tests that the RecursiveTypeMapper behaves correctly if there are no types to map.
+     *
+     * @see \GraphQL\Server\Helper::promiseToExecuteOperation()
      */
     public function testMapNoTypes(): void
     {
@@ -244,7 +247,7 @@ class RecursiveTypeMapperTest extends AbstractQueryProviderTest
             $this->getAnnotationReader()
         );
 
-        $this->expectException(CannotMapTypeException::class);
+        $this->expectException(Error::class);
         $recursiveTypeMapper->mapNameToType('Foo');
     }
 

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -129,20 +129,21 @@ class SchemaFactoryTest extends TestCase
 
     public function testClassNameMapperInjectionWithInvalidMapper(): void
     {
-        $factory = new SchemaFactory(
-            new Psr16Cache(new ArrayAdapter()),
-            new BasicAutoWiringContainer(
-                new EmptyContainer()
-            )
-        );
-        $factory->setAuthenticationService(new VoidAuthenticationService())
-                ->setAuthorizationService(new VoidAuthorizationService())
-                ->setClassNameMapper(new ClassNameMapper())
-                ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers')
-                ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
-
-        $this->expectException(CannotMapTypeException::class);
-        $this->doTestSchema($factory->createSchema());
+        self::markTestSkipped('Testing configuration through request is wrong approach, consider rewriting this test');
+//        $factory = new SchemaFactory(
+//            new Psr16Cache(new ArrayAdapter()),
+//            new BasicAutoWiringContainer(
+//                new EmptyContainer()
+//            )
+//        );
+//        $factory->setAuthenticationService(new VoidAuthenticationService())
+//                ->setAuthorizationService(new VoidAuthorizationService())
+//                ->setClassNameMapper(new ClassNameMapper())
+//                ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers')
+//                ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
+//
+//        $this->expectException(CannotMapTypeException::class);
+//        $this->doTestSchema($factory->createSchema());
     }
 
     public function testException(): void

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -143,9 +143,7 @@ class SchemaFactoryTest extends TestCase
                 ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers')
                 ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
 
-        $errors = $this->doTestSchemaWithError($factory->createSchema());
-        $this->assertCount(1, $errors);
-        $this->assertSame('Unknown type "User"', $errors[0]['message']);
+        $this->doTestSchemaWithError($factory->createSchema());
     }
 
     public function testException(): void
@@ -193,14 +191,14 @@ class SchemaFactoryTest extends TestCase
         );
     }
 
-    private function doTestSchemaWithError(Schema $schema): array
+    private function doTestSchemaWithError(Schema $schema): void
     {
         $result = $this->_doTestSchema($schema);
         $resultArr = $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
         $this->assertArrayHasKey('errors', $resultArr);
         $this->assertArrayNotHasKey('data', $resultArr);
-
-        return $resultArr['errors'];
+        $this->assertCount(1, $resultArr);
+        $this->assertSame('Unknown type "User"', $resultArr['errors'][0]['message']);
     }
 
     private function doTestSchema(Schema $schema): void

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TheCodingMachine\GraphQLite;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use GraphQL\Error\DebugFlag;
+use GraphQL\Executor\ExecutionResult;
 use GraphQL\GraphQL;
 use GraphQL\Type\SchemaConfig;
 use Mouf\Composer\ClassNameMapper;
@@ -20,22 +24,20 @@ use TheCodingMachine\GraphQLite\Fixtures\Integration\Types\ContactFactory;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Types\ContactOtherType;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Types\ContactType;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Types\ExtendedContactType;
-use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
+use TheCodingMachine\GraphQLite\Fixtures\TestSelfType;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\DuplicateMappingException;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Mappers\Root\VoidRootTypeMapperFactory;
 use TheCodingMachine\GraphQLite\Mappers\StaticClassListTypeMapperFactory;
+use TheCodingMachine\GraphQLite\Mappers\TypeNotFoundException;
 use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewarePipe;
-use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Middlewares\InputFieldMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
-use TheCodingMachine\GraphQLite\Fixtures\TestSelfType;
-
 
 class SchemaFactoryTest extends TestCase
 {
-
     public function testCreateSchema(): void
     {
         $container = new BasicAutoWiringContainer(new EmptyContainer());
@@ -65,7 +67,7 @@ class SchemaFactoryTest extends TestCase
 
         $factory->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers');
         $factory->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
-        $factory->setDoctrineAnnotationReader(new \Doctrine\Common\Annotations\AnnotationReader())
+        $factory->setDoctrineAnnotationReader(new AnnotationReader())
                 ->setAuthenticationService(new VoidAuthenticationService())
                 ->setAuthorizationService(new VoidAuthorizationService())
                 ->setNamingStrategy(new NamingStrategy())
@@ -89,8 +91,8 @@ class SchemaFactoryTest extends TestCase
         $factory = new SchemaFactory(
             new Psr16Cache(new ArrayAdapter()),
             new BasicAutoWiringContainer(
-                new EmptyContainer()
-            )
+                new EmptyContainer(),
+            ),
         );
         $factory->setAuthenticationService(new VoidAuthenticationService())
                 ->setAuthorizationService(new VoidAuthorizationService())
@@ -129,21 +131,21 @@ class SchemaFactoryTest extends TestCase
 
     public function testClassNameMapperInjectionWithInvalidMapper(): void
     {
-        self::markTestSkipped('Testing configuration through request is wrong approach, consider rewriting this test');
-//        $factory = new SchemaFactory(
-//            new Psr16Cache(new ArrayAdapter()),
-//            new BasicAutoWiringContainer(
-//                new EmptyContainer()
-//            )
-//        );
-//        $factory->setAuthenticationService(new VoidAuthenticationService())
-//                ->setAuthorizationService(new VoidAuthorizationService())
-//                ->setClassNameMapper(new ClassNameMapper())
-//                ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers')
-//                ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
-//
-//        $this->expectException(CannotMapTypeException::class);
-//        $this->doTestSchema($factory->createSchema());
+        $factory = new SchemaFactory(
+            new Psr16Cache(new ArrayAdapter()),
+            new BasicAutoWiringContainer(
+                new EmptyContainer(),
+            ),
+        );
+        $factory->setAuthenticationService(new VoidAuthenticationService())
+                ->setAuthorizationService(new VoidAuthorizationService())
+                ->setClassNameMapper(new ClassNameMapper())
+                ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers')
+                ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
+
+        $errors = $this->doTestSchemaWithError($factory->createSchema());
+        $this->assertCount(1, $errors);
+        $this->assertSame('Unknown type "User"', $errors[0]['message']);
     }
 
     public function testException(): void
@@ -169,9 +171,8 @@ class SchemaFactoryTest extends TestCase
         $factory->createSchema();
     }
 
-    private function doTestSchema(Schema $schema): void
+    private function _doTestSchema(Schema $schema): ExecutionResult
     {
-
         $schema->assertValid();
 
         $queryString = '
@@ -186,25 +187,41 @@ class SchemaFactoryTest extends TestCase
         }
         ';
 
-        $result = GraphQL::executeQuery(
+        return GraphQL::executeQuery(
             $schema,
-            $queryString
+            $queryString,
         );
+    }
 
+    private function doTestSchemaWithError(Schema $schema): array
+    {
+        $result = $this->_doTestSchema($schema);
+        $resultArr = $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
+        $this->assertArrayHasKey('errors', $resultArr);
+        $this->assertArrayNotHasKey('data', $resultArr);
+
+        return $resultArr['errors'];
+    }
+
+    private function doTestSchema(Schema $schema): void
+    {
+        $result = $this->_doTestSchema($schema);
+        $resultArr = $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
+        $this->assertArrayHasKey('data', $resultArr);
         $this->assertSame([
             'contacts' => [
                 [
                     'name' => 'Joe',
-                    'uppercaseName' => 'JOE'
+                    'uppercaseName' => 'JOE',
                 ],
                 [
                     'name' => 'Bill',
                     'uppercaseName' => 'BILL',
-                    'email' => 'bill@example.com'
-                ]
+                    'email' => 'bill@example.com',
+                ],
 
-            ]
-        ], $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS)['data']);
+            ],
+        ], $resultArr['data']);
     }
 
     public function testDuplicateQueryException(): void
@@ -212,8 +229,8 @@ class SchemaFactoryTest extends TestCase
         $factory = new SchemaFactory(
             new Psr16Cache(new ArrayAdapter()),
             new BasicAutoWiringContainer(
-                new EmptyContainer()
-            )
+                new EmptyContainer(),
+            ),
         );
         $factory->setAuthenticationService(new VoidAuthenticationService())
                 ->setAuthorizationService(new VoidAuthorizationService())
@@ -230,7 +247,7 @@ class SchemaFactoryTest extends TestCase
         ';
         GraphQL::executeQuery(
             $schema,
-            $queryString
+            $queryString,
         );
     }
 
@@ -239,8 +256,8 @@ class SchemaFactoryTest extends TestCase
         $factory = new SchemaFactory(
             new Psr16Cache(new ArrayAdapter()),
             new BasicAutoWiringContainer(
-                new EmptyContainer()
-            )
+                new EmptyContainer(),
+            ),
         );
         $factory->setAuthenticationService(new VoidAuthenticationService())
             ->setAuthorizationService(new VoidAuthorizationService())
@@ -257,7 +274,7 @@ class SchemaFactoryTest extends TestCase
         ';
         GraphQL::executeQuery(
             $schema,
-            $queryString
+            $queryString,
         );
     }
 }

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -30,7 +30,6 @@ use TheCodingMachine\GraphQLite\Mappers\DuplicateMappingException;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Mappers\Root\VoidRootTypeMapperFactory;
 use TheCodingMachine\GraphQLite\Mappers\StaticClassListTypeMapperFactory;
-use TheCodingMachine\GraphQLite\Mappers\TypeNotFoundException;
 use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Middlewares\InputFieldMiddlewarePipe;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
@@ -169,7 +168,7 @@ class SchemaFactoryTest extends TestCase
         $factory->createSchema();
     }
 
-    private function _doTestSchema(Schema $schema): ExecutionResult
+    private function execTestQuery(Schema $schema): ExecutionResult
     {
         $schema->assertValid();
 
@@ -193,7 +192,7 @@ class SchemaFactoryTest extends TestCase
 
     private function doTestSchemaWithError(Schema $schema): void
     {
-        $result = $this->_doTestSchema($schema);
+        $result = $this->execTestQuery($schema);
         $resultArr = $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
         $this->assertArrayHasKey('errors', $resultArr);
         $this->assertArrayNotHasKey('data', $resultArr);
@@ -203,7 +202,7 @@ class SchemaFactoryTest extends TestCase
 
     private function doTestSchema(Schema $schema): void
     {
-        $result = $this->_doTestSchema($schema);
+        $result = $this->execTestQuery($schema);
         $resultArr = $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS);
         $this->assertArrayHasKey('data', $resultArr);
         $this->assertSame([


### PR DESCRIPTION
RecursiveTypeMapper throws CannotMapTypeException when fails to find class by name. This exception goes through the GraphQl executor instead of catching and wrapping into ExecutionResult. Non wrapped exception does not trigger HttpCodeDecider. Schema test trust more to input than configuration which is not optimal, great possibility to improve configuration validation.

Fixes: #336