### PR TITLE
feat: replace thecodingmachine/class-explorer with kcs/class-finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "symfony/cache": "^4.3 || ^5 || ^6 || ^7",
         "symfony/expression-language": "^4 || ^5 || ^6 || ^7",
         "thecodingmachine/cache-utils": "^1",
-        "thecodingmachine/class-explorer": "^1.1.0",
-        "webonyx/graphql-php": "^v15.0"
+        "webonyx/graphql-php": "^v15.0",
+        "kcs/class-finder": "^0.4.0"
     },
     "require-dev": {
         "beberlei/porpaginas": "^1.2 || ^2.0",

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -95,7 +95,7 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
     private function buildInstancesList(): array
     {
         $instances = [];
-        foreach ($this->finder->inNamespace($this->namespace) as $className => $refClass) {
+        foreach ((clone $this->finder)->inNamespace($this->namespace) as $className => $refClass) {
             if (! class_exists($className) && ! interface_exists($className)) {
                 continue;
             }

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -6,14 +6,14 @@ namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\FieldDefinition;
 use InvalidArgumentException;
-use Mouf\Composer\ClassNameMapper;
+use Kcs\ClassFinder\Finder\ComposerFinder;
+use Kcs\ClassFinder\Finder\FinderInterface;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
-use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
 use TheCodingMachine\GraphQLite\Annotations\Mutation;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\GraphQLite\Annotations\Subscription;
@@ -33,27 +33,25 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
 {
     /** @var array<int,string>|null */
     private array|null $instancesList = null;
-    private ClassNameMapper $classNameMapper;
+    private FinderInterface $finder;
     private AggregateControllerQueryProvider|null $aggregateControllerQueryProvider = null;
     private CacheContractInterface $cacheContract;
 
     /**
      * @param string $namespace The namespace that contains the GraphQL types (they must have a `@Type` annotation)
      * @param ContainerInterface $container The container we will fetch controllers from.
-     * @param bool $recursive Whether subnamespaces of $namespace must be analyzed.
      */
     public function __construct(
-        private string $namespace,
-        private FieldsBuilder $fieldsBuilder,
-        private ContainerInterface $container,
-        private AnnotationReader $annotationReader,
-        private CacheInterface $cache,
-        ClassNameMapper|null $classNameMapper = null,
-        private int|null $cacheTtl = null,
-        private bool $recursive = true,
+        private readonly string $namespace,
+        private readonly FieldsBuilder $fieldsBuilder,
+        private readonly ContainerInterface $container,
+        private readonly AnnotationReader $annotationReader,
+        private readonly CacheInterface $cache,
+        FinderInterface|null $finder = null,
+        int|null $cacheTtl = null,
     )
     {
-        $this->classNameMapper = $classNameMapper ?? ClassNameMapper::createFromComposerFile(null, null, true);
+        $this->finder = $finder ?? new ComposerFinder();
         $this->cacheContract = new Psr16Adapter(
             $this->cache,
             str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $namespace),
@@ -96,15 +94,12 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
     /** @return array<int,string> */
     private function buildInstancesList(): array
     {
-        $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->cacheTtl, $this->classNameMapper, $this->recursive);
-        $classes = $explorer->getClasses();
         $instances = [];
-        foreach ($classes as $className) {
+        foreach ($this->finder->inNamespace($this->namespace) as $className => $refClass) {
             if (! class_exists($className) && ! interface_exists($className)) {
                 continue;
             }
-            $refClass = new ReflectionClass($className);
-            if (! $refClass->isInstantiable()) {
+            if (! $refClass instanceof ReflectionClass || ! $refClass->isInstantiable()) {
                 continue;
             }
             if (! $this->hasOperations($refClass)) {

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use GraphQL\Type\SchemaConfig;
-use Mouf\Composer\ClassNameMapper;
+use Kcs\ClassFinder\Finder\FinderInterface;
 use MyCLabs\Enum\Enum;
 use PackageVersions\Versions;
 use Psr\Cache\CacheItemPoolInterface;
@@ -109,7 +109,7 @@ class SchemaFactory
 
     private NamingStrategyInterface|null $namingStrategy = null;
 
-    private ClassNameMapper|null $classNameMapper = null;
+    private FinderInterface|null $finder = null;
 
     private SchemaConfig|null $schemaConfig = null;
 
@@ -262,9 +262,9 @@ class SchemaFactory
         return $this;
     }
 
-    public function setClassNameMapper(ClassNameMapper $classNameMapper): self
+    public function setFinder(FinderInterface $finder): self
     {
-        $this->classNameMapper = $classNameMapper;
+        $this->finder = $finder;
 
         return $this;
     }
@@ -344,7 +344,7 @@ class SchemaFactory
         $namingStrategy = $this->namingStrategy ?: new NamingStrategy();
         $typeRegistry = new TypeRegistry();
 
-        $namespaceFactory = new NamespaceFactory($namespacedCache, $this->classNameMapper, $this->globTTL);
+        $namespaceFactory = new NamespaceFactory($namespacedCache, $this->finder, $this->globTTL);
         $nsList = array_map(
             static fn (string $namespace) => $namespaceFactory->createNamespace($namespace),
             $this->typeNamespaces,
@@ -493,7 +493,7 @@ class SchemaFactory
                 $this->container,
                 $annotationReader,
                 $namespacedCache,
-                $this->classNameMapper,
+                $this->finder,
                 $this->globTTL,
             );
         }

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Utils\Namespaces;
 
-use Mouf\Composer\ClassNameMapper;
+use Kcs\ClassFinder\Finder\FinderInterface;
 use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
 use ReflectionClass;
-use TheCodingMachine\ClassExplorer\Glob\GlobClassExplorer;
-
-use function class_exists;
-use function interface_exists;
 
 /**
  * The NS class represents a PHP Namespace and provides utility methods to explore those classes.
@@ -24,7 +21,7 @@ final class NS
      * Only instantiable classes are returned.
      * Key: fully qualified class name
      *
-     * @var array<string,ReflectionClass<object>>
+     * @var array<class-string,ReflectionClass<object>>
      */
     private array|null $classes = null;
 
@@ -32,9 +29,8 @@ final class NS
     public function __construct(
         private readonly string $namespace,
         private readonly CacheInterface $cache,
-        private readonly ClassNameMapper $classNameMapper,
+        private readonly FinderInterface $finder,
         private readonly int|null $globTTL,
-        private readonly bool $recursive,
     ) {
     }
 
@@ -47,31 +43,32 @@ final class NS
     public function getClassList(): array
     {
         if ($this->classes === null) {
-            $this->classes = [];
-            $explorer = new GlobClassExplorer($this->namespace, $this->cache, $this->globTTL, $this->classNameMapper, $this->recursive);
-            /** @var array<class-string, string> $classes Override class-explorer lib */
-            $classes = $explorer->getClassMap();
-            foreach ($classes as $className => $phpFile) {
-                if (! class_exists($className, false) && ! interface_exists($className, false)) {
-                    // Let's try to load the file if it was not imported yet.
-                    // We are importing the file manually to avoid triggering the autoloader.
-                    // The autoloader might trigger errors if the file does not respect PSR-4 or if the
-                    // Symfony DebugAutoLoader is installed. (see https://github.com/thecodingmachine/graphqlite/issues/216)
-                    require_once $phpFile;
-                    // Does it exists now?
-                    // @phpstan-ignore-next-line
-                    if (! class_exists($className, false) && ! interface_exists($className, false)) {
+            $cacheKey = 'GraphQLite_NS_' . $this->namespace;
+            try {
+                $this->classes = $this->cache->get($cacheKey);
+            } catch (InvalidArgumentException) {
+                $this->classes = null;
+            }
+
+            if ($this->classes === null) {
+                $this->classes = [];
+                /** @var class-string $className */
+                /** @var ReflectionClass<object> $reflector */
+                foreach ($this->finder->inNamespace($this->namespace) as $className => $reflector) {
+                    if (! ($reflector instanceof ReflectionClass)) {
                         continue;
                     }
+
+                    $this->classes[$className] = $reflector;
                 }
-
-                $refClass = new ReflectionClass($className);
-
-                $this->classes[$className] = $refClass;
+                try {
+                    $this->cache->set($cacheKey, $this->classes, $this->globTTL);
+                } catch (InvalidArgumentException) {
+                    // @ignoreException
+                }
             }
         }
 
-        // @phpstan-ignore-next-line - Not sure why we cannot annotate the $classes above
         return $this->classes;
     }
 

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -10,6 +10,12 @@ use Psr\SimpleCache\InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
 
+use function array_keys;
+use function class_exists;
+use function interface_exists;
+use function preg_replace;
+use function trait_exists;
+
 /**
  * The NS class represents a PHP Namespace and provides utility methods to explore those classes.
  *
@@ -49,18 +55,18 @@ final class NS
                 $classes = $this->cache->get($cacheKey);
                 if ($classes !== null) {
                     foreach ($classes as $class) {
-                        if (class_exists($class, false) ||
-                            interface_exists($class, false) ||
-                            trait_exists($class, false)) {
-                            try {
-                                $this->classes[$class] = new ReflectionClass($class);
-                            } catch (ReflectionException) {
-                                // @ignoreException
-                            }
+                        if (
+                            ! class_exists($class, false) &&
+                            ! interface_exists($class, false) &&
+                            ! trait_exists($class, false)
+                        ) {
+                            continue;
                         }
+
+                            $this->classes[$class] = new ReflectionClass($class);
                     }
                 }
-            } catch (InvalidArgumentException) {
+            } catch (InvalidArgumentException | ReflectionException) {
                 $this->classes = null;
             }
 

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Utils\Namespaces;
 
+use Exception;
 use Kcs\ClassFinder\Finder\FinderInterface;
+use Psr\SimpleCache\CacheException;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use ReflectionClass;
@@ -38,7 +40,8 @@ final class NS
         private readonly CacheInterface $cache,
         private readonly FinderInterface $finder,
         private readonly int|null $globTTL,
-    ) {
+    )
+    {
     }
 
     /**
@@ -60,13 +63,15 @@ final class NS
                             ! interface_exists($class, false) &&
                             ! trait_exists($class, false)
                         ) {
-                            continue;
+                            // assume the cache is invalid
+                            throw new class extends Exception implements CacheException {
+                            };
                         }
 
-                            $this->classes[$class] = new ReflectionClass($class);
+                        $this->classes[$class] = new ReflectionClass($class);
                     }
                 }
-            } catch (InvalidArgumentException | ReflectionException) {
+            } catch (CacheException | InvalidArgumentException | ReflectionException) {
                 $this->classes = null;
             }
 

--- a/src/Utils/Namespaces/NamespaceFactory.php
+++ b/src/Utils/Namespaces/NamespaceFactory.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Utils\Namespaces;
 
-use Mouf\Composer\ClassNameMapper;
+use Kcs\ClassFinder\Finder\ComposerFinder;
+use Kcs\ClassFinder\Finder\FinderInterface;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -14,16 +15,16 @@ use Psr\SimpleCache\CacheInterface;
  */
 final class NamespaceFactory
 {
-    private ClassNameMapper $classNameMapper;
+    private FinderInterface $finder;
 
-    public function __construct(private readonly CacheInterface $cache, ClassNameMapper|null $classNameMapper = null, private int|null $globTTL = 2)
+    public function __construct(private readonly CacheInterface $cache, FinderInterface|null $finder = null, private int|null $globTTL = 2)
     {
-        $this->classNameMapper = $classNameMapper ?? ClassNameMapper::createFromComposerFile(null, null, true);
+        $this->finder = $finder ?? new ComposerFinder();
     }
 
     /** @param string $namespace A PHP namespace */
-    public function createNamespace(string $namespace, bool $recursive = true): NS
+    public function createNamespace(string $namespace): NS
     {
-        return new NS($namespace, $this->cache, $this->classNameMapper, $this->globTTL, $recursive);
+        return new NS($namespace, $this->cache, clone $this->finder, $this->globTTL);
     }
 }

--- a/tests/Fixtures/BadNamespace/BadlyNamespacedClass.php
+++ b/tests/Fixtures/BadNamespace/BadlyNamespacedClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Fixtures\BadNamespace\None;
+
+class BadlyNamespacedClass
+{
+
+}

--- a/tests/Fixtures/BadNamespace/ClassWithoutNamespace.php
+++ b/tests/Fixtures/BadNamespace/ClassWithoutNamespace.php
@@ -1,0 +1,5 @@
+<?php
+class ClassWithoutNamespace
+{
+
+}

--- a/tests/Fixtures/Types/EnumType.php
+++ b/tests/Fixtures/Types/EnumType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Types;
+
+enum EnumType
+{
+
+}

--- a/tests/GlobControllerQueryProviderTest.php
+++ b/tests/GlobControllerQueryProviderTest.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TheCodingMachine\GraphQLite;
 
+use Kcs\ClassFinder\Finder\ComposerFinder;
 use Psr\Container\ContainerInterface;
+use ReflectionClass;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use TheCodingMachine\GraphQLite\Fixtures\TestController;
@@ -13,10 +17,8 @@ class GlobControllerQueryProviderTest extends AbstractQueryProviderTest
     {
         $controller = new TestController();
 
-        $container = new class([ TestController::class => $controller ]) implements ContainerInterface {
-            /**
-             * @var array
-             */
+        $container = new class ([TestController::class => $controller]) implements ContainerInterface {
+            /** @var array */
             private $controllers;
 
             public function __construct(array $controllers)
@@ -24,26 +26,27 @@ class GlobControllerQueryProviderTest extends AbstractQueryProviderTest
                 $this->controllers = $controllers;
             }
 
-            public function get($id):mixed
+            public function get($id): mixed
             {
                 return $this->controllers[$id];
             }
 
-            public function has($id):bool
+            public function has($id): bool
             {
                 return isset($this->controllers[$id]);
             }
         };
 
+        $finder = new ComposerFinder();
+        $finder->filter(static fn (ReflectionClass $class) => $class->getNamespaceName() === 'TheCodingMachine\\GraphQLite\\Fixtures'); // Fix for recursive:false
         $globControllerQueryProvider = new GlobControllerQueryProvider(
             'TheCodingMachine\\GraphQLite\\Fixtures',
             $this->getFieldsBuilder(),
             $container,
             $this->getAnnotationReader(),
-            new Psr16Cache(new NullAdapter),
-            null,
-            false,
-            false,
+            new Psr16Cache(new NullAdapter()),
+            $finder,
+            0,
         );
 
         $queries = $globControllerQueryProvider->getQueries();

--- a/tests/SchemaFactoryTest.php
+++ b/tests/SchemaFactoryTest.php
@@ -9,7 +9,8 @@ use GraphQL\Error\DebugFlag;
 use GraphQL\Executor\ExecutionResult;
 use GraphQL\GraphQL;
 use GraphQL\Type\SchemaConfig;
-use Mouf\Composer\ClassNameMapper;
+use Kcs\ClassFinder\Finder\ComposerFinder;
+use Kcs\ClassFinder\Finder\RecursiveFinder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
@@ -89,7 +90,7 @@ class SchemaFactoryTest extends TestCase
         $this->doTestSchema($schema);
     }
 
-    public function testClassNameMapperInjectionWithValidMapper(): void
+    public function testFinderInjectionWithValidMapper(): void
     {
         $factory = new SchemaFactory(
             new Psr16Cache(new ArrayAdapter()),
@@ -99,7 +100,7 @@ class SchemaFactoryTest extends TestCase
         );
         $factory->setAuthenticationService(new VoidAuthenticationService())
                 ->setAuthorizationService(new VoidAuthorizationService())
-                ->setClassNameMapper(ClassNameMapper::createFromComposerFile(null, null, true))
+                ->setFinder(new ComposerFinder())
                 ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers')
                 ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
 
@@ -136,7 +137,7 @@ class SchemaFactoryTest extends TestCase
         $this->doTestSchema($schema);
     }
 
-    public function testClassNameMapperInjectionWithInvalidMapper(): void
+    public function testFinderInjectionWithInvalidMapper(): void
     {
         $factory = new SchemaFactory(
             new Psr16Cache(new ArrayAdapter()),
@@ -146,7 +147,7 @@ class SchemaFactoryTest extends TestCase
         );
         $factory->setAuthenticationService(new VoidAuthenticationService())
                 ->setAuthorizationService(new VoidAuthorizationService())
-                ->setClassNameMapper(new ClassNameMapper())
+                ->setFinder(new RecursiveFinder(__DIR__ . '/Annotations'))
                 ->addControllerNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers')
                 ->addTypeNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration');
 

--- a/tests/Utils/NsTest.php
+++ b/tests/Utils/NsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Utils;
+
+use Kcs\ClassFinder\Finder\ComposerFinder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
+use TheCodingMachine\GraphQLite\Fixtures\Types\AbstractFooType;
+use TheCodingMachine\GraphQLite\Fixtures\Types\FooExtendType;
+use TheCodingMachine\GraphQLite\Fixtures\Types\FooType;
+use TheCodingMachine\GraphQLite\Fixtures\Types\GetterSetterType;
+use TheCodingMachine\GraphQLite\Fixtures\Types\MagicGetterSetterType;
+use TheCodingMachine\GraphQLite\Fixtures\Types\NoTypeAnnotation;
+use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory;
+
+class NsTest extends TestCase
+{
+    /**
+     * @dataProvider loadsClassListProvider
+     */
+    public function testLoadsClassList(array $expectedClasses, string $namespace): void
+    {
+        $ns = new NS(
+            namespace: $namespace,
+            cache: new Psr16Cache(new ArrayAdapter()),
+            finder: new ComposerFinder(),
+            globTTL: null
+        );
+
+        self::assertEqualsCanonicalizing($expectedClasses, array_keys($ns->getClassList()));
+    }
+
+    public static function loadsClassListProvider(): iterable
+    {
+        yield 'autoload' => [
+            [
+                TestFactory::class,
+                GetterSetterType::class,
+                FooType::class,
+                MagicGetterSetterType::class,
+                FooExtendType::class,
+                NoTypeAnnotation::class,
+                AbstractFooType::class,
+            ],
+            'TheCodingMachine\GraphQLite\Fixtures\Types',
+        ];
+
+        // The class should be ignored.
+        yield 'incorrect namespace class without autoload' => [
+            [],
+            'TheCodingMachine\GraphQLite\Fixtures\BadNamespace',
+        ];
+    }
+}

--- a/tests/Utils/NsTest.php
+++ b/tests/Utils/NsTest.php
@@ -1,33 +1,51 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TheCodingMachine\GraphQLite\Utils;
 
+use Exception;
 use Kcs\ClassFinder\Finder\ComposerFinder;
 use Kcs\ClassFinder\Finder\FinderInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
-use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
 use TheCodingMachine\GraphQLite\Fixtures\Types\AbstractFooType;
+use TheCodingMachine\GraphQLite\Fixtures\Types\EnumType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\FooExtendType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\FooType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\GetterSetterType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\MagicGetterSetterType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\NoTypeAnnotation;
 use TheCodingMachine\GraphQLite\Fixtures\Types\TestFactory;
+use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
+
+use function array_keys;
 
 class NsTest extends TestCase
 {
-    /**
-     * @dataProvider loadsClassListProvider
-     */
+    private CacheInterface $cache;
+    private string $namespace;
+    private FinderInterface $finder;
+    private int $globTTL;
+    protected function setUp(): void
+    {
+        $this->cache = new Psr16Cache(new ArrayAdapter());
+        $this->namespace = 'TheCodingMachine\GraphQLite\Fixtures\Types';
+        $this->finder = new ComposerFinder();
+        $this->globTTL = 10;
+    }
+
+    /** @dataProvider loadsClassListProvider */
     public function testLoadsClassList(array $expectedClasses, string $namespace): void
     {
         $ns = new NS(
             namespace: $namespace,
-            cache: new Psr16Cache(new ArrayAdapter()),
-            finder: new ComposerFinder(),
-            globTTL: null
+            cache: $this->cache,
+            finder: $this->finder,
+            globTTL: null,
         );
 
         self::assertEqualsCanonicalizing($expectedClasses, array_keys($ns->getClassList()));
@@ -44,6 +62,7 @@ class NsTest extends TestCase
                 FooExtendType::class,
                 NoTypeAnnotation::class,
                 AbstractFooType::class,
+                EnumType::class
             ],
             'TheCodingMachine\GraphQLite\Fixtures\Types',
         ];
@@ -55,15 +74,13 @@ class NsTest extends TestCase
         ];
     }
 
-    public function testCaching(){
-        $cache = new Psr16Cache(new ArrayAdapter());
-        $finder = new ComposerFinder();
-        $namespace = 'TheCodingMachine\GraphQLite\Fixtures\Types';
+    public function testCaching(): void
+    {
         $ns = new NS(
-            namespace: $namespace,
-            cache: $cache,
-            finder: $finder,
-            globTTL: 10
+            namespace: $this->namespace,
+            cache: $this->cache,
+            finder: $this->finder,
+            globTTL: $this->globTTL,
         );
         self::assertNotNull($ns->getClassList());
 
@@ -71,11 +88,57 @@ class NsTest extends TestCase
         $finder = $this->createMock(FinderInterface::class);
         $finder->expects(self::never())->method('inNamespace')->willReturnSelf();
         $ns = new NS(
-            namespace: $namespace,
-            cache: $cache,
+            namespace: $this->namespace,
+            cache: $this->cache,
             finder: $finder,
-            globTTL: 10
+            globTTL: $this->globTTL,
         );
         self::assertNotNull($ns->getClassList());
     }
+
+    public function testCachingWithInvalidKey(): void
+    {
+        $exception = new class extends Exception implements InvalidArgumentException {
+        };
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willThrowException($exception);
+        $cache->expects(self::once())->method('set')->willThrowException($exception);
+        $ns = new NS(
+            namespace: $this->namespace,
+            cache: $cache,
+            finder: $this->finder,
+            globTTL: $this->globTTL,
+        );
+        $ns->getClassList();
+    }
+
+    public function testCachingWithInvalidCache(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willReturn(['foo']);
+        $ns = new NS(
+            namespace: $this->namespace,
+            cache: $cache,
+            finder: $this->finder,
+            globTTL: $this->globTTL,
+        );
+        $classList = $ns->getClassList();
+        self::assertNotNull($classList);
+        self::assertNotEmpty($classList);
+    }
+
+    public function testFinderWithUnexpectedOutput() {
+
+        $finder = $this->createMock(FinderInterface::class);
+        $finder->expects(self::once())->method('inNamespace')->willReturnSelf();
+        $finder->expects(self::once())->method('getIterator')->willReturn(new \ArrayIterator([ 'test' => new \ReflectionException()]));
+        $ns = new NS(
+            namespace: $this->namespace,
+            cache: $this->cache,
+            finder: $finder,
+            globTTL: $this->globTTL,
+        );
+        $classList = $ns->getClassList();
+        self::assertNotNull($classList);
+        self::assertEmpty($classList);}
 }

--- a/tests/Utils/NsTest.php
+++ b/tests/Utils/NsTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite\Utils;
 
 use Kcs\ClassFinder\Finder\ComposerFinder;
+use Kcs\ClassFinder\Finder\FinderInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
@@ -52,5 +53,29 @@ class NsTest extends TestCase
             [],
             'TheCodingMachine\GraphQLite\Fixtures\BadNamespace',
         ];
+    }
+
+    public function testCaching(){
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $finder = new ComposerFinder();
+        $namespace = 'TheCodingMachine\GraphQLite\Fixtures\Types';
+        $ns = new NS(
+            namespace: $namespace,
+            cache: $cache,
+            finder: $finder,
+            globTTL: 10
+        );
+        self::assertNotNull($ns->getClassList());
+
+        // create with mock finder to test cache
+        $finder = $this->createMock(FinderInterface::class);
+        $finder->expects(self::never())->method('inNamespace')->willReturnSelf();
+        $ns = new NS(
+            namespace: $namespace,
+            cache: $cache,
+            finder: $finder,
+            globTTL: 10
+        );
+        self::assertNotNull($ns->getClassList());
     }
 }


### PR DESCRIPTION
Main issue is to let type mappers find types in vendor packages which class-explorer and maintainer is not updating the project.

Symfony and Laravel bundles have to be updated too. Fixes: #657