### PR TITLE
:package: Use WeakMap instead of SplObjectStorage to simplify GC work

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Context;
 
-use SplObjectStorage;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\GraphQLite\PrefetchBuffer;
+use WeakMap;
 
 /**
  * A context class that should be passed to the Webonyx executor.
  */
 class Context implements ContextInterface, ResetableContextInterface
 {
-    private SplObjectStorage $prefetchBuffers;
+    private WeakMap $prefetchBuffers;
 
     public function __construct()
     {
-        $this->prefetchBuffers = new SplObjectStorage();
+        $this->prefetchBuffers = new WeakMap();
     }
 
     /**
@@ -38,6 +38,6 @@ class Context implements ContextInterface, ResetableContextInterface
 
     public function reset(): void
     {
-        $this->prefetchBuffers = new SplObjectStorage();
+        $this->prefetchBuffers = new WeakMap();
     }
 }

--- a/src/PrefetchBuffer.php
+++ b/src/PrefetchBuffer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use SplObjectStorage;
+use WeakMap;
 
 use function md5;
 use function serialize;
@@ -18,12 +18,12 @@ class PrefetchBuffer
     /** @var array<string, array<int, object>> An array of buffered, indexed by hash of arguments. */
     private array $objects = [];
 
-    /** @var SplObjectStorage A Storage of prefetch method results, holds source to resolved values. */
-    private SplObjectStorage $results;
+    /** @var WeakMap A Storage of prefetch method results, holds source to resolved values. */
+    private WeakMap $results;
 
     public function __construct()
     {
-        $this->results = new SplObjectStorage();
+        $this->results = new WeakMap();
     }
 
     /** @param array<array-key, mixed> $arguments The input arguments passed from GraphQL to the field. */


### PR DESCRIPTION
https://www.php.net/manual/en/class.weakmap.php

There are no use-cases in the library to iterate over all existing references - using WeakMap in this context will improve some work for the garbage collection mechanism and would avoid possible memory leaks for long-running applications