### PR TITLE
docs: fix broken anchors and stale Doctrine annotation references

### DIFF
--- a/website/docs/annotations-reference.md
+++ b/website/docs/annotations-reference.md
@@ -4,8 +4,8 @@ title: Attributes reference
 sidebar_label: Attributes reference
 ---
 
-Note: all annotations are available in PHP 8 attribute format (`#[Query]`), support of Doctrine annotation format was dropped.
-See [Doctrine annotations vs PHP 8 attributes](doctrine-annotations-attributes.mdx) for more details.
+All attributes use PHP 8 native attribute syntax (e.g., `#[Query]`). The legacy Doctrine annotations format (`@Query`) is no longer supported.
+See [migrating from Doctrine annotations to PHP 8 attributes](doctrine-annotations-attributes.mdx) for details.
 
 Attributes are listed in alphabetical order.
 
@@ -21,7 +21,7 @@ It is available out of the box if you use the Symfony bundle.
 Attribute      | Compulsory | Type | Definition
 ---------------|------------|------|--------
 *for*          | *yes*      | string | The name of the PHP parameter
-*constraint*   | *yes       | annotation | One (or many) Symfony validation attributes.
+*constraint*   | *yes       | attribute | One (or many) Symfony validation attributes.
 
 ## #[Autowire]
 
@@ -294,7 +294,7 @@ description    | *no*       | string | Description of the subscription in the do
 ## #[Type]
 
 The `#[Type]` attribute is used to declare a GraphQL object type.  This is used with standard output
-types, as well as enum types.  For input types, use the [#[Input] attribute](#input-annotation) directly on the input type or a [#[Factory] attribute](#factory-annotation) to make/return an input type.
+types, as well as enum types.  For input types, use the [#[Input] attribute](#input) directly on the input type or a [#[Factory] attribute](#factory) to make/return an input type.
 
 **Applies on**: classes.
 

--- a/website/docs/authentication-authorization.mdx
+++ b/website/docs/authentication-authorization.mdx
@@ -10,8 +10,8 @@ queries/mutations/subscriptions or fields reserved to some users.
 GraphQLite offers some control over what a user can do with your API. You can restrict access to
 resources:
 
-- based on authentication using the [`#[Logged]` attribute](#logged-and-right-annotations) (restrict access to logged users)
-- based on authorization using the [`#[Right]` attribute](#logged-and-right-annotations) (restrict access to logged users with certain rights).
+- based on authentication using the [`#[Logged]` attribute](#logged-and-right-attributes) (restrict access to logged users)
+- based on authorization using the [`#[Right]` attribute](#logged-and-right-attributes) (restrict access to logged users with certain rights).
 - based on fine-grained authorization using the [`#[Security]` attribute](fine-grained-security.mdx) (restrict access for some given resources to some users).
 
 <div class="alert alert--info">

--- a/website/docs/fine-grained-security.mdx
+++ b/website/docs/fine-grained-security.mdx
@@ -5,7 +5,7 @@ sidebar_label: Fine grained security
 ---
 
 
-If the [`#[Logged]` and `#[Right]` attributes](authentication-authorization.mdx#logged-and-right-annotations) are not
+If the [`#[Logged]` and `#[Right]` attributes](authentication-authorization.mdx#logged-and-right-attributes) are not
 granular enough for your needs, you can use the advanced `#[Security]` attribute.
 
 Using the `#[Security]` attribute, you can write an *expression* that can contain custom logic. For instance:

--- a/website/docs/queries.mdx
+++ b/website/docs/queries.mdx
@@ -44,7 +44,7 @@ As you can see, GraphQLite will automatically do the mapping between PHP types a
 
 GraphQLite relies a lot on attributes.
 
-It supports the new PHP 8 attributes (`#[Query]`), the "Doctrine annotations" style (`#[Query]`) was dropped.
+GraphQLite uses native PHP 8 attribute syntax (e.g., `#[Query]`). The legacy "Doctrine annotations" style (`@Query`) is no longer supported.
 
 ## Testing the query
 


### PR DESCRIPTION
## Summary

Doctrine annotation support was dropped in #677, and the relevant section headings were subsequently renamed from "annotation(s)" to "attribute(s)". A handful of in-repo links and wording were missed in that rename — this PR cleans them up.

### Broken anchors (navigation currently breaks)

- `annotations-reference.md` `#[Type]` section: `#input-annotation` / `#factory-annotation` → `#input` / `#factory` (sections are now `## #[Input]` and `## #[Factory]`).
- `authentication-authorization.mdx` + `fine-grained-security.mdx`: `#logged-and-right-annotations` → `#logged-and-right-attributes` (section is `## `#[Logged]` and `#[Right]` attributes`).

### Stale / contradictory wording

- `queries.mdx` "About attributes": the Doctrine example was shown as `#[Query]`, which is the new-style syntax. Corrected to `@Query` and rephrased so the old-vs-new distinction actually reads.
- `annotations-reference.md` intro: reworded to reflect that only the PHP 8 attribute format exists now. Kept the link to the migration guide since existing users still benefit from it.
- `annotations-reference.md` `#[Assertion]`: Type column said `annotation` while the description said `attributes` — aligned to `attribute`.

### Intentionally left alone

- `CHANGELOG.md` — historical record.
- `migrating.md` — historical migration guide, references `@SourceField` etc. on purpose.
- `doctrine-annotations-attributes.mdx` — migration guide, still useful for users on the old syntax.
- `annotations` parameter on `#[SourceField]` / `#[MagicField]` — that's the actual PHP parameter name in the source, not stale terminology.
- PHP namespace references like `TheCodingMachine\GraphQLite\Annotations\*` — real symbol names.

## Test plan

- [x] Diff is link/wording changes only; no structural or behavioral edits.
- [x] Render the Docusaurus site locally and click through the four affected pages to confirm the anchor links land on the right sections.