### PR TITLE
Add automatically-verified working examples

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -89,3 +89,33 @@ jobs:
           fail_ci_if_error: false # optional (default = false) - Need CODECOV_TOKEN
         # Do not upload in forks, and only on php8.3, latest deps
         if: ${{ github.repository == 'thecodingmachine/graphqlite' && matrix.php-version == '8.3' && matrix.install-args == '' }}
+
+  examples:
+    name: Check Examples
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example: ['no-framework']
+      fail-fast: false
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+      - name: "Install PHP with extensions"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.2"
+          tools: composer:v2
+      - name: "Install dependencies with composer"
+        working-directory: "examples/${{ matrix.example }}"
+        run: "composer --version && composer install --no-interaction --no-progress --prefer-dist"
+      - name: "Run example ${{ matrix.example }}"
+        working-directory: "examples/${{ matrix.example }}"
+        run: |
+          php -S localhost:8080 &
+          sleep 3
+          curl --silent -X POST -H "Content-Type: application/json" \
+            -d '{"query":"{ hello(name: \"World\") }"}' \
+            http://localhost:8080/graphql -o output.json
+          grep -q '"data":{"hello":"Hello World"}' output.json || \
+            (cat output.json && false)
+          kill %1

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 /.php_cs/cache
 /.idea
 
+examples/*/vendor/
+examples/*/composer.lock
+
 node_modules
 
 lib/core/metadata.js

--- a/examples/no-framework/README.md
+++ b/examples/no-framework/README.md
@@ -1,0 +1,11 @@
+No-Framework Integration Example
+================================
+
+```
+composer install
+php -S 127.0.0.1:8080
+```
+
+```
+curl -X POST -d '{"query":"{ hello(name: \"World\") }"}' -H "Content-Type: application/json" http://localhost:8080/
+```

--- a/examples/no-framework/composer.json
+++ b/examples/no-framework/composer.json
@@ -1,0 +1,28 @@
+{
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  },
+  "require": {
+    "thecodingmachine/graphqlite": "@dev",
+    "mouf/picotainer": "^1.1",
+    "symfony/cache": "^4.2"
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "tmp-graphqlite",
+      "options": {
+          "symlink": true
+      }
+    }
+  ],
+  "scripts": {
+    "symlink-package": [
+      "rm -rf tmp-graphqlite && ln -s -f ../../ tmp-graphqlite"
+    ],
+    "pre-install-cmd": "@symlink-package",
+    "pre-update-cmd": "@symlink-package"
+  }
+}

--- a/examples/no-framework/index.php
+++ b/examples/no-framework/index.php
@@ -1,0 +1,41 @@
+<?php
+use GraphQL\GraphQL;
+use GraphQL\Type\Schema;
+use TheCodingMachine\GraphQLite\SchemaFactory;
+use TheCodingMachine\GraphQLite\Context\Context;
+
+use Symfony\Component\Cache\Simple\FilesystemCache;
+use Mouf\Picotainer\Picotainer;
+use GraphQL\Utils\SchemaPrinter;
+use App\Controllers\MyController;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+// $cache is any PSR-16 compatible cache.
+$cache = new FilesystemCache();
+
+// $container is any PSR-11 compatible container which has
+// been populated with your controller classes.
+$container = new Picotainer([
+        MyController::class => function() {
+                return new MyController();
+        },
+]);
+
+$factory = new SchemaFactory($cache, $container);
+$factory->addControllerNamespace('App\\Controllers')
+        ->addTypeNamespace('App');
+
+$schema = $factory->createSchema();
+
+$rawInput = file_get_contents('php://input');
+$input = json_decode($rawInput, true);
+$query = $input['query'];
+$variableValues = isset($input['variables']) ? $input['variables'] : null;
+
+$result = GraphQL::executeQuery($schema, $query, null, new Context(), $variableValues);
+$output = $result->toArray();
+
+header('Content-Type: application/json');
+echo json_encode($output) . "\n";
+

--- a/examples/no-framework/src/Controllers/MyController.php
+++ b/examples/no-framework/src/Controllers/MyController.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Controllers;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+
+class MyController
+{
+    #[Query]
+    public function hello(string $name): string
+    {
+        return 'Hello '.$name;
+    }
+}
+


### PR DESCRIPTION
Add "no framework" example to examples folder

Having an example as actual code rather than as out-of-context snippets inside a text file means that we can run the code, and ensure that it actually works

Submitting mostly for discussion to see if people like this idea

TODO:
- have a github action which runs the code and ensures that the "hello world" query works (thus ensuring that the example code is correct)
- install graphqlite from parent folder instead of downloading the published 6.X (thus ensuring that the example is always in-sync with the library it is an example of)
- update the documentation to reference the files in this repository, rather than embedding hard-coded out-of-context snippets into the .mdx files (thus ensuring that the documentation stays in-sync with the known-good example code)
