### PR TITLE
Fix MutableInterfaceType not frozen in mutation-only return types

### DIFF
--- a/src/Mappers/RecursiveTypeMapper.php
+++ b/src/Mappers/RecursiveTypeMapper.php
@@ -243,6 +243,14 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
                 continue;
             }
 
+            // Map through RecursiveTypeMapper's pipeline to ensure the interface
+            // is registered in the TypeRegistry, extended, and frozen.
+            // Calling the underlying typeMapper directly would create an orphaned,
+            // unfrozen instance that is never registered in the TypeRegistry.
+            $this->mapClassToType($interface, null);
+
+            // Now retrieve the frozen MutableInterfaceType. TypeGenerator returns
+            // the same instance from the TypeRegistry that mapClassToType registered.
             $interfaceType = $this->typeMapper->mapClassToType($interface, null);
 
             assert($interfaceType instanceof MutableInterfaceType);
@@ -489,14 +497,14 @@ class RecursiveTypeMapper implements RecursiveTypeMapperInterface
                 if ($cachedType !== $type) {
                     throw new RuntimeException('Cached type in registry is not the type returned by type mapper.');
                 }
-                if ($cachedType instanceof MutableObjectType && $cachedType->getStatus() === MutableObjectType::STATUS_FROZEN) {
+                if ($cachedType instanceof MutableInterface && $cachedType->getStatus() === MutableInterface::STATUS_FROZEN) {
                     return $type;
                 }
             }
 
             $this->typeRegistry->registerType($type);
 
-            if ($type instanceof MutableObjectType) {
+            if ($type instanceof MutableObjectType || $type instanceof MutableInterfaceType) {
                 if ($this->typeMapper->canExtendTypeForName($typeName, $type)) {
                     $this->typeMapper->extendTypeForName($typeName, $type);
                 }

--- a/tests/Fixtures/MutationInterfaceFreeze/Controllers/MutationOnlyController.php
+++ b/tests/Fixtures/MutationInterfaceFreeze/Controllers/MutationOnlyController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\MutationInterfaceFreeze\Controllers;
+
+use TheCodingMachine\GraphQLite\Annotations\Mutation;
+use TheCodingMachine\GraphQLite\Fixtures\MutationInterfaceFreeze\Types\ConcreteResult;
+use TheCodingMachine\GraphQLite\Fixtures\MutationInterfaceFreeze\Types\ResultInterface;
+
+class MutationOnlyController
+{
+    #[Mutation]
+    public function mutateResult(): ResultInterface
+    {
+        return new ConcreteResult('success');
+    }
+}

--- a/tests/Fixtures/MutationInterfaceFreeze/Types/ConcreteResult.php
+++ b/tests/Fixtures/MutationInterfaceFreeze/Types/ConcreteResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\MutationInterfaceFreeze\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+#[Type]
+class ConcreteResult implements ResultInterface
+{
+    public function __construct(private readonly string $message)
+    {
+    }
+
+    #[Field]
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    #[Field]
+    public function getExtra(): string
+    {
+        return 'extra';
+    }
+}

--- a/tests/Fixtures/MutationInterfaceFreeze/Types/ResultInterface.php
+++ b/tests/Fixtures/MutationInterfaceFreeze/Types/ResultInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\MutationInterfaceFreeze\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+#[Type]
+interface ResultInterface
+{
+    #[Field]
+    public function getMessage(): string;
+}

--- a/tests/Integration/MutationInterfaceFreezeTest.php
+++ b/tests/Integration/MutationInterfaceFreezeTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Integration;
+
+use GraphQL\Error\DebugFlag;
+use GraphQL\GraphQL;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
+use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
+use TheCodingMachine\GraphQLite\Schema;
+use TheCodingMachine\GraphQLite\SchemaFactory;
+
+/**
+ * Regression test for issue #308: MutableInterfaceType not frozen when used
+ * exclusively as a mutation return type.
+ *
+ * @see https://github.com/thecodingmachine/graphqlite/issues/308
+ */
+class MutationInterfaceFreezeTest extends TestCase
+{
+    private Schema $schema;
+
+    public function setUp(): void
+    {
+        $container = new BasicAutoWiringContainer(new EmptyContainer());
+
+        $schemaFactory = new SchemaFactory(new Psr16Cache(new ArrayAdapter()), $container);
+        $schemaFactory->addNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\MutationInterfaceFreeze');
+
+        $this->schema = $schemaFactory->createSchema();
+    }
+
+    /**
+     * Schema validation triggers getTypeMap() which traverses all types.
+     * Before the fix, this would throw:
+     * "You must freeze() a MutableObjectType before fetching its fields."
+     */
+    public function testSchemaValidationDoesNotThrowForMutationOnlyInterface(): void
+    {
+        $this->schema->assertValid();
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Executing a mutation that returns an interface type should work
+     * without any query also returning that interface.
+     */
+    public function testMutationReturningInterfaceCanBeExecuted(): void
+    {
+        $queryString = '
+        mutation {
+            mutateResult {
+                message
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $this->schema,
+            $queryString,
+        );
+
+        $this->assertSame(
+            ['mutateResult' => ['message' => 'success']],
+            $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS)['data'],
+        );
+    }
+
+    /**
+     * Inline fragments on an interface type in a mutation should work.
+     * Before the fix, the OverlappingFieldsCanBeMerged validator would
+     * access the unfrozen MutableInterfaceType and crash.
+     */
+    public function testMutationWithInlineFragmentOnInterface(): void
+    {
+        $queryString = '
+        mutation {
+            mutateResult {
+                ... on ResultInterface {
+                    message
+                }
+                ... on ConcreteResult {
+                    message
+                    extra
+                }
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $this->schema,
+            $queryString,
+        );
+
+        $this->assertSame(
+            [
+                'mutateResult' => [
+                    'message' => 'success',
+                    'extra' => 'extra',
+                ],
+            ],
+            $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS)['data'],
+        );
+    }
+
+    /**
+     * Introspection must include the mutation return interface type
+     * and it must be resolvable without errors.
+     */
+    public function testIntrospectionIncludesMutationInterfaceType(): void
+    {
+        $queryString = '
+        {
+            __type(name: "ResultInterface") {
+                kind
+                name
+                fields {
+                    name
+                }
+            }
+        }
+        ';
+
+        $result = GraphQL::executeQuery(
+            $this->schema,
+            $queryString,
+        );
+
+        $data = $result->toArray(DebugFlag::RETHROW_INTERNAL_EXCEPTIONS)['data'];
+        $this->assertSame('INTERFACE', $data['__type']['kind']);
+        $this->assertSame('ResultInterface', $data['__type']['name']);
+        $this->assertContains(
+            ['name' => 'message'],
+            $data['__type']['fields'],
+        );
+    }
+}


### PR DESCRIPTION
## Description

Fixes #308 — `MutableInterfaceType` instances escape the freeze mechanism when used exclusively as mutation return types (no corresponding query returning the same interface). This causes `RuntimeException: You must freeze() a MutableObjectType before fetching its fields` during schema validation, introspection, and query execution.

## Root Cause

Two code paths in `RecursiveTypeMapper` allowed `MutableInterfaceType` to bypass freezing:

### 1. `findInterfaces()` created orphaned, unfrozen instances

`findInterfaces()` called `$this->typeMapper->mapClassToType()` (the **underlying** type mapper) instead of going through `RecursiveTypeMapper::mapClassToType()`. The underlying mapper (via `TypeGenerator`) creates a **new** `MutableInterfaceType` instance that is:
- **Not registered** in the `TypeRegistry`
- **Not extended** via `@ExtendType`
- **Not frozen**

Meanwhile, `RecursiveTypeMapper::mapClassToType()` later creates a **different** instance of the same type that *is* properly frozen and registered. This leaves webonyx holding a reference to the orphaned unfrozen instance (from `ObjectType::getInterfaces()`), while the `TypeRegistry` contains the frozen one.

Since webonyx's `TypeInfo::extractTypes()` processes `getInterfaces()` **before** `getFields()`, the unfrozen interface is discovered before the fields callback (which would trigger proper mapping) has a chance to run.

### 2. `mapNameToType()` didn't freeze `MutableInterfaceType`

The freeze logic in `mapNameToType()` handled `MutableObjectType` and input types but had no branch for `MutableInterfaceType`. If an interface type was loaded by name through the `typeLoader` before being mapped through `mapClassToType()`, it was returned in `PENDING` state.

## Fix

1. **`findInterfaces()`**: Now calls `$this->mapClassToType()` (RecursiveTypeMapper's own method) before retrieving the interface type, ensuring the instance is registered, extended, and frozen through the proper pipeline.

2. **`mapNameToType()`**: Extended the freeze logic to also handle `MutableInterfaceType`, including applying type extensions before freezing — matching the existing pattern for `MutableObjectType`.

## Why not the `finalizeTypes()` approach (#789)?

PR #789 proposes brute-force freezing all registered types in `TypeRegistry::finalizeTypes()` before schema creation. While well-intentioned, this doesn't address the root cause:

- `findInterfaces()` creates orphaned instances that are **never registered** in the `TypeRegistry`, so `finalizeTypes()` misses them entirely
- Types created during lazy resolution (after `finalizeTypes()` has already run) would still be unfrozen
- `mapNameToType()` still wouldn't freeze `MutableInterfaceType` at runtime
- It skips the extension step that `mapClassToType()` applies before freezing

## Test Plan

- [x] 4 new regression tests in `MutationInterfaceFreezeTest`:
  - Schema validation doesn't throw for mutation-only interface return types
  - Mutation execution returns correct data
  - Inline fragments on interface types in mutations work correctly
  - Introspection resolves the interface type without errors
- [x] Tests **fail** on `master` with the exact error from #308, **pass** with the fix
- [x] All 493 tests pass (489 existing + 4 new)