### PR TITLE
chore: remove package-versions-deprecated dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
+        "composer-runtime-api": "^2.0",
         "php": ">=8.2",
         "ext-json": "*",
-        "composer/package-versions-deprecated": "^1.8",
         "phpdocumentor/reflection-docblock": "^5.4",
         "phpdocumentor/type-resolver": "^1.7",
         "psr/container": "^1.1 || ^2",
@@ -64,7 +64,6 @@
     },
     "config": {
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true
         },

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite;
 
+use Composer\InstalledVersions;
 use GraphQL\Type\SchemaConfig;
 use Kcs\ClassFinder\FileFinder\CachedFileFinder;
 use Kcs\ClassFinder\FileFinder\DefaultFileFinder;
 use Kcs\ClassFinder\Finder\ComposerFinder;
 use Kcs\ClassFinder\Finder\FinderInterface;
-use PackageVersions\Versions;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -141,7 +141,7 @@ class SchemaFactory
         private readonly ContainerInterface $container,
         private ClassBoundCache|null $classBoundCache = null,
     ) {
-        $this->cacheNamespace = substr(md5(Versions::getVersion('thecodingmachine/graphqlite')), 0, 8);
+        $this->cacheNamespace = substr(md5(InstalledVersions::getVersion('thecodingmachine/graphqlite') ?? ''), 0, 8);
     }
 
     /**

--- a/src/Utils/NamespacedCache.php
+++ b/src/Utils/NamespacedCache.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Utils;
 
+use Composer\InstalledVersions;
 use DateInterval;
-use PackageVersions\Versions;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use function md5;
@@ -22,7 +22,7 @@ class NamespacedCache implements CacheInterface
 
     public function __construct(private readonly CacheInterface $cache)
     {
-        $this->namespace = substr(md5(Versions::getVersion('thecodingmachine/graphqlite')), 0, 8);
+        $this->namespace = substr(md5(InstalledVersions::getVersion('thecodingmachine/graphqlite') ?? ''), 0, 8);
     }
 
     /**


### PR DESCRIPTION
## Summary

Remove the abandoned `composer/package-versions-deprecated` dependency.

GraphQLite only used `PackageVersions\Versions` to derive a cache namespace from the installed package version. This PR replaces that usage with Composer 2's built-in `Composer\InstalledVersions`.

## Changes

- Replace `PackageVersions\Versions` with `Composer\InstalledVersions`
- Add `composer-runtime-api` requirement
- Remove `composer/package-versions-deprecated`
- Remove the related Composer plugin allow-list entry

## Tests

- `composer validate --strict`
- `git diff --check`
- `composer audit --abandoned=fail`
- `composer cs-check`
- `vendor/bin/phpstan analyse -c phpstan.neon --no-progress src/SchemaFactory.php src/Utils/NamespacedCache.php`
- `vendor/bin/phpunit --no-coverage tests/Utils/NamespacedCacheTest.php tests/SchemaFactoryTest.php`
