### PR TITLE
test: update phpunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ website/.cache-loader
 
 .phpunit.result.cache
 .phpstan-cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "php-coveralls/php-coveralls": "^2.1",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^8.5.19 || ^9.5.8",
+        "phpunit/phpunit": "^10.1 || ^11.0",
         "symfony/var-dumper": "^5.4 || ^6.0 || ^7",
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="tests/Bootstrap.php"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/Bootstrap.php" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="GraphQLite Test Suite">
       <directory>./tests/</directory>
       <exclude>./tests/Bootstrap.php</exclude>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
+  <logging/>
+  <source>
+    <include>
       <directory suffix=".php">src/</directory>
-    </whitelist>
-  </filter>
-  <logging>
-    <log type="coverage-html" target="build/coverage"/>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
-  </logging>
+    </include>
+  </source>
 </phpunit>

--- a/tests/AbstractQueryProvider.php
+++ b/tests/AbstractQueryProvider.php
@@ -57,7 +57,7 @@ use TheCodingMachine\GraphQLite\Types\TypeResolver;
 use TheCodingMachine\GraphQLite\Utils\Namespaces\NamespaceFactory;
 use UnitEnum;
 
-abstract class AbstractQueryProviderTest extends TestCase
+abstract class AbstractQueryProvider extends TestCase
 {
     private $testObjectType;
     private $testObjectType2;
@@ -455,7 +455,7 @@ abstract class AbstractQueryProviderTest extends TestCase
         return $this->typeRegistry;
     }
 
-    protected function resolveType(string $type): \phpDocumentor\Reflection\Type
+    protected static function resolveType(string $type): \phpDocumentor\Reflection\Type
     {
         return (new PhpDocumentorTypeResolver())->resolve($type);
     }

--- a/tests/AggregateControllerQueryProviderTest.php
+++ b/tests/AggregateControllerQueryProviderTest.php
@@ -5,7 +5,7 @@ namespace TheCodingMachine\GraphQLite;
 use Psr\Container\ContainerInterface;
 use TheCodingMachine\GraphQLite\Fixtures\TestController;
 
-class AggregateControllerQueryProviderTest extends AbstractQueryProviderTest
+class AggregateControllerQueryProviderTest extends AbstractQueryProvider
 {
     public function testAggregate(): void
     {

--- a/tests/Containers/BasicAutoWiringContainerTest.php
+++ b/tests/Containers/BasicAutoWiringContainerTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Containers;
 
 use Psr\Container\ContainerInterface;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\TestType;
 
-class BasicAutoWiringContainerTest extends AbstractQueryProviderTest
+class BasicAutoWiringContainerTest extends AbstractQueryProvider
 {
     private function getContainer(): ContainerInterface
     {

--- a/tests/Containers/LazyContainerTest.php
+++ b/tests/Containers/LazyContainerTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Containers;
 
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\TestType;
 
-final class LazyContainerTest extends AbstractQueryProviderTest
+final class LazyContainerTest extends AbstractQueryProvider
 {
     private function getContainer(): LazyContainer
     {

--- a/tests/FactoryContextTest.php
+++ b/tests/FactoryContextTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\Cache\Psr16Cache;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Fixtures\Inputs\Validator;
 
-class FactoryContextTest extends AbstractQueryProviderTest
+class FactoryContextTest extends AbstractQueryProvider
 {
     const GLOB_TTL_SECONDS = 2;
 

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -74,7 +74,7 @@ use TheCodingMachine\GraphQLite\Fixtures\PropertyPromotionInputTypeWithoutGeneri
 use TheCodingMachine\GraphQLite\Types\DateTimeType;
 use TheCodingMachine\GraphQLite\Types\VoidType;
 
-class FieldsBuilderTest extends AbstractQueryProviderTest
+class FieldsBuilderTest extends AbstractQueryProvider
 {
     public function testQueryProvider(): void
     {

--- a/tests/GlobControllerQueryProviderTest.php
+++ b/tests/GlobControllerQueryProviderTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use TheCodingMachine\GraphQLite\Fixtures\TestController;
 
-class GlobControllerQueryProviderTest extends AbstractQueryProviderTest
+class GlobControllerQueryProviderTest extends AbstractQueryProvider
 {
     public function testGlob(): void
     {

--- a/tests/InputTypeUtilsTest.php
+++ b/tests/InputTypeUtilsTest.php
@@ -10,7 +10,7 @@ use TheCodingMachine\GraphQLite\Parameters\InputTypeParameterInterface;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\Parameters\SourceParameter;
 
-class InputTypeUtilsTest extends AbstractQueryProviderTest
+class InputTypeUtilsTest extends AbstractQueryProvider
 {
 
     public function testNoReturnType(): void

--- a/tests/Integration/QueryComplexityTest.php
+++ b/tests/Integration/QueryComplexityTest.php
@@ -6,6 +6,7 @@ use GraphQL\Error\DebugFlag;
 use GraphQL\GraphQL;
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\QueryComplexity;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TheCodingMachine\GraphQLite\Schema;
 
 class QueryComplexityTest extends IntegrationTestCase
@@ -58,9 +59,7 @@ class QueryComplexityTest extends IntegrationTestCase
         $this->assertSame('Max query complexity should be 5 but got 60.', $result->toArray(DebugFlag::RETHROW_UNSAFE_EXCEPTIONS)['errors'][0]['message']);
     }
 
-    /**
-     * @dataProvider calculatesCorrectQueryCostProvider
-     */
+    #[DataProvider('calculatesCorrectQueryCostProvider')]
     public function testCalculatesCorrectQueryCost(int $expectedCost, string $query): void
     {
         $schema = $this->mainContainer->get(Schema::class);
@@ -140,9 +139,7 @@ class QueryComplexityTest extends IntegrationTestCase
         ];
     }
 
-    /**
-     * @dataProvider reportsQueryCostInIntrospectionProvider
-     */
+    #[DataProvider('reportsQueryCostInIntrospectionProvider')]
     public function testReportsQueryCostInIntrospection(string|null $expectedDescription, string $typeName, string $fieldName): void
     {
         $schema = $this->mainContainer->get(Schema::class);

--- a/tests/Mappers/CannotMapTypeTraitTest.php
+++ b/tests/Mappers/CannotMapTypeTraitTest.php
@@ -3,11 +3,11 @@
 namespace TheCodingMachine\GraphQLite\Mappers;
 
 use ReflectionClass;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\TestTypeId;
 use TheCodingMachine\GraphQLite\Fixtures\Types\FooExtendType;
 
-class CannotMapTypeTraitTest extends AbstractQueryProviderTest
+class CannotMapTypeTraitTest extends AbstractQueryProvider
 {
 
     public function testAddParamInfoSupphp74()

--- a/tests/Mappers/CompositeTypeMapperTest.php
+++ b/tests/Mappers/CompositeTypeMapperTest.php
@@ -5,7 +5,7 @@ namespace TheCodingMachine\GraphQLite\Mappers;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\OutputType;
 use GraphQL\Type\Definition\Type;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use GraphQL\Type\Definition\InputObjectType;
@@ -14,7 +14,7 @@ use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 
-class CompositeTypeMapperTest extends AbstractQueryProviderTest
+class CompositeTypeMapperTest extends AbstractQueryProvider
 {
     /**
      * @var CompositeTypeMapper

--- a/tests/Mappers/GlobTypeMapperTest.php
+++ b/tests/Mappers/GlobTypeMapperTest.php
@@ -7,7 +7,7 @@ use GraphQL\Type\Definition\Type;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Psr16Cache;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\ClassNotFoundException;
 use TheCodingMachine\GraphQLite\Containers\LazyContainer;
 use TheCodingMachine\GraphQLite\FailedResolvingInputType;
@@ -28,7 +28,7 @@ use TheCodingMachine\GraphQLite\NamingStrategy;
 use GraphQL\Type\Definition\ObjectType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 
-class GlobTypeMapperTest extends AbstractQueryProviderTest
+class GlobTypeMapperTest extends AbstractQueryProvider
 {
     public function testGlobTypeMapper(): void
     {

--- a/tests/Mappers/Parameters/ContainerParameterMapperTest.php
+++ b/tests/Mappers/Parameters/ContainerParameterMapperTest.php
@@ -6,13 +6,13 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Type;
 use ReflectionMethod;
 use ReflectionParameter;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\Parameter;
 use TheCodingMachine\GraphQLite\Annotations\Autowire;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotations;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 
-class ContainerParameterMapperTest extends AbstractQueryProviderTest
+class ContainerParameterMapperTest extends AbstractQueryProvider
 {
 
     public function testMapParameter(): void

--- a/tests/Mappers/Parameters/InjectUserParameterHandlerTest.php
+++ b/tests/Mappers/Parameters/InjectUserParameterHandlerTest.php
@@ -4,18 +4,17 @@ namespace TheCodingMachine\GraphQLite\Mappers\Parameters;
 
 use Generator;
 use phpDocumentor\Reflection\DocBlock;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 use stdClass;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\InjectUser;
 use TheCodingMachine\GraphQLite\Parameters\InjectUserParameter;
 use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 
-class InjectUserParameterHandlerTest extends AbstractQueryProviderTest
+class InjectUserParameterHandlerTest extends AbstractQueryProvider
 {
-    /**
-     * @dataProvider mapParameterProvider
-     */
+    #[DataProvider('mapParameterProvider')]
     public function testMapParameter(bool $optional, string $method): void
     {
         $authenticationService = $this->createMock(AuthenticationServiceInterface::class);
@@ -37,7 +36,7 @@ class InjectUserParameterHandlerTest extends AbstractQueryProviderTest
         );
     }
 
-    public function mapParameterProvider(): Generator
+    public static function mapParameterProvider(): Generator
     {
         yield 'required user' => [false, 'requiredUser'];
         yield 'optional user' => [true, 'optionalUser'];

--- a/tests/Mappers/Parameters/PrefetchParameterMiddlewareTest.php
+++ b/tests/Mappers/Parameters/PrefetchParameterMiddlewareTest.php
@@ -10,7 +10,7 @@ use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\Autowire;
 use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotations;
 use TheCodingMachine\GraphQLite\Annotations\Prefetch;
@@ -22,7 +22,7 @@ use TheCodingMachine\GraphQLite\ParameterizedCallableResolver;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\Parameters\PrefetchDataParameter;
 
-class PrefetchParameterMiddlewareTest extends AbstractQueryProviderTest
+class PrefetchParameterMiddlewareTest extends AbstractQueryProvider
 {
     public function testIgnoresParametersWithoutPrefetchAttribute(): void
     {

--- a/tests/Mappers/Parameters/TypeMapperTest.php
+++ b/tests/Mappers/Parameters/TypeMapperTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\UnionType;
 use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\HideParameter;
 use TheCodingMachine\GraphQLite\Fixtures\UnionOutputType;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
@@ -17,7 +17,7 @@ use TheCodingMachine\GraphQLite\Parameters\DefaultValueParameter;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
 use TheCodingMachine\GraphQLite\Reflection\CachedDocBlockFactory;
 
-class TypeMapperTest extends AbstractQueryProviderTest
+class TypeMapperTest extends AbstractQueryProvider
 {
 
     public function testMapScalarUnionException(): void

--- a/tests/Mappers/PorpaginasTypeMapperTest.php
+++ b/tests/Mappers/PorpaginasTypeMapperTest.php
@@ -8,11 +8,11 @@ use GraphQL\Type\Definition\StringType;
 use Porpaginas\Arrays\ArrayResult;
 use Porpaginas\Result;
 use RuntimeException;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 
-class PorpaginasTypeMapperTest extends AbstractQueryProviderTest
+class PorpaginasTypeMapperTest extends AbstractQueryProvider
 {
     private function getPorpaginasTypeMapper(): PorpaginasTypeMapper
     {

--- a/tests/Mappers/RecursiveTypeMapperTest.php
+++ b/tests/Mappers/RecursiveTypeMapperTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\NullCache;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Containers\LazyContainer;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Filter;
 use TheCodingMachine\GraphQLite\Fixtures\Interfaces\ClassA;
@@ -26,7 +26,7 @@ use TheCodingMachine\GraphQLite\TypeGenerator;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputObjectType;
 
-class RecursiveTypeMapperTest extends AbstractQueryProviderTest
+class RecursiveTypeMapperTest extends AbstractQueryProvider
 {
 
     public function testMapClassToType(): void

--- a/tests/Mappers/Root/BaseTypeMapperTest.php
+++ b/tests/Mappers/Root/BaseTypeMapperTest.php
@@ -13,13 +13,14 @@ use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\Resource_;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 
-class BaseTypeMapperTest extends AbstractQueryProviderTest
+class BaseTypeMapperTest extends AbstractQueryProvider
 {
     public function testNullableToGraphQLInputType(): void
     {
@@ -60,16 +61,15 @@ class BaseTypeMapperTest extends AbstractQueryProviderTest
     /**
      * @param string $phpdocType
      * @param class-string $expectedItemType
-     *
+     * @param string|null $expectedWrappedItemType
      * @return void
-     *
-     * @dataProvider genericIterablesProvider
      */
+    #[DataProvider('genericIterablesProvider')]
     public function testOutputGenericIterables(string $phpdocType, string $expectedItemType, ?string $expectedWrappedItemType = null): void
     {
         $typeMapper = $this->getRootTypeMapper();
 
-        $result = $typeMapper->toGraphQLOutputType($this->resolveType($phpdocType), null, new ReflectionMethod(__CLASS__, 'testOutputGenericIterables'), new DocBlock());
+        $result = $typeMapper->toGraphQLOutputType(self::resolveType($phpdocType), null, new ReflectionMethod(__CLASS__, 'testOutputGenericIterables'), new DocBlock());
 
         $this->assertInstanceOf(NonNull::class, $result);
         $this->assertInstanceOf(ListOfType::class, $result->getWrappedType());
@@ -81,7 +81,7 @@ class BaseTypeMapperTest extends AbstractQueryProviderTest
         }
     }
 
-    public function genericIterablesProvider(): iterable
+    public static function genericIterablesProvider(): iterable
     {
         yield '\ArrayIterator with nullable int item' => ['\ArrayIterator<int|null>', IntType::class];
         yield '\ArrayIterator with int item' => ['\ArrayIterator<int>', NonNull::class, IntType::class];

--- a/tests/Mappers/Root/CompoundTypeMapperTest.php
+++ b/tests/Mappers/Root/CompoundTypeMapperTest.php
@@ -9,11 +9,11 @@ use phpDocumentor\Reflection\Types\Iterable_;
 use phpDocumentor\Reflection\Types\String_;
 use ReflectionMethod;
 use RuntimeException;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\NamingStrategy;
 
-class CompoundTypeMapperTest extends AbstractQueryProviderTest
+class CompoundTypeMapperTest extends AbstractQueryProvider
 {
     public function testException1()
     {

--- a/tests/Mappers/Root/IteratorTypeMapperTest.php
+++ b/tests/Mappers/Root/IteratorTypeMapperTest.php
@@ -7,11 +7,11 @@ use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
 use phpDocumentor\Reflection\DocBlock;
 use ReflectionMethod;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 
-class IteratorTypeMapperTest extends AbstractQueryProviderTest
+class IteratorTypeMapperTest extends AbstractQueryProvider
 {
     public function testInputIterator(): void
     {
@@ -20,14 +20,14 @@ class IteratorTypeMapperTest extends AbstractQueryProviderTest
         // A type like ArrayObject|int[] CAN be mapped to an output type, but NOT to an input type.
         $this->expectException(CannotMapTypeException::class);
         $this->expectExceptionMessage('cannot map class "ArrayObject" to a known GraphQL input type. Are you missing a @Factory annotation? If you have a @Factory annotation, is it in a namespace analyzed by GraphQLite?');
-        $typeMapper->toGraphQLInputType($this->resolveType('ArrayObject|int[]'), null, 'foo', new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
+        $typeMapper->toGraphQLInputType(self::resolveType('ArrayObject|int[]'), null, 'foo', new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
     }
 
     public function testOutputNullableValueIterator(): void
     {
         $typeMapper = $this->getRootTypeMapper();
 
-        $result = $typeMapper->toGraphQLOutputType($this->resolveType('ArrayObject|array<int|null>'), null, new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
+        $result = $typeMapper->toGraphQLOutputType(self::resolveType('ArrayObject|array<int|null>'), null, new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
         $this->assertInstanceOf(NonNull::class, $result);
         $this->assertInstanceOf(ListOfType::class, $result->getWrappedType());
         $this->assertInstanceOf(IntType::class, $result->getWrappedType()->getWrappedType());
@@ -39,7 +39,7 @@ class IteratorTypeMapperTest extends AbstractQueryProviderTest
 
         $this->expectException(CannotMapTypeException::class);
         $this->expectExceptionMessage('"\ArrayObject" is iterable. Please provide a more specific type. For instance: \ArrayObject|User[].');
-        $result = $typeMapper->toGraphQLOutputType($this->resolveType('ArrayObject|'.TestObject::class), null, new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
+        $result = $typeMapper->toGraphQLOutputType(self::resolveType('ArrayObject|'.TestObject::class), null, new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
     }
 
     public function testIterableWithTwoArrays(): void
@@ -48,6 +48,6 @@ class IteratorTypeMapperTest extends AbstractQueryProviderTest
 
         $this->expectException(CannotMapTypeException::class);
         $this->expectExceptionMessage('"\ArrayObject" is iterable. Please provide a more specific type. For instance: \ArrayObject|User[].');
-        $result = $typeMapper->toGraphQLOutputType($this->resolveType('ArrayObject|array<int>|array<string>'), null, new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
+        $result = $typeMapper->toGraphQLOutputType(self::resolveType('ArrayObject|array<int>|array<string>'), null, new ReflectionMethod(__CLASS__, 'testInputIterator'), new DocBlock());
     }
 }

--- a/tests/Mappers/Root/MyCLabsEnumTypeMapperTest.php
+++ b/tests/Mappers/Root/MyCLabsEnumTypeMapperTest.php
@@ -8,10 +8,10 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Types\Object_;
 use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 
-class MyCLabsEnumTypeMapperTest extends AbstractQueryProviderTest
+class MyCLabsEnumTypeMapperTest extends AbstractQueryProvider
 {
     public function testObjectTypeHint(): void
     {

--- a/tests/Mappers/Root/NullableTypeMapperAdapterTest.php
+++ b/tests/Mappers/Root/NullableTypeMapperAdapterTest.php
@@ -12,17 +12,16 @@ use GraphQL\Type\Definition\Type as GraphQLType;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Nullable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 
-class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
+class NullableTypeMapperAdapterTest extends AbstractQueryProvider
 {
-    /**
-     * @dataProvider nullableVariationsProvider
-     */
+    #[DataProvider('nullableVariationsProvider')]
     public function testMultipleCompound(callable $type): void
     {
         $compoundTypeMapper = $this->getRootTypeMapper();
@@ -31,14 +30,14 @@ class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
         $this->assertNotInstanceOf(NonNull::class, $result);
     }
 
-    public function nullableVariationsProvider(): Generator
+    public static function nullableVariationsProvider(): Generator
     {
         yield 'php documentor generated from phpdoc' => [
-            fn () => $this->resolveType(TestObject::class . '|' . TestObject2::class . '|null'),
+            fn () => self::resolveType(TestObject::class . '|' . TestObject2::class . '|null'),
         ];
 
         yield 'type handler nullable wrapped native reflection union type' => [
-            fn () => new Nullable($this->resolveType(TestObject::class . '|' . TestObject2::class . '|null')),
+            fn () => new Nullable(self::resolveType(TestObject::class . '|' . TestObject2::class . '|null')),
         ];
     }
 
@@ -48,7 +47,7 @@ class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
 
         $this->expectException(CannotMapTypeException::class);
         $this->expectExceptionMessage('type-hinting against null only in the PHPDoc is not allowed.');
-        $compoundTypeMapper->toGraphQLOutputType($this->resolveType('null'), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
+        $compoundTypeMapper->toGraphQLOutputType(self::resolveType('null'), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
     }
 
     public function testOnlyNull2(): void
@@ -57,7 +56,7 @@ class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
 
         $this->expectException(CannotMapTypeException::class);
         $this->expectExceptionMessage('type-hinting against null only in the PHPDoc is not allowed.');
-        $compoundTypeMapper->toGraphQLInputType($this->resolveType('null'), null, 'foo', new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
+        $compoundTypeMapper->toGraphQLInputType(self::resolveType('null'), null, 'foo', new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
     }
 
     public function testNonNullableReturnedByWrappedMapper(): void
@@ -85,6 +84,6 @@ class NullableTypeMapperAdapterTest extends AbstractQueryProviderTest
 
         $this->expectException(CannotMapTypeException::class);
         $this->expectExceptionMessage('a type mapper returned a GraphQL\\Type\\Definition\\NonNull instance.');
-        $typeMapper->toGraphQLOutputType($this->resolveType(TestObject::class . '|' . TestObject2::class . '|null'), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
+        $typeMapper->toGraphQLOutputType(self::resolveType(TestObject::class . '|' . TestObject2::class . '|null'), null, new ReflectionMethod(__CLASS__, 'testMultipleCompound'), new DocBlock());
     }
 }

--- a/tests/Mappers/StaticClassListTypeMapperTest.php
+++ b/tests/Mappers/StaticClassListTypeMapperTest.php
@@ -6,12 +6,12 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Cache\Simple\ArrayCache;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\NamingStrategy;
 
-class StaticClassListTypeMapperTest extends AbstractQueryProviderTest
+class StaticClassListTypeMapperTest extends AbstractQueryProvider
 {
     public function testClassListException(): void
     {

--- a/tests/Mappers/StaticTypeMapperTest.php
+++ b/tests/Mappers/StaticTypeMapperTest.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
@@ -22,7 +22,7 @@ use GraphQL\Type\Definition\ObjectType;
 use TheCodingMachine\GraphQLite\SchemaFactory;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 
-class StaticTypeMapperTest extends AbstractQueryProviderTest
+class StaticTypeMapperTest extends AbstractQueryProvider
 {
     /**
      * @var StaticTypeMapper

--- a/tests/Middlewares/AuthorizationFieldMiddlewareTest.php
+++ b/tests/Middlewares/AuthorizationFieldMiddlewareTest.php
@@ -4,7 +4,7 @@ namespace TheCodingMachine\GraphQLite\Middlewares;
 
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\Type;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\IncompatibleAnnotationsException;
 use TheCodingMachine\GraphQLite\Annotations\FailWith;
 use TheCodingMachine\GraphQLite\Annotations\HideIfUnauthorized;
@@ -18,7 +18,7 @@ use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 
-class AuthorizationFieldMiddlewareTest extends AbstractQueryProviderTest
+class AuthorizationFieldMiddlewareTest extends AbstractQueryProvider
 {
     public function testReturnsResolversValueWhenAuthorized(): void
     {

--- a/tests/Middlewares/AuthorizationInputFieldMiddlewareTest.php
+++ b/tests/Middlewares/AuthorizationInputFieldMiddlewareTest.php
@@ -5,7 +5,7 @@ namespace TheCodingMachine\GraphQLite\Middlewares;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use stdClass;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\HideIfUnauthorized;
 use TheCodingMachine\GraphQLite\Annotations\Logged;
 use TheCodingMachine\GraphQLite\Annotations\MiddlewareAnnotationInterface;
@@ -19,7 +19,7 @@ use TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface;
 use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
 use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
 
-class AuthorizationInputFieldMiddlewareTest extends AbstractQueryProviderTest
+class AuthorizationInputFieldMiddlewareTest extends AbstractQueryProvider
 {
     public function testReturnsResolversValueWhenAuthorized(): void
     {

--- a/tests/Middlewares/CostFieldMiddlewareTest.php
+++ b/tests/Middlewares/CostFieldMiddlewareTest.php
@@ -4,9 +4,10 @@ namespace TheCodingMachine\GraphQLite\Middlewares;
 
 use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\Cost;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\IncompatibleAnnotationsException;
 use TheCodingMachine\GraphQLite\Annotations\FailWith;
@@ -39,9 +40,7 @@ class CostFieldMiddlewareTest extends TestCase
         self::assertNull($result);
     }
 
-    /**
-     * @dataProvider setsComplexityFunctionProvider
-     */
+    #[DataProvider('setsComplexityFunctionProvider')]
     public function testSetsComplexityFunction(int $expectedComplexity, Cost $cost): void
     {
         $field = $this->stubField();
@@ -86,9 +85,7 @@ class CostFieldMiddlewareTest extends TestCase
 
     }
 
-    /**
-     * @dataProvider addsCostInDescriptionProvider
-     */
+    #[DataProvider('addsCostInDescriptionProvider')]
     public function testAddsCostInDescription(string $expectedDescription, Cost $cost): void
     {
         if (Version::series() === '8.5') {

--- a/tests/Parameters/InjectUserParameterTest.php
+++ b/tests/Parameters/InjectUserParameterTest.php
@@ -4,6 +4,7 @@ namespace TheCodingMachine\GraphQLite\Parameters;
 
 use Generator;
 use GraphQL\Type\Definition\ResolveInfo;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use TheCodingMachine\GraphQLite\Middlewares\MissingAuthorizationException;
@@ -11,9 +12,7 @@ use TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface;
 
 class InjectUserParameterTest extends TestCase
 {
-    /**
-     * @dataProvider resolveReturnsUserProvider
-     */
+    #[DataProvider('resolveReturnsUserProvider')]
     public function testResolveReturnsUser(stdClass|null $user, bool $optional): void
     {
         $authenticationService = $this->createMock(AuthenticationServiceInterface::class);
@@ -30,7 +29,7 @@ class InjectUserParameterTest extends TestCase
         self::assertSame($user, $resolved);
     }
 
-    public function resolveReturnsUserProvider(): Generator
+    public static function resolveReturnsUserProvider(): Generator
     {
         yield 'non optional and has user' => [new stdClass(), false];
         yield 'optional and has user' => [new stdClass(), true];

--- a/tests/QueryFieldDescriptorTest.php
+++ b/tests/QueryFieldDescriptorTest.php
@@ -3,15 +3,14 @@
 namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\Type;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use TheCodingMachine\GraphQLite\Middlewares\ServiceResolver;
 
 class QueryFieldDescriptorTest extends TestCase
 {
-    /**
-     * @dataProvider withAddedCommentLineProvider
-     */
+    #[DataProvider('withAddedCommentLineProvider')]
     public function testWithAddedCommentLine(string $expected, string|null $previous, string $added): void
     {
         $resolver = fn () => null;

--- a/tests/RootTypeMapperFactoryContextTest.php
+++ b/tests/RootTypeMapperFactoryContextTest.php
@@ -10,7 +10,7 @@ use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperFactoryContext;
 use TheCodingMachine\GraphQLite\Utils\Namespaces\NS;
 
-class RootTypeMapperFactoryContextTest extends AbstractQueryProviderTest
+class RootTypeMapperFactoryContextTest extends AbstractQueryProvider
 {
     const GLOB_TTL_SECONDS = 2;
 

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -2,7 +2,7 @@
 
 namespace TheCodingMachine\GraphQLite;
 
-class SchemaTest extends AbstractQueryProviderTest
+class SchemaTest extends AbstractQueryProvider
 {
 
     public function testEmptyQuery(): void

--- a/tests/TypeGeneratorTest.php
+++ b/tests/TypeGeneratorTest.php
@@ -8,7 +8,7 @@ use TheCodingMachine\GraphQLite\Containers\LazyContainer;
 use TheCodingMachine\GraphQLite\Fixtures\TypeFoo;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 
-class TypeGeneratorTest extends AbstractQueryProviderTest
+class TypeGeneratorTest extends AbstractQueryProvider
 {
     private ContainerInterface$container;
 

--- a/tests/Types/ArgumentResolverTest.php
+++ b/tests/Types/ArgumentResolverTest.php
@@ -7,9 +7,9 @@ use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
 use RuntimeException;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 
-abstract class ArgumentResolverTest extends AbstractQueryProviderTest
+class ArgumentResolverTest extends AbstractQueryProvider
 {
 
     public function testResolveArrayException(): void
@@ -26,6 +26,11 @@ abstract class ArgumentResolverTest extends AbstractQueryProviderTest
         $argumentResolver = $this->getArgumentResolver();
 
         $this->expectException(RuntimeException::class);
-        $argumentResolver->resolve(null, 42, null, $this->createMock(ResolveInfo::class), new class extends Type implements InputType {});
+        $argumentResolver->resolve(null, 42, null, $this->createMock(ResolveInfo::class), new class extends Type implements InputType {
+            public function toString(): string
+            {
+                return 'foo';
+            }
+        });
     }
 }

--- a/tests/Types/InputTypeTest.php
+++ b/tests/Types/InputTypeTest.php
@@ -7,8 +7,9 @@ use GraphQL\Type\Definition\IntType;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\StringType;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Container\ContainerInterface;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Annotations\Exceptions\IncompatibleAnnotationsException;
 use TheCodingMachine\GraphQLite\FailedResolvingInputType;
 use TheCodingMachine\GraphQLite\Fixtures\Inputs\CircularInputA;
@@ -21,7 +22,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Inputs\TestConstructorPromotedPropertie
 use TheCodingMachine\GraphQLite\Fixtures\Inputs\TestOnlyConstruct;
 use TheCodingMachine\GraphQLite\Fixtures\Inputs\TypedFooBar;
 
-class InputTypeTest extends AbstractQueryProviderTest
+class InputTypeTest extends AbstractQueryProvider
 {
     public function testInputConfiguredCorrectly(): void
     {
@@ -142,9 +143,7 @@ class InputTypeTest extends AbstractQueryProviderTest
         $this->assertEquals(200, $result->getBar());
     }
 
-    /**
-     * @group PR-466
-     */
+    #[Group('PR-466')]
     public function testResolvesCorrectlyWithConstructorAndProperties(): void
     {
         $input = new InputType(

--- a/tests/Types/ResolvableMutableInputObjectTypeTest.php
+++ b/tests/Types/ResolvableMutableInputObjectTypeTest.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\ResolveInfo;
 use stdClass;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;
 use TheCodingMachine\GraphQLite\FieldsBuilder;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
@@ -18,7 +18,7 @@ use TheCodingMachine\GraphQLite\Mappers\Parameters\HardCodedParameter;
 use TheCodingMachine\GraphQLite\Parameters\MissingArgumentException;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 
-class ResolvableMutableInputObjectTypeTest extends AbstractQueryProviderTest
+class ResolvableMutableInputObjectTypeTest extends AbstractQueryProvider
 {
     public function testResolve(): void
     {

--- a/tests/Types/TypeAnnotatedInterfaceTypeTest.php
+++ b/tests/Types/TypeAnnotatedInterfaceTypeTest.php
@@ -4,9 +4,9 @@ namespace TheCodingMachine\GraphQLite\Types;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use InvalidArgumentException;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 
-class TypeAnnotatedInterfaceTypeTest extends AbstractQueryProviderTest
+class TypeAnnotatedInterfaceTypeTest extends AbstractQueryProvider
 {
 
     public function testResolveTypeException()

--- a/tests/Types/UnionTypeTest.php
+++ b/tests/Types/UnionTypeTest.php
@@ -5,12 +5,12 @@ namespace TheCodingMachine\GraphQLite\Types;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\StringType;
 use PHPUnit\Framework\TestCase;
-use TheCodingMachine\GraphQLite\AbstractQueryProviderTest;
+use TheCodingMachine\GraphQLite\AbstractQueryProvider;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
 use TheCodingMachine\GraphQLite\NamingStrategy;
 
-class UnionTypeTest extends AbstractQueryProviderTest
+class UnionTypeTest extends AbstractQueryProvider
 {
     public function testConstructor(): void
     {

--- a/tests/Utils/NsTest.php
+++ b/tests/Utils/NsTest.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\GraphQLite\Utils;
 use Exception;
 use Kcs\ClassFinder\Finder\ComposerFinder;
 use Kcs\ClassFinder\Finder\FinderInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -38,7 +39,7 @@ class NsTest extends TestCase
         $this->globTTL = 10;
     }
 
-    /** @dataProvider loadsClassListProvider */
+    #[DataProvider('loadsClassListProvider')]
     public function testLoadsClassList(array $expectedClasses, string $namespace): void
     {
         $ns = new NS(

--- a/tests/Utils/PropertyAccessorTest.php
+++ b/tests/Utils/PropertyAccessorTest.php
@@ -3,6 +3,7 @@
 namespace TheCodingMachine\GraphQLite\Utils;
 
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Contact;
 use TheCodingMachine\GraphQLite\Fixtures\Integration\Models\Post;
@@ -14,9 +15,7 @@ use TheCodingMachine\GraphQLite\Fixtures\Types\MagicGetterSetterType;
 
 class PropertyAccessorTest extends TestCase
 {
-    /**
-     * @dataProvider findGetterProvider
-     */
+    #[DataProvider('findGetterProvider')]
     public function testFindGetter(mixed $expected, string $class, string $propertyName): void
     {
         self::assertSame($expected, PropertyAccessor::findGetter($class, $propertyName));
@@ -31,9 +30,7 @@ class PropertyAccessorTest extends TestCase
         yield 'undefined property' => [null, MagicGetterSetterType::class, 'twenty'];
     }
 
-    /**
-     * @dataProvider findSetterProvider
-     */
+    #[DataProvider('findSetterProvider')]
     public function testFindSetter(mixed $expected, string $class, string $propertyName): void
     {
         self::assertSame($expected, PropertyAccessor::findSetter($class, $propertyName));
@@ -47,9 +44,7 @@ class PropertyAccessorTest extends TestCase
         yield 'undefined property' => [null, MagicGetterSetterType::class, 'twenty'];
     }
 
-    /**
-     * @dataProvider getValueProvider
-     */
+    #[DataProvider('getValueProvider')]
     public function testGetValue(mixed $expected, object $object, string $propertyName, array $args = []): void
     {
         if ($expected instanceof Exception) {
@@ -70,9 +65,7 @@ class PropertyAccessorTest extends TestCase
         yield 'undefined property' => [AccessPropertyException::createForUnreadableProperty(GetterSetterType::class, 'twenty'), new GetterSetterType(), 'twenty'];
     }
 
-    /**
-     * @dataProvider setValueProvider
-     */
+    #[DataProvider('setValueProvider')]
     public function testSetValue(mixed $expected, object $object, string $propertyName, mixed $value): void
     {
         if ($expected instanceof Exception) {


### PR DESCRIPTION
Fixes deprecations, AbstractQueryProviderTest renamed because Test suffix produces warning in file with no tests