### PR TITLE
Add hasser as property accessor

### DIFF
--- a/src/Utils/PropertyAccessor.php
+++ b/src/Utils/PropertyAccessor.php
@@ -22,7 +22,7 @@ class PropertyAccessor
      */
     public static function findGetter(string $class, string $propertyName): string|null
     {
-        foreach (['get', 'is'] as $prefix) {
+        foreach (['get', 'is', 'has'] as $prefix) {
             $methodName = self::propertyToMethodName($prefix, $propertyName);
 
             if (self::isPublicMethod($class, $methodName)) {

--- a/tests/Fixtures/Types/GetterSetterType.php
+++ b/tests/Fixtures/Types/GetterSetterType.php
@@ -15,6 +15,7 @@ class GetterSetterType
         public bool $three = false,
         #[Field]
         public string $four = '',
+        public bool $five = true,
     )
     {
     }
@@ -37,6 +38,11 @@ class GetterSetterType
     private function getFour(string $arg = ''): string
     {
         throw new \RuntimeException('Should not be called');
+    }
+
+    public function hasFive(string $arg = ''): bool
+    {
+        return $arg === 'foo';
     }
 
     private function setFour(string $value, string $arg): void

--- a/tests/Utils/PropertyAccessorTest.php
+++ b/tests/Utils/PropertyAccessorTest.php
@@ -26,6 +26,7 @@ class PropertyAccessorTest extends TestCase
         yield 'regular property' => [null, MagicGetterSetterType::class, 'one'];
         yield 'getter' => ['getTwo', MagicGetterSetterType::class, 'two'];
         yield 'isser' => ['isThree', MagicGetterSetterType::class, 'three'];
+        yield 'hasser' => ['hasFive', MagicGetterSetterType::class, 'five'];
         yield 'private getter' => [null, MagicGetterSetterType::class, 'four'];
         yield 'undefined property' => [null, MagicGetterSetterType::class, 'twenty'];
     }
@@ -60,6 +61,8 @@ class PropertyAccessorTest extends TestCase
         yield 'getter' => ['result', new MagicGetterSetterType(), 'two', ['result']];
         yield 'isser #1' => [true, new MagicGetterSetterType(), 'three', ['foo']];
         yield 'isser #2' => [false, new MagicGetterSetterType(), 'three', ['bar']];
+        yield 'hasser #1' => [true, new MagicGetterSetterType(), 'five', ['foo']];
+        yield 'hasser #2' => [false, new MagicGetterSetterType(), 'five', ['bar']];
         yield 'private getter' => ['result', new MagicGetterSetterType(four: 'result'), 'four'];
         yield 'magic getter' => ['magic', new MagicGetterSetterType(), 'twenty'];
         yield 'undefined property' => [AccessPropertyException::createForUnreadableProperty(GetterSetterType::class, 'twenty'), new GetterSetterType(), 'twenty'];


### PR DESCRIPTION
Hi! :wave: 

This PR allows using hasser as property accessor. Hasser is another type of "getter" and acts like an isser.

Considering this following class:
```php
class MyClass
{
  private bool $something;

  public function hasSomething(): bool
  {
    return $this->something;
  }
}
```

Now, we have to override the getter:
```php
#[Type(class: MyClass::class)]
class MyClassType
{
    #[Field]
    public function getSomething(MyClass $myClass): bool
    {
        return $myClass->hasSomething();
    }
}
```

With that PR:
```php
#[Type(class: MyClass::class)]
#[SourceField(name: 'something')]
class MyClassType
{
}
```

Just for information, I've made a search on the issue tracker and didn't find an issue about hassers and also run PHPStan and PHPUnit.

Thanks :slightly_smiling_face: 