### PR TITLE
chore: remove dependency on thecodingmachine/cache-utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "psr/simple-cache": "^1.0.1 || ^2 || ^3",
         "symfony/cache": "^4.3 || ^5 || ^6 || ^7",
         "symfony/expression-language": "^4 || ^5 || ^6 || ^7",
-        "thecodingmachine/cache-utils": "^1",
         "webonyx/graphql-php": "^v15.0",
         "kcs/class-finder": "^0.5.0"
     },

--- a/examples/no-framework/composer.json
+++ b/examples/no-framework/composer.json
@@ -7,7 +7,8 @@
   "require": {
     "thecodingmachine/graphqlite": "@dev",
     "mouf/picotainer": "^1.1",
-    "symfony/cache": "^4.2"
+    "symfony/cache": "^4.3",
+    "psr/simple-cache": "^1.0"
   },
   "repositories": [
     {

--- a/examples/no-framework/index.php
+++ b/examples/no-framework/index.php
@@ -4,7 +4,8 @@ use GraphQL\Type\Schema;
 use TheCodingMachine\GraphQLite\SchemaFactory;
 use TheCodingMachine\GraphQLite\Context\Context;
 
-use Symfony\Component\Cache\Simple\FilesystemCache;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 use Mouf\Picotainer\Picotainer;
 use GraphQL\Utils\SchemaPrinter;
 use App\Controllers\MyController;
@@ -12,7 +13,7 @@ use App\Controllers\MyController;
 require_once __DIR__ . '/vendor/autoload.php';
 
 // $cache is any PSR-16 compatible cache.
-$cache = new FilesystemCache();
+$cache = new Psr16Cache(new FilesystemAdapter());;
 
 // $container is any PSR-11 compatible container which has
 // been populated with your controller classes.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,7 +34,7 @@ parameters:
            message: '#Unreachable statement - code above always terminates.#'
            path: src/Http/WebonyxGraphqlMiddleware.php
         -
-           message: '#Property TheCodingMachine\\GraphQLite\\Annotations\\Type::\$class \(class-string<object>\\|null\) does not accept string.#'
+           message: '#Property TheCodingMachine\\GraphQLite\\Annotations\\Type::\$class \(class-string<object>\|null\) does not accept string.#'
            path: src/Annotations/Type.php
         -
            message: '#Method TheCodingMachine\\GraphQLite\\AnnotationReader::(getMethodAnnotations|getPropertyAnnotations)\(\) should return array<int, T of object> but returns array<object>.#'

--- a/src/Cache/ClassBoundCacheContract.php
+++ b/src/Cache/ClassBoundCacheContract.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+use ReflectionClass;
+
+use function str_replace;
+
+class ClassBoundCacheContract implements ClassBoundCacheContractInterface
+{
+    private readonly string $cachePrefix;
+
+    public function __construct(private readonly CacheInterface $classBoundCache, string $cachePrefix = '')
+    {
+        $this->cachePrefix = str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $cachePrefix);
+    }
+
+    /**
+     * @param string $key An optional key to differentiate between cache items attached to the same class.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function get(ReflectionClass $reflectionClass, callable $resolver, string $key = '', int|null $ttl = null): mixed
+    {
+        $cacheKey = $reflectionClass->getName() . '__' . $key;
+        $cacheKey = $this->cachePrefix . str_replace(['\\', '{', '}', '(', ')', '/', '@', ':'], '_', $cacheKey);
+
+        $item = $this->classBoundCache->get($cacheKey);
+        if ($item !== null) {
+            return $item;
+        }
+
+        $item = $resolver();
+
+        $this->classBoundCache->set($cacheKey, $item, $ttl);
+
+        return $item;
+    }
+}

--- a/src/Cache/ClassBoundCacheContractFactory.php
+++ b/src/Cache/ClassBoundCacheContractFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+class ClassBoundCacheContractFactory implements ClassBoundCacheContractFactoryInterface
+{
+    public function make(CacheInterface $classBoundCache, string $cachePrefix = ''): ClassBoundCacheContractInterface
+    {
+        return new ClassBoundCacheContract($classBoundCache, $cachePrefix);
+    }
+}

--- a/src/Cache/ClassBoundCacheContractFactoryInterface.php
+++ b/src/Cache/ClassBoundCacheContractFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+interface ClassBoundCacheContractFactoryInterface
+{
+    public function make(CacheInterface $classBoundCache, string $cachePrefix = ''): ClassBoundCacheContractInterface;
+}

--- a/src/Cache/ClassBoundCacheContractInterface.php
+++ b/src/Cache/ClassBoundCacheContractInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Cache;
+
+use ReflectionClass;
+
+interface ClassBoundCacheContractInterface
+{
+    /** @param string $key An optional key to differentiate between cache items attached to the same class. */
+    public function get(ReflectionClass $reflectionClass, callable $resolver, string $key = '', int|null $ttl = null): mixed;
+}

--- a/src/FactoryContext.php
+++ b/src/FactoryContext.php
@@ -6,6 +6,7 @@ namespace TheCodingMachine\GraphQLite;
 
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractFactoryInterface;
 use TheCodingMachine\GraphQLite\Mappers\RecursiveTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Types\InputTypeValidatorInterface;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
@@ -31,6 +32,7 @@ final class FactoryContext
         private readonly InputTypeValidatorInterface|null $inputTypeValidator,
         private readonly int|null $globTTL,
         private readonly int|null $mapTTL = null,
+        private readonly ClassBoundCacheContractFactoryInterface|null $classBoundCacheContractFactory = null,
     ) {
     }
 
@@ -82,6 +84,11 @@ final class FactoryContext
     public function getCache(): CacheInterface
     {
         return $this->cache;
+    }
+
+    public function getClassBoundCacheContractFactory(): ClassBoundCacheContractFactoryInterface|null
+    {
+        return $this->classBoundCacheContractFactory;
     }
 
     public function getInputTypeValidator(): InputTypeValidatorInterface|null

--- a/src/Mappers/AbstractTypeMapper.php
+++ b/src/Mappers/AbstractTypeMapper.php
@@ -15,12 +15,10 @@ use ReflectionException;
 use ReflectionMethod;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Contracts\Cache\CacheInterface as CacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundCache;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContract;
-use TheCodingMachine\CacheUtils\ClassBoundCacheContractInterface;
-use TheCodingMachine\CacheUtils\ClassBoundMemoryAdapter;
-use TheCodingMachine\CacheUtils\FileBoundCache;
 use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractFactory;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractFactoryInterface;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractInterface;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
@@ -66,23 +64,15 @@ abstract class AbstractTypeMapper implements TypeMapperInterface
         private readonly CacheInterface $cache,
         protected int|null $globTTL = 2,
         private readonly int|null $mapTTL = null,
+        ClassBoundCacheContractFactoryInterface|null $classBoundCacheContractFactory = null,
     )
     {
         $this->cacheContract = new Psr16Adapter($this->cache, $cachePrefix, $this->globTTL ?? 0);
 
-        $classToAnnotationsCache = new ClassBoundCache(
-            new FileBoundCache($this->cache, 'classToAnnotations_' . $cachePrefix),
-        );
-        $this->mapClassToAnnotationsCache = new ClassBoundCacheContract(
-            new ClassBoundMemoryAdapter($classToAnnotationsCache),
-        );
+        $classBoundCacheContractFactory = $classBoundCacheContractFactory ?? new ClassBoundCacheContractFactory();
 
-        $classToExtendedAnnotationsCache = new ClassBoundCache(
-            new FileBoundCache($this->cache, 'classToExtendAnnotations_' . $cachePrefix),
-        );
-        $this->mapClassToExtendAnnotationsCache = new ClassBoundCacheContract(
-            new ClassBoundMemoryAdapter($classToExtendedAnnotationsCache),
-        );
+        $this->mapClassToAnnotationsCache = $classBoundCacheContractFactory->make($cache, 'classToAnnotations_' . $cachePrefix);
+        $this->mapClassToExtendAnnotationsCache = $classBoundCacheContractFactory->make($cache, 'classToExtendAnnotations_' . $cachePrefix);
     }
 
     /**

--- a/src/Mappers/GlobTypeMapper.php
+++ b/src/Mappers/GlobTypeMapper.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractFactoryInterface;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
 use TheCodingMachine\GraphQLite\NamingStrategyInterface;
@@ -44,6 +45,7 @@ final class GlobTypeMapper extends AbstractTypeMapper
         CacheInterface $cache,
         int|null $globTTL = 2,
         int|null $mapTTL = null,
+        ClassBoundCacheContractFactoryInterface|null $classBoundCacheContractFactory = null,
     ) {
         $cachePrefix = str_replace(
             ['\\', '{', '}', '(', ')', '/', '@', ':'],
@@ -63,6 +65,7 @@ final class GlobTypeMapper extends AbstractTypeMapper
             $cache,
             $globTTL,
             $mapTTL,
+            $classBoundCacheContractFactory,
         );
     }
 

--- a/src/Mappers/StaticClassListTypeMapper.php
+++ b/src/Mappers/StaticClassListTypeMapper.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractFactoryInterface;
 use TheCodingMachine\GraphQLite\GraphQLRuntimeException;
 use TheCodingMachine\GraphQLite\InputTypeGenerator;
 use TheCodingMachine\GraphQLite\InputTypeUtils;
@@ -45,6 +46,7 @@ final class StaticClassListTypeMapper extends AbstractTypeMapper
         CacheInterface $cache,
         int|null $globTTL = 2,
         int|null $mapTTL = null,
+        ClassBoundCacheContractFactoryInterface|null $classBoundCacheContractFactory = null,
     ) {
         $cachePrefix = str_replace(
             ['\\', '{', '}', '(', ')', '/', '@', ':'],
@@ -64,6 +66,7 @@ final class StaticClassListTypeMapper extends AbstractTypeMapper
             $cache,
             $globTTL,
             $mapTTL,
+            $classBoundCacheContractFactory,
         );
     }
 

--- a/src/Mappers/StaticClassListTypeMapperFactory.php
+++ b/src/Mappers/StaticClassListTypeMapperFactory.php
@@ -38,6 +38,7 @@ final class StaticClassListTypeMapperFactory implements TypeMapperFactoryInterfa
             $context->getCache(),
             $context->getGlobTTL(),
             $context->getMapTTL(),
+            $context->getClassBoundCacheContractFactory(),
         );
     }
 }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -13,6 +13,7 @@ use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractFactoryInterface;
 use TheCodingMachine\GraphQLite\Mappers\CompositeTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\GlobTypeMapper;
 use TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterHandler;
@@ -120,7 +121,7 @@ class SchemaFactory
 
     private string $cacheNamespace;
 
-    public function __construct(private readonly CacheInterface $cache, private readonly ContainerInterface $container)
+    public function __construct(private readonly CacheInterface $cache, private readonly ContainerInterface $container, private ClassBoundCacheContractFactoryInterface|null $classBoundCacheContractFactory = null)
     {
         $this->cacheNamespace = substr(md5(Versions::getVersion('thecodingmachine/graphqlite')), 0, 8);
     }
@@ -255,6 +256,18 @@ class SchemaFactory
     public function setGlobTTL(int|null $globTTL): self
     {
         $this->globTTL = $globTTL;
+
+        return $this;
+    }
+
+    /**
+     * Set a custom ClassBoundCacheContractFactory.
+     * This is used to create CacheContracts that store reflection results.
+     * Set this to "null" to use the default fallback factory.
+     */
+    public function setClassBoundCacheContractFactory(ClassBoundCacheContractFactoryInterface|null $classBoundCacheContractFactory): self
+    {
+        $this->classBoundCacheContractFactory = $classBoundCacheContractFactory;
 
         return $this;
     }
@@ -430,6 +443,7 @@ class SchemaFactory
                 $recursiveTypeMapper,
                 $namespacedCache,
                 $this->globTTL,
+                classBoundCacheContractFactory: $this->classBoundCacheContractFactory,
             ));
         }
 
@@ -447,6 +461,7 @@ class SchemaFactory
                 $namespacedCache,
                 $this->inputTypeValidator,
                 $this->globTTL,
+                classBoundCacheContractFactory: $this->classBoundCacheContractFactory,
             );
         }
 

--- a/tests/FactoryContextTest.php
+++ b/tests/FactoryContextTest.php
@@ -4,6 +4,7 @@ namespace TheCodingMachine\GraphQLite;
 
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
+use TheCodingMachine\GraphQLite\Cache\ClassBoundCacheContractFactory;
 use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
 use TheCodingMachine\GraphQLite\Fixtures\Inputs\Validator;
 
@@ -16,6 +17,7 @@ class FactoryContextTest extends AbstractQueryProvider
         $namingStrategy = new NamingStrategy();
         $container = new EmptyContainer();
         $arrayCache = new Psr16Cache(new ArrayAdapter());
+        $classBoundCacheContractFactory = new ClassBoundCacheContractFactory();
         $validator = new Validator();
 
         $context = new FactoryContext(
@@ -30,7 +32,8 @@ class FactoryContextTest extends AbstractQueryProvider
             $container,
             $arrayCache,
             $validator,
-            self::GLOB_TTL_SECONDS
+            self::GLOB_TTL_SECONDS,
+            classBoundCacheContractFactory: $classBoundCacheContractFactory,
         );
 
         $this->assertSame($this->getAnnotationReader(), $context->getAnnotationReader());


### PR DESCRIPTION
The package seems to be unmaintained and prevents usage due to old `psr/simple-cache`.
This removes the dependency on that package, which provided cache clearance on Classes and ParentClasses when their files changed.
The functionality can still be achieved by creating a custom implementation of `TheCodingMachine\GraphQLite\Utils\Cache\ClassBoundCacheContractFactoryInterface` that returns a wrapped version of `thecodingmachine/cache-utils` or an updated fork.

My implementation is quite naive and changes how the caching works. This may be considered a breaking change.

I'm happy to make adjustments if needed.

fixes thecodingmachine/graphqlite#693

Note: PHPStan seems to have problems. This is probably not related to my changes.