### PR TITLE
Use ComposerFinder's useAutoloading method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/expression-language": "^4 || ^5 || ^6 || ^7",
         "thecodingmachine/cache-utils": "^1",
         "webonyx/graphql-php": "^v15.0",
-        "kcs/class-finder": "^0.4.0"
+        "kcs/class-finder": "dev-master"
     },
     "require-dev": {
         "beberlei/porpaginas": "^1.2 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/expression-language": "^4 || ^5 || ^6 || ^7",
         "thecodingmachine/cache-utils": "^1",
         "webonyx/graphql-php": "^v15.0",
-        "kcs/class-finder": "dev-master"
+        "kcs/class-finder": "^0.5.0"
     },
     "require-dev": {
         "beberlei/porpaginas": "^1.2 || ^2.0",

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -6,7 +6,6 @@ namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\FieldDefinition;
 use InvalidArgumentException;
-use Kcs\ClassFinder\Finder\ComposerFinder;
 use Kcs\ClassFinder\Finder\FinderInterface;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;

--- a/src/GlobControllerQueryProvider.php
+++ b/src/GlobControllerQueryProvider.php
@@ -33,7 +33,6 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
 {
     /** @var array<int,string>|null */
     private array|null $instancesList = null;
-    private FinderInterface $finder;
     private AggregateControllerQueryProvider|null $aggregateControllerQueryProvider = null;
     private CacheContractInterface $cacheContract;
 
@@ -47,11 +46,10 @@ final class GlobControllerQueryProvider implements QueryProviderInterface
         private readonly ContainerInterface $container,
         private readonly AnnotationReader $annotationReader,
         private readonly CacheInterface $cache,
-        FinderInterface|null $finder = null,
+        private readonly FinderInterface $finder,
         int|null $cacheTtl = null,
     )
     {
-        $this->finder = $finder ?? new ComposerFinder();
         $this->cacheContract = new Psr16Adapter(
             $this->cache,
             str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $namespace),

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -126,8 +126,6 @@ class SchemaFactory
 
     private string $cacheNamespace;
 
-    private ?bool $useAutoloading = null;
-
     public function __construct(private CacheInterface $cache, private ContainerInterface $container)
     {
         $this->cacheNamespace = substr(md5(Versions::getVersion('thecodingmachine/graphqlite')), 0, 8);
@@ -273,16 +271,6 @@ class SchemaFactory
     }
 
     /**
-     * Use autoloading when scanning for classes or not.
-     */
-    public function useAutoloading(bool $value = true): self
-    {
-        $this->useAutoloading = $value;
-
-        return $this;
-    }
-
-    /**
      * Sets the time to live time of the cache for annotations in files.
      * By default this is set to 2 seconds which is ok for development environments.
      * Set this to "null" (i.e. infinity) for production environments.
@@ -357,10 +345,6 @@ class SchemaFactory
         $namingStrategy = $this->namingStrategy ?: new NamingStrategy();
         $typeRegistry = new TypeRegistry();
         $finder = $this->finder ?? new ComposerFinder();
-
-        if ($this->useAutoloading !== null) {
-            $finder = $finder->useAutoloading($this->useAutoloading);
-        }
 
         $namespaceFactory = new NamespaceFactory($namespacedCache, $finder, $this->globTTL);
         $nsList = array_map(

--- a/src/Utils/Namespaces/NS.php
+++ b/src/Utils/Namespaces/NS.php
@@ -79,7 +79,7 @@ final class NS
                 $this->classes = [];
                 /** @var class-string $className */
                 /** @var ReflectionClass<object> $reflector */
-                foreach ($this->finder->inNamespace($this->namespace) as $className => $reflector) {
+                foreach ((clone $this->finder)->inNamespace($this->namespace) as $className => $reflector) {
                     if (! ($reflector instanceof ReflectionClass)) {
                         continue;
                     }

--- a/src/Utils/Namespaces/NamespaceFactory.php
+++ b/src/Utils/Namespaces/NamespaceFactory.php
@@ -15,12 +15,11 @@ use Psr\SimpleCache\CacheInterface;
  */
 final class NamespaceFactory
 {
-    private FinderInterface $finder;
-
-    public function __construct(private readonly CacheInterface $cache, FinderInterface|null $finder = null, private int|null $globTTL = 2)
-    {
-        $this->finder = $finder ?? new ComposerFinder();
-    }
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly FinderInterface $finder,
+        private int|null $globTTL = 2
+    ) {}
 
     /** @param string $namespace A PHP namespace */
     public function createNamespace(string $namespace): NS

--- a/src/Utils/Namespaces/NamespaceFactory.php
+++ b/src/Utils/Namespaces/NamespaceFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Utils\Namespaces;
 
-use Kcs\ClassFinder\Finder\ComposerFinder;
 use Kcs\ClassFinder\Finder\FinderInterface;
 use Psr\SimpleCache\CacheInterface;
 
@@ -18,8 +17,9 @@ final class NamespaceFactory
     public function __construct(
         private readonly CacheInterface $cache,
         private readonly FinderInterface $finder,
-        private int|null $globTTL = 2
-    ) {}
+        private int|null $globTTL = 2,
+    ) {
+    }
 
     /** @param string $namespace A PHP namespace */
     public function createNamespace(string $namespace): NS

--- a/tests/AbstractQueryProviderTest.php
+++ b/tests/AbstractQueryProviderTest.php
@@ -9,6 +9,7 @@ use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
+use Kcs\ClassFinder\Finder\ComposerFinder;
 use phpDocumentor\Reflection\TypeResolver as PhpDocumentorTypeResolver;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -466,7 +467,7 @@ abstract class AbstractQueryProviderTest extends TestCase
             $arrayAdapter->setLogger(new ExceptionLogger());
             $psr16Cache = new Psr16Cache($arrayAdapter);
 
-            $this->namespaceFactory = new NamespaceFactory($psr16Cache);
+            $this->namespaceFactory = new NamespaceFactory($psr16Cache, new ComposerFinder());
         }
         return $this->namespaceFactory;
     }

--- a/tests/Fixtures/BadNamespace/BadlyNamespacedClass.php
+++ b/tests/Fixtures/BadNamespace/BadlyNamespacedClass.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace TheCodingMachine\GraphQLite\Fixtures\BadNamespace\None;
-
-class BadlyNamespacedClass
-{
-
-}

--- a/tests/Fixtures/BadNamespace/ClassWithoutNamespace.php
+++ b/tests/Fixtures/BadNamespace/ClassWithoutNamespace.php
@@ -1,5 +1,0 @@
-<?php
-class ClassWithoutNamespace
-{
-
-}

--- a/tests/Fixtures/Integration/Models/BadNamespaceClass.php
+++ b/tests/Fixtures/Integration/Models/BadNamespaceClass.php
@@ -1,9 +1,0 @@
-<?php
-
-/**
- * This class has a bad namespace. It should not trigger errors when using GlobTypeMapper.
- */
-class BadNamespaceClass
-{
-
-}

--- a/website/docs/other-frameworks.mdx
+++ b/website/docs/other-frameworks.mdx
@@ -100,8 +100,8 @@ $result = GraphQL::executeQuery($schema, $query, null, new Context(), $variableV
 
 ### Disabling autoloading
 
-GraphQLite uses `kcs/class-finder` to iterate over classes and find all that have GraphQLite attributes. By default,
-it uses autoloading under the hood. But if you have an older codebase that contains classes with incorrect or missing
+GraphQLite uses `kcs/class-finder` to find all classes that have GraphQLite attributes. By default, it uses
+autoloading under the hood. But if you have an older codebase that contains classes with incorrect or missing
 namespaces, you may need to use `include_once` instead. To do so, you can overwrite the finder using `setFinder()`:
 
 ```php

--- a/website/docs/other-frameworks.mdx
+++ b/website/docs/other-frameworks.mdx
@@ -98,6 +98,26 @@ use TheCodingMachine\GraphQLite\Context\Context;
 $result = GraphQL::executeQuery($schema, $query, null, new Context(), $variableValues);
 ```
 
+### Disabling autoloading
+
+GraphQLite uses `kcs/class-finder` to iterate over classes and find all that have GraphQLite attributes. By default,
+it uses autoloading under the hood. But if you have an older codebase that contains classes with incorrect or missing
+namespaces, you may need to use `include_once` instead. To do so, you can overwrite the finder using `setFinder()`:
+
+```php
+use Kcs\ClassFinder\Finder\ComposerFinder;
+use TheCodingMachine\GraphQLite\SchemaFactory;
+
+$factory = new SchemaFactory($cache, $container);
+$factory->addControllerNamespace('App\\Controllers\\')
+        ->addTypeNamespace('App\\')
+        ->setFinder(
+            (new ComposerFinder())->useAutoloading(false)
+        );
+
+$schema = $factory->createSchema();
+```
+
 ## Minimal example
 
 The smallest working example using no framework is:


### PR DESCRIPTION
Closes #659

This implementation is much simpler: now that we use kcs/class-finder and that it has autoloading enabled by default, the only thing left to do is provide an option to disable it if you need the "legacy" behaviour for whatever reason.

I've tested the new autoloading flow in our project and it's behaving exactly as expected.