### PR TITLE
Fix CI: update Symfony and PSR cache dependencies for no-framework example, make static analysis happy with possible types of callback params

### DIFF
--- a/examples/no-framework/composer.json
+++ b/examples/no-framework/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "thecodingmachine/graphqlite": "@dev",
     "mouf/picotainer": "^1.1",
-    "symfony/cache": "^8.1",
+    "symfony/cache": "^7.4",
     "psr/simple-cache": "^3.0"
   },
   "repositories": [

--- a/examples/no-framework/composer.json
+++ b/examples/no-framework/composer.json
@@ -7,8 +7,8 @@
   "require": {
     "thecodingmachine/graphqlite": "@dev",
     "mouf/picotainer": "^1.1",
-    "symfony/cache": "^4.3",
-    "psr/simple-cache": "^1.0"
+    "symfony/cache": "^8.1",
+    "psr/simple-cache": "^3.0"
   },
   "repositories": [
     {

--- a/src/Http/Psr15GraphQLMiddlewareBuilder.php
+++ b/src/Http/Psr15GraphQLMiddlewareBuilder.php
@@ -6,6 +6,8 @@ namespace TheCodingMachine\GraphQLite\Http;
 
 use DateInterval;
 use GraphQL\Error\DebugFlag;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Server\OperationParams;
 use GraphQL\Server\ServerConfig;
 use GraphQL\Type\Schema;
 use GraphQL\Validator\DocumentValidator;
@@ -133,13 +135,17 @@ class Psr15GraphQLMiddlewareBuilder
         // So if we only added given rule, all of the default rules would not be validated, so we must also provide them.
         $originalValidationRules = $this->config->getValidationRules() ?? DocumentValidator::allRules();
 
-        $this->config->setValidationRules(function (...$args) use ($originalValidationRules) {
-            if (is_callable($originalValidationRules)) {
-                $originalValidationRules = $originalValidationRules(...$args);
-            }
+        $this->config->setValidationRules(function (
+            OperationParams $operation,
+            DocumentNode $doc,
+            string $operationType,
+        ) use ($originalValidationRules): array {
+            $validationRules = is_callable($originalValidationRules)
+                ? $originalValidationRules($operation, $doc, $operationType)
+                : $originalValidationRules;
 
             return [
-                ...$originalValidationRules,
+                ...$validationRules,
                 ...$this->addedValidationRules,
             ];
         });


### PR DESCRIPTION
1. symfony/cache v4 is affected by PKSA-z7t6-zt6p-wtng security advisory


Addresses CI failure for "Check Examples (no-framework)"
```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires symfony/cache ^4.3, found symfony/cache[v4.3.0, ..., v4.4.48] but these were not loaded, because they are affected by security advisories ("PKSA-z7t6-zt6p-wtng", "PKSA-w17b-j6zx-knvn"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add their IDs to the "policy.advisories.ignore-id" config or add the package to "policy.advisories.ignore". To turn the feature off entirely, you can set "policy.advisories.block" to false.
  Problem 2
    - Root composer.json requires thecodingmachine/graphqlite @dev -> satisfiable by thecodingmachine/graphqlite[dev-703ca1fcacb60789bd36d39a93ee28b5b6ec457b].
    - thecodingmachine/graphqlite dev-703ca1fcacb60789bd36d39a93ee28b5b6ec457b requires symfony/cache ^4.3 || ^5 || ^6 || ^7 || ^8 -> found symfony/cache[v4.3.0, ..., v4.4.48, v5.0.0, ..., v5.4.53, v6.0.0, ..., v6.4.41, v7.0.0, ..., v7.4.13, v8.0.0, ..., v8.1.0] but these were not loaded, because they are affected by security advisories ("PKSA-z7t6-zt6p-wtng", "PKSA-w17b-j6zx-knvn"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add their IDs to the "policy.advisories.ignore-id" config or add the package to "policy.advisories.ignore". To turn the feature off entirely, you can set "policy.advisories.block" to false.

Error: Your requirements could not be resolved to an installable set of packages.
```

---

2. Static analysis starts emitting issue about validation rules callback params.

Addresses CI failure for "Continuous Integration (*)" jobs.

```
Error: Parameter #1 $operation of callable callable(GraphQL\Server\OperationParams, GraphQL\Language\AST\DocumentNode, string): array<GraphQL\Validator\Rules\ValidationRule> expects GraphQL\Server\OperationParams, GraphQL\Language\AST\DocumentNode|GraphQL\Server\OperationParams|string given.
 ------ ----------------------------------------------------------------------- 
  Line   Http/Psr15GraphQLMiddlewareBuilder.php                                 
 ------ ----------------------------------------------------------------------- 
  138    Parameter #1 $operation of callable                                    
         callable(GraphQL\Server\OperationParams,                               
         GraphQL\Language\AST\DocumentNode, string): array<GraphQL\Validator\R  
         ules\ValidationRule> expects GraphQL\Server\OperationParams, GraphQL\  
         Language\AST\DocumentNode|GraphQL\Server\OperationParams|string        
         given.                                                                 
         🪪  argument.type                                                      
PHP runtime version: 8.5.6
 ------ ----------------------------------------------------------------------- 


Error:  [ERROR] Found 1 error                  
```         