### PR TITLE
don't purge the results from buffer

### DIFF
--- a/src/Parameters/PrefetchDataParameter.php
+++ b/src/Parameters/PrefetchDataParameter.php
@@ -57,10 +57,7 @@ class PrefetchDataParameter implements ParameterInterface, ExpandsInputTypeParam
                 $this->processPrefetch($args, $context, $info, $prefetchBuffer);
             }
 
-            $result = $prefetchBuffer->getResult($source);
-            // clear internal storage
-            $prefetchBuffer->purgeResult($source);
-            return $result;
+            return $prefetchBuffer->getResult($source);
         });
     }
 

--- a/tests/Parameters/PrefetchDataParameterTest.php
+++ b/tests/Parameters/PrefetchDataParameterTest.php
@@ -37,43 +37,6 @@ class PrefetchDataParameterTest extends TestCase
         self::assertSame($prefetchResult, $this->deferredValue($resolvedParameterPromise));
     }
 
-    public function testResolveWithoutExistingResult(): void
-    {
-        $prefetchResult = new stdClass();
-        $source = new stdClass();
-        $prefetchHandler = function (array $sources, string $second) use ($prefetchResult, $source) {
-            self::assertSame([$source], $sources);
-            self::assertSame('rty', $second);
-
-            return $prefetchResult;
-        };
-
-        $parameter = new PrefetchDataParameter('field', $prefetchHandler, [
-            new InputTypeParameter(
-                name: 'second',
-                type: Type::string(),
-                description: '',
-                hasDefaultValue: false,
-                defaultValue: null,
-                argumentResolver: new ArgumentResolver()
-            )
-        ]);
-
-        $context = new Context();
-        $args = [
-            'first' => 'qwe',
-            'second' => 'rty',
-        ];
-        $buffer = $context->getPrefetchBuffer($parameter);
-
-        $resolvedParameterPromise = $parameter->resolve($source, $args, $context, $this->createStub(ResolveInfo::class));
-
-        self::assertFalse($buffer->hasResult($source));
-        self::assertSame([$source], $buffer->getObjectsByArguments($args));
-        self::assertSame($prefetchResult, $this->deferredValue($resolvedParameterPromise));
-        self::assertFalse($buffer->hasResult($source));
-    }
-
     private function deferredValue(Deferred $promise): mixed
     {
         $syncPromiseAdapter = new SyncPromiseAdapter();


### PR DESCRIPTION
I tried upgrading graphqlite lib in my project and I was hit by this issue: https://github.com/thecodingmachine/graphqlite/issues/729

I am making pr that removes purging from the buffer, but if there is different way to fix the issue, please let me know