### PR TITLE
fix: validate files in FilesSnapshot before processing

### DIFF
--- a/src/Cache/FilesSnapshot.php
+++ b/src/Cache/FilesSnapshot.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\GraphQLite\Cache;
 use ReflectionClass;
 
 use function array_unique;
+use function is_file;
 use function Safe\filemtime;
 
 class FilesSnapshot
@@ -24,6 +25,10 @@ class FilesSnapshot
         $dependencies = [];
 
         foreach (array_unique($files) as $file) {
+            if (! is_file($file)) {
+                continue;
+            }
+
             $dependencies[$file] = filemtime($file);
         }
 

--- a/tests/Cache/FilesSnapshotTest.php
+++ b/tests/Cache/FilesSnapshotTest.php
@@ -69,6 +69,34 @@ class FilesSnapshotTest extends TestCase
         self::assertTrue($snapshot->changed());
     }
 
+    public function testIgnoresNonExistentFiles(): void
+    {
+        $nonExistentFile = '/path/to/non/existent/file.php';
+
+        $snapshot = FilesSnapshot::for([$nonExistentFile]);
+
+        self::assertFalse($snapshot->changed());
+    }
+
+    public function testIgnoresNonExistentFilesInMixedList(): void
+    {
+        $existingFile = (new \ReflectionClass(FooType::class))->getFileName();
+        $nonExistentFile1 = '/path/to/non/existent/file1.php';
+        $nonExistentFile2 = '/path/to/non/existent/file2.php';
+
+        $snapshot = FilesSnapshot::for([
+            $nonExistentFile1,
+            $existingFile,
+            $nonExistentFile2,
+        ]);
+
+        self::assertFalse($snapshot->changed());
+        
+        $this->touch($existingFile);
+
+        self::assertTrue($snapshot->changed());
+    }
+
     private function touch(string $fileName): void
     {
         touch($fileName, filemtime($fileName) + 1);


### PR DESCRIPTION
Add check to ensure each file is valid before processing. Without this change filemtime throws an error if the file doesn't exist but is part of cache, which is very common in dev environment.

For production it won't matter since is_file is cached, for some reason is_file is also faster than file_exists. Symfony codebase also prefers is_file over file_exists when checking existence of php file.