### PR TITLE
🐛 fix(cache): Normalize file names to avoid Windows issues

### DIFF
--- a/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
+++ b/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
@@ -116,6 +116,11 @@ class SnapshotClassFinderComputedCache implements ClassFinderComputedCache
         foreach ($classFinder as $classReflection) {
             $filename = $classReflection->getFileName();
 
+            // Skip internal classes or classes without a file
+            if ($filename === false) {
+                continue;
+            }
+
             // Normalize filename to avoid issues on Windows.
             $normalizedFilename = str_replace('\\', '/', $filename);
 

--- a/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
+++ b/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
@@ -10,6 +10,7 @@ use TheCodingMachine\GraphQLite\Cache\FilesSnapshot;
 use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
 
 use function sprintf;
+use function str_replace;
 
 /**
  * Provides cache for a {@see ClassFinder} based on a {@see filemtime()}.

--- a/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
+++ b/src/Discovery/Cache/SnapshotClassFinderComputedCache.php
@@ -79,7 +79,6 @@ class SnapshotClassFinderComputedCache implements ClassFinderComputedCache
         $changed = false;
 
         $classFinder = $classFinder->withPathFilter(static function (string $filename) use (&$entries, &$result, &$changed, $previousEntries) {
-
             // Normalize filename to avoid issues on Windows.
             $normalizedFilename = str_replace('\\', '/', $filename);
 
@@ -123,7 +122,6 @@ class SnapshotClassFinderComputedCache implements ClassFinderComputedCache
 
             // Normalize filename to avoid issues on Windows.
             $normalizedFilename = str_replace('\\', '/', $filename);
-
 
             $result[$normalizedFilename] = $map($classReflection);
             $entries[$normalizedFilename] = [


### PR DESCRIPTION
* In `SnapshotClassFinderComputedCache`, normalize file names to ensure no path issues occur in Windows environments.


[Errors regarding devMode and prodMode on Windows OS](https://github.com/thecodingmachine/graphqlite/issues/737)

Regarding this ERROR, I already know the cause. It's due to Windows file path issues. It can be resolved simply by normalizing the paths.