### PR TITLE
fix: drop @internal annotation from InputField

### DIFF
--- a/src/InputField.php
+++ b/src/InputField.php
@@ -22,8 +22,6 @@ use Throwable;
 /**
  * A GraphQL input field that maps to a PHP method automatically.
  *
- * @internal
- *
  * @phpstan-import-type InputObjectFieldConfig from InputObjectField
  * @phpstan-import-type ArgumentType from InputObjectField
  */


### PR DESCRIPTION
Closes #761.

## Problem

`InputField` is marked `@internal`, but userland cannot avoid referencing it: the public `InputFieldMiddlewareInterface::process()` method signature returns `InputField|null`, so any middleware implementation must import and return `InputField` directly.

```php
public function process(
    InputFieldDescriptor $inputFieldDescriptor,
    InputFieldHandlerInterface $inputFieldHandler,
): InputField|null;
```

The `@internal` marker contradicts that public-API contract and causes static analysis tooling to flag legitimate middleware implementations.

## Fix

Drop the `@internal` line from the `InputField` class docblock. The class is already `final`, which keeps its inheritance contract locked down; removing `@internal` just acknowledges that the type is part of the public surface reachable through the middleware interface.

Note: the sibling `QueryField` class retains `@internal` because `FieldMiddlewareInterface::process()` returns the parent `FieldDefinition`, not `QueryField` — userland middleware never needs to name `QueryField` directly.