### PR TITLE
Add a comment mentioning that FilesystemCache can be used when APCu isn't available

### DIFF
--- a/website/docs/other-frameworks.mdx
+++ b/website/docs/other-frameworks.mdx
@@ -261,6 +261,10 @@ return new Picotainer([
         return $builder->createMiddleware();
     },
     CacheInterface::class => function() {
+        // Any PSR-16 cache should work - APCu is recommended for good
+        // performance, but it requires that module to be enabled. For
+        // small scale testing with zero dependencies, FilesystemCache
+        // can be used instead.
         return new ApcuCache();
     },
     Schema::class => function(ContainerInterface $container) {


### PR DESCRIPTION
Add a comment mentioning that FilesystemCache can be used when APCu isn't available

APCu isn't enabled by default, which makes the example crash, and there are no hints as to what the user is supposed to do about it
