### PR TITLE
Fix issue with kept deprecation reason

### DIFF
--- a/src/FieldsBuilder.php
+++ b/src/FieldsBuilder.php
@@ -689,6 +689,7 @@ class FieldsBuilder
                 $docBlockComment = rtrim($docBlockObj->getSummary() . "\n" . $docBlockObj->getDescription()->render());
 
                 $deprecated = $docBlockObj->getTagsByName('deprecated');
+                $deprecationReason = null;
                 if (count($deprecated) >= 1) {
                     $deprecationReason = trim((string) $deprecated[0]);
                 }

--- a/tests/FieldsBuilderTest.php
+++ b/tests/FieldsBuilderTest.php
@@ -37,11 +37,13 @@ use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithNullableArray;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithParamDateTime;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithReturnDateTime;
 use TheCodingMachine\GraphQLite\Fixtures\TestControllerWithUnionInputParam;
+use TheCodingMachine\GraphQLite\Fixtures\TestDeprecatedField;
 use TheCodingMachine\GraphQLite\Fixtures\TestDoubleReturnTag;
 use TheCodingMachine\GraphQLite\Fixtures\TestEnum;
 use TheCodingMachine\GraphQLite\Fixtures\TestFieldBadInputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestFieldBadOutputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestObject;
+use TheCodingMachine\GraphQLite\Fixtures\TestObjectWithDeprecatedField;
 use TheCodingMachine\GraphQLite\Fixtures\TestSelfType;
 use TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType;
 use TheCodingMachine\GraphQLite\Fixtures\TestSourceFieldBadOutputType2;
@@ -921,5 +923,21 @@ class FieldsBuilderTest extends AbstractQueryProvider
         $resolve = $query->resolveFn;
         $result = $resolve($source, [], null, $this->createMock(ResolveInfo::class));
         $this->assertSame('bar value', $result);
+    }
+
+    public function testDeprecationInDocblock(): void
+    {
+        $fieldsBuilder = $this->buildFieldsBuilder();
+        $inputFields = $fieldsBuilder->getFields(
+            new TestDeprecatedField(),
+            'Test',
+        );
+
+        $this->assertCount(2, $inputFields);
+
+        $this->assertEquals('this is deprecated', $inputFields['deprecatedField']->deprecationReason);
+        $this->assertTrue( $inputFields['deprecatedField']->isDeprecated());
+        $this->assertNull( $inputFields['name']->deprecationReason);
+        $this->assertFalse( $inputFields['name']->isDeprecated());
     }
 }

--- a/tests/Fixtures/TestDeprecatedField.php
+++ b/tests/Fixtures/TestDeprecatedField.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+#[Type(class: TestObjectWithDeprecatedField::class)]
+#[SourceField(name: 'deprecatedField')]
+#[SourceField(name: 'name')]
+class TestDeprecatedField
+{
+
+}

--- a/tests/Fixtures/TestObjectWithDeprecatedField.php
+++ b/tests/Fixtures/TestObjectWithDeprecatedField.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures;
+
+class TestObjectWithDeprecatedField
+{
+
+    /** @deprecated this is deprecated */
+    public function getDeprecatedField(): string
+    {
+        return 'deprecatedField';
+    }
+
+    public function getName(): string
+    {
+        return 'Foo';
+    }
+
+}


### PR DESCRIPTION
When a type contains multiple fields and one of them is deprecated the following fields will be marked as deprecated. By resetting the value in each run we make sure the value is not kept.

With @stijnie2210