### PR TITLE
:bug: [#711] Don't reuse cache for differently configured class finder instances

### DIFF
--- a/src/Discovery/Cache/HardClassFinderComputedCache.php
+++ b/src/Discovery/Cache/HardClassFinderComputedCache.php
@@ -8,12 +8,13 @@ use Psr\SimpleCache\CacheInterface;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
 
+use function sprintf;
+
 class HardClassFinderComputedCache implements ClassFinderComputedCache
 {
     public function __construct(
         private readonly CacheInterface $cache,
-    )
-    {
+    ) {
     }
 
     /**
@@ -32,6 +33,7 @@ class HardClassFinderComputedCache implements ClassFinderComputedCache
         callable $reduce,
     ): mixed
     {
+        $key = sprintf('%s.%s', $key, $classFinder->hash());
         $result = $this->cache->get($key);
 
         if ($result !== null) {

--- a/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
+++ b/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
@@ -9,6 +9,8 @@ use ReflectionClass;
 use TheCodingMachine\GraphQLite\Cache\FilesSnapshot;
 use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
 
+use function sprintf;
+
 /**
  * Provides cache for a {@see ClassFinder} based on a {@see filemtime()}.
  *
@@ -49,6 +51,7 @@ class SnapshotClassFinderComputedCache implements ClassFinderComputedCache
         callable $reduce,
     ): mixed
     {
+        $key = sprintf('%s.%s', $key, $classFinder->hash());
         $entries = $this->entries($classFinder, $key . '.entries', $map);
 
         return $reduce($entries);

--- a/src/Discovery/ClassFinder.php
+++ b/src/Discovery/ClassFinder.php
@@ -11,4 +11,9 @@ use ReflectionClass;
 interface ClassFinder extends IteratorAggregate
 {
     public function withPathFilter(callable $filter): self;
+
+    /**
+     * Path filter does not affect the hash.
+     */
+    public function hash(): string;
 }

--- a/src/Discovery/KcsClassFinder.php
+++ b/src/Discovery/KcsClassFinder.php
@@ -12,8 +12,8 @@ class KcsClassFinder implements ClassFinder
 {
     public function __construct(
         private FinderInterface $finder,
-    )
-    {
+        private readonly string $hash,
+    ) {
     }
 
     public function withPathFilter(callable $filter): ClassFinder
@@ -28,5 +28,10 @@ class KcsClassFinder implements ClassFinder
     public function getIterator(): Traversable
     {
         return $this->finder->getIterator();
+    }
+
+    public function hash(): string
+    {
+        return $this->hash;
     }
 }

--- a/src/Discovery/StaticClassFinder.php
+++ b/src/Discovery/StaticClassFinder.php
@@ -7,10 +7,15 @@ namespace TheCodingMachine\GraphQLite\Discovery;
 use ReflectionClass;
 use Traversable;
 
+use function md5;
+use function serialize;
+
 class StaticClassFinder implements ClassFinder
 {
     /** @var (callable(string): bool)|null  */
     private mixed $pathFilter = null;
+
+    private string|null $hash = null;
 
     /** @param list<class-string> $classes */
     public function __construct(
@@ -40,5 +45,10 @@ class StaticClassFinder implements ClassFinder
 
             yield $class => $classReflection;
         }
+    }
+
+    public function hash(): string
+    {
+        return $this->hash ??= md5(serialize($this->classes));
     }
 }

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -70,6 +70,7 @@ use TheCodingMachine\GraphQLite\Utils\NamespacedCache;
 
 use function array_reverse;
 use function class_exists;
+use function implode;
 use function md5;
 use function substr;
 use function trigger_error;
@@ -565,6 +566,8 @@ class SchemaFactory
             $finder = $finder->inNamespace($namespace);
         }
 
-        return new KcsClassFinder($finder);
+        $hash = md5(implode(',', $this->namespaces));
+
+        return new KcsClassFinder($finder, $hash);
     }
 }

--- a/tests/AbstractQueryProvider.php
+++ b/tests/AbstractQueryProvider.php
@@ -29,8 +29,8 @@ use TheCodingMachine\GraphQLite\Containers\LazyContainer;
 use TheCodingMachine\GraphQLite\Discovery\Cache\ClassFinderComputedCache;
 use TheCodingMachine\GraphQLite\Discovery\Cache\HardClassFinderComputedCache;
 use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
-use TheCodingMachine\GraphQLite\Discovery\StaticClassFinder;
 use TheCodingMachine\GraphQLite\Discovery\KcsClassFinder;
+use TheCodingMachine\GraphQLite\Discovery\StaticClassFinder;
 use TheCodingMachine\GraphQLite\Fixtures\Mocks\MockResolvableInputObjectType;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject2;
@@ -66,6 +66,9 @@ use TheCodingMachine\GraphQLite\Types\MutableInterface;
 use TheCodingMachine\GraphQLite\Types\MutableObjectType;
 use TheCodingMachine\GraphQLite\Types\ResolvableMutableInputInterface;
 use TheCodingMachine\GraphQLite\Types\TypeResolver;
+
+use function implode;
+use function md5;
 
 abstract class AbstractQueryProvider extends TestCase
 {
@@ -481,7 +484,9 @@ abstract class AbstractQueryProvider extends TestCase
 
         $finder = $finder->withFileFinder(new CachedFileFinder(new DefaultFileFinder(), $arrayAdapter));
 
-        return new KcsClassFinder($finder);
+        $hash = md5(implode(',', (array) $namespaces));
+
+        return new KcsClassFinder($finder, $hash);
     }
 
     protected function getClassFinderComputedCache(): ClassFinderComputedCache

--- a/tests/Discovery/Cache/HardClassFinderComputedCacheTest.php
+++ b/tests/Discovery/Cache/HardClassFinderComputedCacheTest.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TheCodingMachine\GraphQLite\Discovery\Cache;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use TheCodingMachine\GraphQLite\Discovery\StaticClassFinder;
@@ -12,10 +15,12 @@ use TheCodingMachine\GraphQLite\Fixtures\Types\FooExtendType;
 use TheCodingMachine\GraphQLite\Fixtures\Types\FooType;
 use TheCodingMachine\GraphQLite\Loggers\ExceptionLogger;
 
+use function array_values;
+
 #[CoversClass(HardClassFinderComputedCache::class)]
 class HardClassFinderComputedCacheTest extends TestCase
 {
-    public function testCachesResultOfReduceFunction(): void
+    public function testNotReusedCacheBecauseDifferentList(): void
     {
         $arrayAdapter = new ArrayAdapter();
         $arrayAdapter->setLogger(new ExceptionLogger());
@@ -30,8 +35,8 @@ class HardClassFinderComputedCacheTest extends TestCase
                 TestType::class,
             ]),
             'key',
-            fn (\ReflectionClass $reflection) => $reflection->getShortName(),
-            fn (array $entries) => [array_values($entries)],
+            static fn (ReflectionClass $reflection) => $reflection->getShortName(),
+            static fn (array $entries) => [array_values($entries)],
         );
 
         $this->assertSame([
@@ -40,13 +45,51 @@ class HardClassFinderComputedCacheTest extends TestCase
             'TestType',
         ], $result);
 
-        // Even though the class finder and both functions have changed - the result should still be cached.
+        // Class finder have different class list - result should not be reused from the cache.
+        // This is necessary to avoid caching issues when there're multiple class finders shares the same cache pool.
+        [$result] = $classFinderComputedCache->compute(
+            new StaticClassFinder([FooType::class]),
+            'key',
+            static fn (ReflectionClass $reflection) => $reflection->getShortName(),
+            static fn (array $entries) => [array_values($entries)],
+        );
+
+        $this->assertSame(['FooType'], $result);
+    }
+
+    public function testReusedCacheBecauseSameList(): void
+    {
+        $arrayAdapter = new ArrayAdapter();
+        $arrayAdapter->setLogger(new ExceptionLogger());
+        $cache = new Psr16Cache($arrayAdapter);
+
+        $classFinderComputedCache = new HardClassFinderComputedCache($cache);
+
+        $classList = [
+            FooType::class,
+            FooExtendType::class,
+            TestType::class,
+        ];
+        [$result] = $classFinderComputedCache->compute(
+            new StaticClassFinder($classList),
+            'key',
+            static fn (ReflectionClass $reflection) => $reflection->getShortName(),
+            static fn (array $entries) => [array_values($entries)],
+        );
+
+        $this->assertSame([
+            'FooType',
+            'FooExtendType',
+            'TestType',
+        ], $result);
+
+        // Class finder have the same class list - even both functions have changed - the result should be cached.
         // This is useful in production, where code and file structure doesn't change.
         [$result] = $classFinderComputedCache->compute(
-            new StaticClassFinder([]),
+            new StaticClassFinder($classList),
             'key',
-            fn (\ReflectionClass $reflection) => self::fail('Should not be called.'),
-            fn (array $entries) => self::fail('Should not be called.'),
+            static fn (ReflectionClass $reflection) => self::fail('Should not be called.'),
+            static fn (array $entries) => self::fail('Should not be called.'),
         );
 
         $this->assertSame([

--- a/tests/Discovery/KcsClassFinderTest.php
+++ b/tests/Discovery/KcsClassFinderTest.php
@@ -20,9 +20,10 @@ class KcsClassFinderTest extends TestCase
 {
     public function testYieldsGivenClasses(): void
     {
+        $namespaces = 'TheCodingMachine\GraphQLite\Fixtures\Types';
         $finder = new KcsClassFinder(
-            (new ComposerFinder())
-                ->inNamespace('TheCodingMachine\GraphQLite\Fixtures\Types')
+            (new ComposerFinder())->inNamespace($namespaces),
+            md5($namespaces)
         );
 
         $finderWithPath = $finder->withPathFilter(fn (string $path) => str_contains($path, 'FooExtendType.php'));

--- a/tests/Fixtures/ClassFinderCustomTypeMapper/Controllers/TestCustomMapperController.php
+++ b/tests/Fixtures/ClassFinderCustomTypeMapper/Controllers/TestCustomMapperController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\ClassFinderCustomTypeMapper\Controllers;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Fixtures\ClassFinderCustomTypeMapper\Types\TestCustomMapperObject;
+
+/**
+ * Pretty standard controller. It is separated from the other controllers to test discovering via added as
+ * a separated independent mapper in Schema.
+ */
+final class TestCustomMapperController
+{
+    #[Query]
+    public function getCustomMapperObject(): TestCustomMapperObject
+    {
+        return new TestCustomMapperObject();
+    }
+}

--- a/tests/Fixtures/ClassFinderCustomTypeMapper/Types/TestCustomMapperObject.php
+++ b/tests/Fixtures/ClassFinderCustomTypeMapper/Types/TestCustomMapperObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\ClassFinderCustomTypeMapper\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+#[Type]
+final class TestCustomMapperObject
+{
+    #[Field]
+    public function getFoo(): int
+    {
+        return 42;
+    }
+}

--- a/tests/Fixtures/ClassFinderTypeMapper/Controllers/TestLegacyController.php
+++ b/tests/Fixtures/ClassFinderTypeMapper/Controllers/TestLegacyController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\ClassFinderTypeMapper\Controllers;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Fixtures\ClassFinderTypeMapper\Types\TestLegacyObject;
+
+class TestLegacyController
+{
+    #[Query]
+    public function getLegacyObject(): TestLegacyObject
+    {
+        return new TestLegacyObject();
+    }
+}

--- a/tests/Fixtures/ClassFinderTypeMapper/Types/TestLegacyObject.php
+++ b/tests/Fixtures/ClassFinderTypeMapper/Types/TestLegacyObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\ClassFinderTypeMapper\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+#[Type]
+class TestLegacyObject
+{
+    #[Field]
+    public function getFoo(): int
+    {
+        return 42;
+    }
+}

--- a/tests/GlobControllerQueryProviderTest.php
+++ b/tests/GlobControllerQueryProviderTest.php
@@ -13,6 +13,8 @@ use TheCodingMachine\GraphQLite\Discovery\Cache\HardClassFinderComputedCache;
 use TheCodingMachine\GraphQLite\Discovery\KcsClassFinder;
 use TheCodingMachine\GraphQLite\Fixtures\TestController;
 
+use function md5;
+
 class GlobControllerQueryProviderTest extends AbstractQueryProvider
 {
     public function testGlob(): void
@@ -39,15 +41,18 @@ class GlobControllerQueryProviderTest extends AbstractQueryProvider
             }
         };
 
+        $namespace = 'TheCodingMachine\\GraphQLite\\Fixtures';
         $finder = new ComposerFinder();
-        $finder->inNamespace('TheCodingMachine\\GraphQLite\\Fixtures');
-        $finder->filter(static fn (ReflectionClass $class) => $class->getNamespaceName() === 'TheCodingMachine\\GraphQLite\\Fixtures'); // Fix for recursive:false
+        $finder->inNamespace($namespace);
+        $finder->filter(static fn (ReflectionClass $class) => $class->getNamespaceName() === $namespace); // Fix for recursive:false
+        $hash = md5($namespace);
+
         $globControllerQueryProvider = new GlobControllerQueryProvider(
             $this->getFieldsBuilder(),
             $container,
             $this->getAnnotationReader(),
-            new KcsClassFinder($finder),
-            new HardClassFinderComputedCache(new Psr16Cache(new NullAdapter()))
+            new KcsClassFinder($finder, $hash),
+            new HardClassFinderComputedCache(new Psr16Cache(new NullAdapter())),
         );
 
         $queries = $globControllerQueryProvider->getQueries();

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -95,12 +95,19 @@ class IntegrationTestCase extends TestCase
                 return new Schema($container->get(QueryProviderInterface::class), $container->get(RecursiveTypeMapperInterface::class), $container->get(TypeResolver::class), $container->get(RootTypeMapperInterface::class));
             },
             ClassFinder::class => function () {
-                $composerFinder = new ComposerFinder();
-                $composerFinder->inNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Types');
-                $composerFinder->inNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Models');
-                $composerFinder->inNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers');
+                $namespaces = [
+                    'TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Types',
+                    'TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Models',
+                    'TheCodingMachine\\GraphQLite\\Fixtures\\Integration\\Controllers',
+                ];
 
-                return new KcsClassFinder($composerFinder);
+                $hash = md5(implode(',', $namespaces));
+                $composerFinder = new ComposerFinder();
+                foreach ($namespaces as $namespace) {
+                    $composerFinder->inNamespace($namespace);
+                }
+
+                return new KcsClassFinder($composerFinder, $hash);
             },
             ClassFinderComputedCache::class => function () {
                 return new HardClassFinderComputedCache(


### PR DESCRIPTION
Context: #711 

/cc @oprypkhantc @SCIF