### PR TITLE
fix: resolve built-in scalar types in BaseTypeMapper::mapNameToType

### DIFF
--- a/src/Mappers/Root/BaseTypeMapper.php
+++ b/src/Mappers/Root/BaseTypeMapper.php
@@ -107,7 +107,9 @@ class BaseTypeMapper implements RootTypeMapperInterface
      *
      * @throws CannotMapTypeException
      */
-    private function mapBaseType(Type $type): BooleanType|FloatType|IDType|IntType|StringType|UploadType|DateTimeType|ScalarType|null
+    private function mapBaseType(
+        Type $type,
+    ): BooleanType|FloatType|IDType|IntType|StringType|UploadType|DateTimeType|ScalarType|null
     {
         if ($type instanceof Integer) {
             return GraphQLType::int();
@@ -180,11 +182,15 @@ class BaseTypeMapper implements RootTypeMapperInterface
      */
     public function mapNameToType(string $typeName): NamedType&GraphQLType
     {
-        // No need to map base types, only types added by us.
         return match ($typeName) {
-            'Upload'=>self::getUploadType(),
-            'DateTime'=>self::getDateTimeType(),
-            default=>$this->next->mapNameToType($typeName)
+            'ID' => GraphQLType::id(),
+            'String' => GraphQLType::string(),
+            'Int' => GraphQLType::int(),
+            'Float' => GraphQLType::float(),
+            'Boolean' => GraphQLType::boolean(),
+            'Upload' => self::getUploadType(),
+            'DateTime' => self::getDateTimeType(),
+            default => $this->next->mapNameToType($typeName),
         };
     }
 }

--- a/tests/Mappers/Root/BaseTypeMapperTest.php
+++ b/tests/Mappers/Root/BaseTypeMapperTest.php
@@ -3,9 +3,11 @@
 namespace TheCodingMachine\GraphQLite\Mappers\Root;
 
 use GraphQL\Type\Definition\BooleanType;
+use GraphQL\Type\Definition\IDType;
 use GraphQL\Type\Definition\IntType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\WrappingType;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
@@ -79,6 +81,34 @@ class BaseTypeMapperTest extends AbstractQueryProvider
             $this->assertInstanceOf(WrappingType::class, $itemType);
             $this->assertInstanceOf($expectedWrappedItemType, $itemType->getWrappedType());
         }
+    }
+
+    /**
+     * Built-in scalars (ID, String, Int, Float, Boolean) must be resolved by
+     * mapNameToType so that webonyx/graphql-php's Schema::getType() — which
+     * calls the typeLoader before checking builtInScalars — doesn't throw.
+     */
+    #[DataProvider('builtInScalarNamesProvider')]
+    public function testMapNameToTypeResolvesBuiltInScalars(string $scalarName, string $expectedType): void
+    {
+        $baseTypeMapper = new BaseTypeMapper(
+            new FinalRootTypeMapper($this->getTypeMapper()),
+            $this->getTypeMapper(),
+            $this->getRootTypeMapper(),
+        );
+
+        $result = $baseTypeMapper->mapNameToType($scalarName);
+
+        $this->assertInstanceOf($expectedType, $result);
+    }
+
+    public static function builtInScalarNamesProvider(): iterable
+    {
+        yield 'ID' => ['ID', IDType::class];
+        yield 'String' => ['String', StringType::class];
+        yield 'Int' => ['Int', IntType::class];
+        yield 'Float' => ['Float', \GraphQL\Type\Definition\FloatType::class];
+        yield 'Boolean' => ['Boolean', BooleanType::class];
     }
 
     public static function genericIterablesProvider(): iterable


### PR DESCRIPTION
## Summary

`BaseTypeMapper::mapNameToType()` now resolves the five built-in GraphQL scalar types (`ID`, `String`, `Int`, `Float`, `Boolean`) directly instead of delegating them to the next mapper in the chain.

## Problem

In `webonyx/graphql-php` v15.31.0 (commit [ef79ce1](https://github.com/webonyx/graphql-php/commit/ef79ce1) — "Support per-schema scalar overrides"), the resolution order in `Schema::getType()` was changed:

**Before (≤ v15.30.2):**
1. `resolvedTypes` cache
2. Introspection types
3. **Built-in scalars (`getStandardTypes()`)** ← resolved here
4. `loadType()` → typeLoader callback

**After (v15.31.0+):**
1. `resolvedTypes` cache
2. Introspection types
3. **`loadType()` → typeLoader callback** ← now runs first, throws
4. Built-in scalars (`builtInScalars()`)

GraphQLite's `Schema` registers a typeLoader that calls the `RootTypeMapper` chain. When the chain can't resolve a type name, `FinalRootTypeMapper` delegates to `RecursiveTypeMapper::mapNameToType()`, which throws `TypeNotFoundException`. This means step 4 is never reached for built-in scalars.

This causes `"Unknown type "ID"` errors when using `outputType` string annotations like `#[Field(outputType: 'ID')]`.

## Fix

Added the five built-in scalar names to the `match` in `BaseTypeMapper::mapNameToType()`, using the stable static factory methods (`GraphQLType::id()`, `GraphQLType::string()`, etc.) that exist across all v15.x versions.

## Test plan

- Added `testMapNameToTypeResolvesBuiltInScalars` with a data provider covering all 5 built-in scalar types
- Full test suite passes (489 tests, 1175 assertions)