### PR TITLE
[Error handling] Remove category from exceptions

### DIFF
--- a/src/Exceptions/GraphQLException.php
+++ b/src/Exceptions/GraphQLException.php
@@ -14,7 +14,6 @@ class GraphQLException extends Exception implements GraphQLExceptionInterface
         string $message,
         int $code = 0,
         Throwable|null $previous = null,
-        protected string $category = 'Exception',
         protected array $extensions = [],
     ) {
         parent::__construct($message, $code, $previous);
@@ -26,16 +25,6 @@ class GraphQLException extends Exception implements GraphQLExceptionInterface
     public function isClientSafe(): bool
     {
         return true;
-    }
-
-    /**
-     * Returns string describing a category of the error.
-     *
-     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
-     */
-    public function getCategory(): string
-    {
-        return $this->category;
     }
 
     /**

--- a/src/Mappers/PorpaginasMissingParameterException.php
+++ b/src/Mappers/PorpaginasMissingParameterException.php
@@ -28,14 +28,4 @@ class PorpaginasMissingParameterException extends Exception implements ClientAwa
     {
         return true;
     }
-
-    /**
-     * Returns string describing a category of the error.
-     *
-     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
-     */
-    public function getCategory(): string
-    {
-        return 'pagination';
-    }
 }

--- a/src/Middlewares/MissingAuthorizationException.php
+++ b/src/Middlewares/MissingAuthorizationException.php
@@ -26,14 +26,4 @@ class MissingAuthorizationException extends Exception implements ClientAware
     {
         return true;
     }
-
-    /**
-     * Returns string describing a category of the error.
-     *
-     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
-     */
-    public function getCategory(): string
-    {
-        return 'security';
-    }
 }

--- a/src/Parameters/MissingArgumentException.php
+++ b/src/Parameters/MissingArgumentException.php
@@ -82,16 +82,6 @@ class MissingArgumentException extends BadMethodCallException implements GraphQL
     }
 
     /**
-     * Returns string describing a category of the error.
-     *
-     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
-     */
-    public function getCategory(): string
-    {
-        return 'graphql';
-    }
-
-    /**
      * Returns the "extensions" object attached to the GraphQL error.
      *
      * @return array<string, mixed>

--- a/tests/Exceptions/ErrorHandlerTest.php
+++ b/tests/Exceptions/ErrorHandlerTest.php
@@ -10,7 +10,7 @@ class ErrorHandlerTest extends TestCase
 
     public function testErrorFormatter()
     {
-        $exception = new GraphQLException('foo', 0, null, 'MyCategory', ['field' => 'foo']);
+        $exception = new GraphQLException('foo', 0, null, ['field' => 'foo']);
         $error = new Error('foo', null, null, [], null, $exception);
         $formattedError = WebonyxErrorHandler::errorFormatter($error);
         $this->assertSame([
@@ -23,7 +23,7 @@ class ErrorHandlerTest extends TestCase
 
     public function testErrorHandler()
     {
-        $exception = new GraphQLException('foo', 0, null, 'MyCategory', ['field' => 'foo']);
+        $exception = new GraphQLException('foo', 0, null, ['field' => 'foo']);
         $error = new Error('bar', null, null, [], null, $exception);
         $aggregateException = new GraphQLAggregateException();
         $aggregateException->add($exception);

--- a/tests/Http/HttpCodeDeciderTest.php
+++ b/tests/Http/HttpCodeDeciderTest.php
@@ -38,11 +38,6 @@ class HttpCodeDeciderTest extends TestCase
             {
                 return true;
             }
-
-            public function getCategory()
-            {
-                return 'foo';
-            }
         };
         $clientAwareError = new Error('Foo', null, null, [], null, $clientAwareException);
 

--- a/tests/Parameters/MissingArgumentExceptionTest.php
+++ b/tests/Parameters/MissingArgumentExceptionTest.php
@@ -21,6 +21,5 @@ class MissingArgumentExceptionTest extends TestCase
 
         $this->assertTrue($e->isClientSafe());
         $this->assertSame([], $e->getExtensions());
-        $this->assertSame('graphql', $e->getCategory());
     }
 }

--- a/website/docs/error-handling.mdx
+++ b/website/docs/error-handling.mdx
@@ -12,10 +12,7 @@ In GraphQL, when an error occurs, the server must add an "error" entry in the re
     {
       "message": "Name for character with ID 1002 could not be fetched.",
       "locations": [ { "line": 6, "column": 7 } ],
-      "path": [ "hero", "heroFriends", 1, "name" ],
-      "extensions": {
-        "category": "Exception"
-      }
+      "path": [ "hero", "heroFriends", 1, "name" ]
     }
   ]
 }
@@ -43,30 +40,6 @@ throw new GraphQLException("Not found", 404);
 <div class="alert alert--info">GraphQL allows to have several errors for one request. If you have several
 <code>GraphQLException</code> thrown for the same request, the HTTP status code used will be the highest one.</div>
 
-## Customizing the category
-
-By default, GraphQLite adds a "category" entry in the "extensions section". You can customize the category with the
-4th parameter of the constructor:
-
-```php
-throw new GraphQLException("Not found", 404, null, "NOT_FOUND");
-```
-
-will generate:
-
-```json
-{
-  "errors": [
-    {
-      "message": "Not found",
-      "extensions": {
-        "category": "NOT_FOUND"
-      }
-    }
-  ]
-}
-```
-
 ## Customizing the extensions section
 
 You can customize the whole "extensions" section with the 5th parameter of the constructor:
@@ -83,7 +56,6 @@ will generate:
     {
       "message": "Field required",
       "extensions": {
-        "category": "VALIDATION",
         "field": "name"
       }
     }
@@ -107,16 +79,6 @@ class ValidationException extends Exception implements GraphQLExceptionInterface
     public function isClientSafe(): bool
     {
         return true;
-    }
-
-    /**
-     * Returns string describing a category of the error.
-     *
-     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
-     */
-    public function getCategory(): string
-    {
-        return 'VALIDATION';
     }
 
     /**

--- a/website/docs/laravel-package-advanced.mdx
+++ b/website/docs/laravel-package-advanced.mdx
@@ -43,15 +43,13 @@ If a validation fails to pass, the message will be printed in the "errors" secti
         {
             "message": "The email must be a valid email address.",
             "extensions": {
-                "argument": "email",
-                "category": "Validate"
+                "argument": "email"
             }
         },
         {
             "message": "The password must be greater than or equal 8 characters.",
             "extensions": {
-                "argument": "password",
-                "category": "Validate"
+                "argument": "password"
             }
         }
     ]

--- a/website/docs/validation.mdx
+++ b/website/docs/validation.mdx
@@ -96,8 +96,7 @@ If a validation fails, GraphQLite will return the failed validations in the "err
             "message": "The email '\"foo@thisdomaindoesnotexistatall.com\"' is not a valid email.",
             "extensions": {
                 "code": "bf447c1c-0266-4e10-9c6c-573df282e413",
-                "field": "email",
-                "category": "Validate"
+                "field": "email"
             }
         }
     ]


### PR DESCRIPTION
As mentioned in #683, category support has already been removed from graphQL error responses with graphqlite because of graphql-php update to v15 ( see [upgrade guide v14 -> v15](https://github.com/webonyx/graphql-php/blob/master/UPGRADE.md?rgh-link-date=2024-04-24T14%3A18%3A16Z#breaking-removed-error-extension-field-category) ), which means `category` is already missing from `extensions` in responses.

The purpose of this PR is to remove the category argument from Exceptions.

> [!CAUTION]
> **BC Break**

The `category` argument has been removed from `GraphQLException`, which means any existing instance of a GraphQLException passing category and/or extensions will trigger an error.

**BEFORE**
```php
throw new GraphQLException('foo', 0, null, 'MyCategory', ['field' => 'foo']);
```

**AFTER**
```php
throw new GraphQLException('foo', 0, null, ['field' => 'foo']);
```

> [!NOTE]
> If you want to keep `category`, you'll have two options : 
> 1. Creating your own `GraphQLException` class and using your own `errorFormatter` method
> 2. Moving the category directly into `extensions`

---

Fixes #683 