### PR TITLE
[doc] Fix typo in old Doctrine Annotation syntax

### DIFF
--- a/website/versioned_docs/version-8.0.0/queries.mdx
+++ b/website/versioned_docs/version-8.0.0/queries.mdx
@@ -44,7 +44,7 @@ As you can see, GraphQLite will automatically do the mapping between PHP types a
 
 GraphQLite relies a lot on attributes.
 
-It supports the new PHP 8 attributes (`#[Query]`), the "Doctrine annotations" style (`#[Query]`) was dropped.
+It supports the new PHP 8 attributes (`#[Query]`), the "Doctrine annotations" style (`@Query`) was dropped.
 
 ## Testing the query
 


### PR DESCRIPTION
The text was displaying the Attribute syntax instead of the Doctrine Annotation syntax.