### PR TITLE
:sparkles: Improve exception message for unexpected null value - mention expected type

### DIFF
--- a/src/ResolveUtils.php
+++ b/src/ResolveUtils.php
@@ -24,7 +24,7 @@ final class ResolveUtils
     public static function assertInnerReturnType(mixed $result, Type $type): void
     {
         if ($type instanceof NonNull && $result === null) {
-            throw TypeMismatchRuntimeException::unexpectedNullValue();
+            throw TypeMismatchRuntimeException::unexpectedNullValue($type);
         }
         if ($result === null) {
             return;
@@ -56,7 +56,7 @@ final class ResolveUtils
     public static function assertInnerInputType(mixed $input, Type $type): void
     {
         if ($type instanceof NonNull && $input === null) {
-            throw TypeMismatchRuntimeException::unexpectedNullValue();
+            throw TypeMismatchRuntimeException::unexpectedNullValue($type);
         }
         if ($input === null) {
             return;

--- a/src/TypeMismatchRuntimeException.php
+++ b/src/TypeMismatchRuntimeException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
+use GraphQL\Type\Definition\Type;
+
 use function gettype;
 
 /**
@@ -11,9 +13,15 @@ use function gettype;
  */
 class TypeMismatchRuntimeException extends GraphQLRuntimeException
 {
-    public static function unexpectedNullValue(): self
+    public static function unexpectedNullValue(Type|null $expectedType = null): self
     {
-        return new self('Unexpected null value for non nullable field.');
+        $expectedMessageTail = '';
+        if ($expectedType !== null) {
+            $expectedMessageTail = ' Expected: "' . $expectedType->toString() . '"';
+            // ToDo: support for NULL $expectedType should be dropped in the next major
+        }
+
+        return new self('Unexpected null value for non nullable field.' . $expectedMessageTail);
     }
 
     public static function expectedIterable(mixed $result): self

--- a/tests/ResolveUtilsTest.php
+++ b/tests/ResolveUtilsTest.php
@@ -12,6 +12,7 @@ class ResolveUtilsTest extends TestCase
     public function testAssertNull(): void
     {
         $this->expectException(TypeMismatchRuntimeException::class);
+        $this->expectExceptionMessage('Unexpected null value for non nullable field. Expected: "String!"');
         ResolveUtils::assertInnerReturnType(null, Type::nonNull(Type::string()));
     }
 
@@ -30,6 +31,7 @@ class ResolveUtilsTest extends TestCase
     public function testAssertInputNull(): void
     {
         $this->expectException(TypeMismatchRuntimeException::class);
+        $this->expectExceptionMessage('Unexpected null value for non nullable field. Expected: "String!"');
         ResolveUtils::assertInnerInputType(null, Type::nonNull(Type::string()));
     }
 


### PR DESCRIPTION
In our case, we attempted to investigate the reason for the error "Unexpected null value for non nullable field" for the array output field (and all PHP types were returning an array). But the real reason was about array elements - we returned null instead of a string - aka array('foobar', null) instead of array('foobar') - because of `array<string>` phpdoc over the output field method.

---

Before:
```
In Acme\Graphql\Type\FooType::getButtons() (declaring field "buttons"): Unexpected null value for non nullable field.
```
After:
```
In Acme\Graphql\Type\FooType::getButtons() (declaring field "buttons"): Unexpected null value for non nullable field. Expected: "String!".
```