### PR TITLE
Fix promoted default values

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -170,7 +170,7 @@ class FieldsBuilder
         $reflectorByFields = [];
 
         $inputFields = [];
-        $defaultProperties = $refClass->getDefaultProperties();
+        $defaultProperties = $this->getClassDefaultProperties($refClass);
 
         $closestMatchingTypeClass = null;
         $parent = get_parent_class($refClass->getName());
@@ -1142,5 +1142,19 @@ class FieldsBuilder
         }
 
         return $names;
+    }
+
+    /** @return array<string, mixed> */
+    private function getClassDefaultProperties(ReflectionClass $refClass): array
+    {
+        $properties = $refClass->getDefaultProperties();
+
+        foreach ($refClass->getConstructor()?->getParameters() ?? [] as $parameter) {
+            if ($parameter->isPromoted() && $parameter->isDefaultValueAvailable()) {
+                $properties[$parameter->getName()] = $parameter->getDefaultValue();
+            }
+        }
+
+        return $properties;
     }
 }

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -1150,7 +1150,7 @@ class FieldsBuilder
         $properties = $refClass->getDefaultProperties();
 
         foreach ($refClass->getConstructor()?->getParameters() ?? [] as $parameter) {
-            if (!$parameter->isPromoted() || !$parameter->isDefaultValueAvailable()) {
+            if (! $parameter->isPromoted() || ! $parameter->isDefaultValueAvailable()) {
                 continue;
             }
 

--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -1150,9 +1150,11 @@ class FieldsBuilder
         $properties = $refClass->getDefaultProperties();
 
         foreach ($refClass->getConstructor()?->getParameters() ?? [] as $parameter) {
-            if ($parameter->isPromoted() && $parameter->isDefaultValueAvailable()) {
-                $properties[$parameter->getName()] = $parameter->getDefaultValue();
+            if (!$parameter->isPromoted() || !$parameter->isDefaultValueAvailable()) {
+                continue;
             }
+
+            $properties[$parameter->getName()] = $parameter->getDefaultValue();
         }
 
         return $properties;

--- a/tests/Fixtures/Integration/Controllers/ArticleController.php
+++ b/tests/Fixtures/Integration/Controllers/ArticleController.php
@@ -41,6 +41,7 @@ class ArticleController
     {
         $article = new Article('test');
         $article->magazine = $input->magazine;
+        $article->summary = $input->summary;
 
         return $article;
     }

--- a/tests/Fixtures/Integration/Models/UpdateArticleInput.php
+++ b/tests/Fixtures/Integration/Models/UpdateArticleInput.php
@@ -13,6 +13,7 @@ class UpdateArticleInput
         #[Field]
         #[Security("magazine != 'NYTimes'")]
         public readonly string|null $magazine,
+        public readonly string $summary = 'default',
     )
     {
     }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1911,6 +1911,7 @@ class EndToEndTest extends IntegrationTestCase
                 magazine: "Test"
             }) {
                 magazine
+                summary
             }
         }
         ';
@@ -1922,6 +1923,7 @@ class EndToEndTest extends IntegrationTestCase
 
         $data = $this->getSuccessResult($result);
         $this->assertSame('Test', $data['updateArticle']['magazine']);
+        $this->assertSame('default', $data['updateArticle']['summary']);
         $queryString = '
         mutation {
             updateArticle(input: {


### PR DESCRIPTION
Hey

Currently constructor promoted properties' default values are ignored, because `ReflectionClass::getDefaultProperties()` does not return default values from promoted props.

This fixes it, so the behaviour matches regular properties.