### PR TITLE
Fix Security "this" variable on ExtendType fields

### DIFF
--- a/src/Middlewares/SecurityFieldMiddleware.php
+++ b/src/Middlewares/SecurityFieldMiddleware.php
@@ -83,7 +83,12 @@ class SecurityFieldMiddleware implements FieldMiddlewareInterface
         $injectSource = $queryFieldDescriptor->isInjectSource();
 
         $queryFieldDescriptor = $queryFieldDescriptor->withResolver(function (object|null $source, ...$args) use ($originalResolver, $securityAnnotations, $resolver, $failWith, $parameters, $queryFieldDescriptor, $injectSource) {
-            $variables = $this->getVariables($args, $parameters, $originalResolver->executionSource($source), $injectSource);
+            $variables = $this->getVariables(
+                $args,
+                $parameters,
+                $injectSource ? $source : $originalResolver->executionSource($source),
+                $injectSource,
+            );
 
             foreach ($securityAnnotations as $annotation) {
                 try {

--- a/src/Middlewares/SecurityInputFieldMiddleware.php
+++ b/src/Middlewares/SecurityInputFieldMiddleware.php
@@ -51,7 +51,12 @@ class SecurityInputFieldMiddleware implements InputFieldMiddlewareInterface
         $injectSource = $inputFieldDescriptor->isInjectSource();
 
         $inputFieldDescriptor = $inputFieldDescriptor->withResolver(function (object|null $source, ...$args) use ($originalResolver, $securityAnnotations, $resolver, $parameters, $inputFieldDescriptor, $injectSource) {
-            $variables = $this->getVariables($args, $parameters, $originalResolver->executionSource($source), $injectSource);
+            $variables = $this->getVariables(
+                $args,
+                $parameters,
+                $injectSource ? $source : $originalResolver->executionSource($source),
+                $injectSource,
+            );
 
             foreach ($securityAnnotations as $annotation) {
                 try {

--- a/tests/Fixtures/Integration/Types/ExtendedContactType.php
+++ b/tests/Fixtures/Integration/Types/ExtendedContactType.php
@@ -48,4 +48,15 @@ class ExtendedContactType
     {
         return $contact->getName();
     }
+
+    /**
+     * Regression: in #[Security] on an #[ExtendType] field, `this` must be
+     * the source object, not the resolver instance.
+     */
+    #[Field]
+    #[Security("user && this.getName() == 'Joe'", failWith: null)]
+    public function sourceAwareSecretName(Contact $contact): string|null
+    {
+        return $contact->getName();
+    }
 }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -1360,6 +1360,7 @@ class EndToEndTest extends IntegrationTestCase
             contacts {
                 name
                 extendedSecretName
+                sourceAwareSecretName
             }
         }
         ';
@@ -1368,6 +1369,7 @@ class EndToEndTest extends IntegrationTestCase
         $data = $this->getSuccessResult($result);
         $this->assertSame('Joe', $data['contacts'][0]['name']);
         $this->assertNull($data['contacts'][0]['extendedSecretName']);
+        $this->assertNull($data['contacts'][0]['sourceAwareSecretName']);
 
         // Logged-in user with bar=42 → the Security expression passes and the field returns the name.
         $container = $this->createContainer([
@@ -1394,6 +1396,7 @@ class EndToEndTest extends IntegrationTestCase
         $result = GraphQL::executeQuery($schema, $queryString);
         $data = $this->getSuccessResult($result);
         $this->assertSame('Joe', $data['contacts'][0]['extendedSecretName']);
+        $this->assertSame('Joe', $data['contacts'][0]['sourceAwareSecretName']);
     }
 
     public function testEndToEndUnions(): void


### PR DESCRIPTION
Fixes #653
Related to #792

## Problem

When using `#[Security]` on a field declared in an `#[ExtendType]`, the `this`
variable incorrectly points to the resolver instance instead of the source object.

This breaks authorization logic relying on the domain object (e.g. voters).

## Fix

Preserve `$source` when `injectSource=true` instead of always using
`$originalResolver->executionSource($source)`.

## Test coverage

Extends existing end-to-end test to assert that:

- `this` is the source object
- not the resolver instance

## Result

- Correct behavior for `#[Security]` on `#[ExtendType]`
- No regression on existing tests