### PR TITLE
Update broken URL link to webonyx/graphql-php -> object-types

### DIFF
--- a/website/docs/custom-types.mdx
+++ b/website/docs/custom-types.mdx
@@ -57,7 +57,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-3.0/custom_types.mdx
+++ b/website/versioned_docs/version-3.0/custom_types.mdx
@@ -109,7 +109,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-4.0/custom_types.mdx
+++ b/website/versioned_docs/version-4.0/custom_types.mdx
@@ -63,7 +63,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-4.1/custom_types.mdx
+++ b/website/versioned_docs/version-4.1/custom_types.mdx
@@ -110,7 +110,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-4.2/custom-types.mdx
+++ b/website/versioned_docs/version-4.2/custom-types.mdx
@@ -109,7 +109,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-4.3/custom-types.mdx
+++ b/website/versioned_docs/version-4.3/custom-types.mdx
@@ -109,7 +109,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-5.0/custom-types.mdx
+++ b/website/versioned_docs/version-5.0/custom-types.mdx
@@ -109,7 +109,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-6.0/custom-types.mdx
+++ b/website/versioned_docs/version-6.0/custom-types.mdx
@@ -109,7 +109,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-6.1/custom-types.mdx
+++ b/website/versioned_docs/version-6.1/custom-types.mdx
@@ -62,7 +62,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 

--- a/website/versioned_docs/version-7.0.0/custom-types.mdx
+++ b/website/versioned_docs/version-7.0.0/custom-types.mdx
@@ -110,7 +110,7 @@ In order to create a custom output type, you need to:
 1. Design a class that extends `GraphQL\Type\Definition\ObjectType`.
 2. Register this class in the GraphQL schema.
 
-You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-system/object-types/).
+You'll find more details on the [Webonyx documentation](https://webonyx.github.io/graphql-php/type-definitions/object-types/).
 
 ---
 


### PR DESCRIPTION
webonyx/graphql-php have changed the url in v15.0.0

Old: https://webonyx.github.io/graphql-php/type-system/object-types/ (not working)
New: https://webonyx.github.io/graphql-php/type-definitions/object-types/