### PR TITLE
feat: Allow Custom Directives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/simple-cache": "^1.0.1 || ^2 || ^3",
         "symfony/cache": "^4.3 || ^5 || ^6 || ^7 || ^8",
         "symfony/expression-language": "^4 || ^5 || ^6 || ^7 || ^8",
-        "webonyx/graphql-php": "^v15.0",
+        "webonyx/graphql-php": "^15.33.0",
         "kcs/class-finder": "^0.6.0"
     },
     "require-dev": {

--- a/src/Directives/DirectiveRegistry.php
+++ b/src/Directives/DirectiveRegistry.php
@@ -9,12 +9,18 @@ use ReflectionClass;
 use TheCodingMachine\GraphQLite\AnnotationReader;
 use TheCodingMachine\GraphQLite\Directives\BuiltIn\Deprecated;
 use TheCodingMachine\GraphQLite\Directives\BuiltIn\OneOf;
+use TheCodingMachine\GraphQLite\Directives\Discovery\DirectiveClassFinder;
 use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
 
+use function array_key_exists;
+use function assert;
+use function method_exists;
+
 /**
- * Holds the directives known to a schema. In this layer that's the built-ins that bind PHP behavior
- * to directives webonyx already declares (`@oneOf`, `@deprecated`); a later layer adds user-defined
- * directives on top.
+ * Holds the directives known to a schema: the user-defined directives discovered in the configured
+ * namespaces plus the built-ins that bind PHP behavior to directives webonyx already declares
+ * (`@oneOf`, `@deprecated`). For each discovered class it runs {@see DirectiveValidator}, caches what
+ * {@see DirectiveResolver} produces, and enforces name uniqueness across the set.
  *
  * The dispatcher middlewares query it at apply time for a directive's argument shape, which the AST
  * builder needs to encode each arg as a GraphQL value.
@@ -24,7 +30,15 @@ final class DirectiveRegistry
     /** @var array<class-string<DirectiveInterface>, ResolvedDirective> */
     private array $resolvedByClass = [];
 
-    /** Attribute classes that bind PHP behavior to webonyx's built-in directives. */
+    /** @var array<string, class-string<DirectiveInterface>> */
+    private array $classByName = [];
+
+    /**
+     * Attribute classes that bind PHP behavior to webonyx's pre-existing built-in directives.
+     * Also the source of truth for reserved names: a custom (non-built-in) directive can't claim
+     * one of these names unless it declares `builtIn: true` to override the bundled binding.
+     * Registered after user discovery so such an override wins.
+     */
     private const BUILT_IN_ATTRIBUTES = [
         OneOf::class,
         Deprecated::class,
@@ -32,20 +46,76 @@ final class DirectiveRegistry
 
     public function __construct(
         private readonly AnnotationReader $annotationReader,
+        private readonly DirectiveClassFinder $classFinder,
     ) {
     }
 
-    /** Resolve the built-in directives once. Idempotent. */
+    /** Discover + validate the user directives, then the built-ins. Idempotent. */
     public function discover(): void
     {
-        foreach (self::BUILT_IN_ATTRIBUTES as $directiveClass) {
-            /** @var class-string<TypeSystemDirective> $directiveClass */
-            if (isset($this->resolvedByClass[$directiveClass])) {
-                continue;
-            }
-
-            $this->resolvedByClass[$directiveClass] = DirectiveResolver::resolve($directiveClass, $directiveClass::definition());
+        // User classes first: an override of a built-in (same name, builtIn: true) needs to land
+        // before our bundled copy registers.
+        foreach ($this->classFinder->findDirectives() as $directiveClass) {
+            $this->register($directiveClass);
         }
+        foreach (self::BUILT_IN_ATTRIBUTES as $directiveClass) {
+            $this->register($directiveClass);
+        }
+    }
+
+    /**
+     * @param class-string<TypeSystemDirective> $directiveClass
+     *
+     * @throws InvalidDirectiveException
+     */
+    private function register(string $directiveClass): void
+    {
+        // Registering the same class twice is a no-op; discovery and the built-in list share this
+        // registry, so duplicates are expected.
+        if (isset($this->resolvedByClass[$directiveClass])) {
+            return;
+        }
+
+        if (! method_exists($directiveClass, 'definition')) {
+            throw InvalidDirectiveException::noDefinitionMethod($directiveClass);
+        }
+
+        $definition = $directiveClass::definition();
+        assert($definition instanceof DirectiveDefinition);
+
+        DirectiveValidator::validate($directiveClass, $definition);
+
+        if (! $definition->builtIn && $this->isReservedBuiltInName($definition->name)) {
+            throw InvalidDirectiveException::reservedName($definition->name, $directiveClass);
+        }
+
+        if (array_key_exists($definition->name, $this->classByName)) {
+            // A name clash is fine when this side is also built-in: the user supplied their own
+            // implementation and we defer to it. Two custom directives sharing a name is an error.
+            if ($definition->builtIn) {
+                return;
+            }
+            throw InvalidDirectiveException::duplicateName(
+                $definition->name,
+                $this->classByName[$definition->name],
+                $directiveClass,
+            );
+        }
+
+        $this->resolvedByClass[$directiveClass] = DirectiveResolver::resolve($directiveClass, $definition);
+        $this->classByName[$definition->name] = $directiveClass;
+    }
+
+    /** Whether $name is bound by one of our built-in attributes, so only a `builtIn: true` override may take it. */
+    private function isReservedBuiltInName(string $name): bool
+    {
+        foreach (self::BUILT_IN_ATTRIBUTES as $builtInClass) {
+            if ($builtInClass::definition()->name === $name) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function hasAny(): bool

--- a/src/Directives/DirectiveRegistry.php
+++ b/src/Directives/DirectiveRegistry.php
@@ -16,13 +16,8 @@ use function array_key_exists;
 use function in_array;
 
 /**
- * Holds the directives known to a schema: the user-defined directives discovered in the configured
- * namespaces plus the built-ins that bind PHP behavior to directives webonyx already declares
- * (`@oneOf`, `@deprecated`). For each discovered class it runs {@see DirectiveValidator}, caches what
- * {@see DirectiveResolver} produces, and enforces name uniqueness across the set.
- *
- * The dispatcher middlewares query it at apply time for a directive's argument shape, which the AST
- * builder needs to encode each arg as a GraphQL value.
+ * Discovers, validates and holds a schema's directives: the user-defined ones plus the built-ins
+ * (`@oneOf`, `@deprecated`). Middlewares query it at apply time for a directive's argument shape.
  */
 final class DirectiveRegistry
 {
@@ -32,22 +27,13 @@ final class DirectiveRegistry
     /** @var array<string, class-string<DirectiveInterface>> */
     private array $classByName = [];
 
-    /**
-     * Attribute classes that bind PHP behavior to webonyx's pre-existing built-in directives.
-     * Also the source of truth for reserved names: a custom (non-built-in) directive can't claim
-     * one of these names unless it declares `builtIn: true` to override the bundled binding.
-     * Registered after user discovery so such an override wins.
-     */
+    /** Attributes we bind to webonyx's built-ins; a custom directive reuses these names only via `builtIn: true`. */
     private const BUILT_IN_ATTRIBUTES = [
         OneOf::class,
         Deprecated::class,
     ];
 
-    /**
-     * Directive names webonyx declares itself that GraphQLite doesn't bind (the execution directives
-     * and @specifiedBy). A custom directive can't claim these: there's no bundled binding to override
-     * and emitting our own would clash with webonyx's at schema build.
-     */
+    /** webonyx directives we don't bind; no custom directive may take these names. */
     private const RESERVED_WEBONYX_NAMES = [
         WebonyxDirective::SKIP_NAME,
         WebonyxDirective::INCLUDE_NAME,
@@ -60,11 +46,9 @@ final class DirectiveRegistry
     ) {
     }
 
-    /** Discover + validate the user directives, then the built-ins. Idempotent. */
+    /** Idempotent. User directives first, so a `builtIn: true` override lands before the bundled copy. */
     public function discover(): void
     {
-        // User classes first: an override of a built-in (same name, builtIn: true) needs to land
-        // before our bundled copy registers.
         foreach ($this->classFinder->findDirectives() as $directiveClass) {
             $this->register($directiveClass);
         }
@@ -73,15 +57,10 @@ final class DirectiveRegistry
         }
     }
 
-    /**
-     * @param class-string<TypeSystemDirective> $directiveClass
-     *
-     * @throws InvalidDirectiveException
-     */
+    /** @param class-string<TypeSystemDirective> $directiveClass */
     private function register(string $directiveClass): void
     {
-        // Registering the same class twice is a no-op; discovery and the built-in list share this
-        // registry, so duplicates are expected.
+        // Discovery and the built-in list overlap, so a repeat is expected.
         if (isset($this->resolvedByClass[$directiveClass])) {
             return;
         }
@@ -99,8 +78,7 @@ final class DirectiveRegistry
         }
 
         if (array_key_exists($definition->name, $this->classByName)) {
-            // A name clash is fine when this side is also built-in: the user supplied their own
-            // implementation and we defer to it. Two custom directives sharing a name is an error.
+            // A builtIn override defers to the already-registered user class; two customs is an error.
             if ($definition->builtIn) {
                 return;
             }
@@ -115,7 +93,6 @@ final class DirectiveRegistry
         $this->classByName[$definition->name] = $directiveClass;
     }
 
-    /** Whether $name is bound by one of our built-in attributes, so only a `builtIn: true` override may take it. */
     private function isReservedBuiltInName(string $name): bool
     {
         foreach (self::BUILT_IN_ATTRIBUTES as $builtInClass) {

--- a/src/Directives/DirectiveRegistry.php
+++ b/src/Directives/DirectiveRegistry.php
@@ -13,8 +13,7 @@ use TheCodingMachine\GraphQLite\Directives\Discovery\DirectiveClassFinder;
 use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
 
 use function array_key_exists;
-use function assert;
-use function method_exists;
+use function in_array;
 
 /**
  * Holds the directives known to a schema: the user-defined directives discovered in the configured
@@ -42,6 +41,17 @@ final class DirectiveRegistry
     private const BUILT_IN_ATTRIBUTES = [
         OneOf::class,
         Deprecated::class,
+    ];
+
+    /**
+     * Directive names webonyx declares itself that GraphQLite doesn't bind (the execution directives
+     * and @specifiedBy). A custom directive can't claim these: there's no bundled binding to override
+     * and emitting our own would clash with webonyx's at schema build.
+     */
+    private const RESERVED_WEBONYX_NAMES = [
+        WebonyxDirective::SKIP_NAME,
+        WebonyxDirective::INCLUDE_NAME,
+        WebonyxDirective::SPECIFIED_BY_NAME,
     ];
 
     public function __construct(
@@ -76,14 +86,13 @@ final class DirectiveRegistry
             return;
         }
 
-        if (! method_exists($directiveClass, 'definition')) {
-            throw InvalidDirectiveException::noDefinitionMethod($directiveClass);
-        }
-
         $definition = $directiveClass::definition();
-        assert($definition instanceof DirectiveDefinition);
 
         DirectiveValidator::validate($directiveClass, $definition);
+
+        if (! $definition->builtIn && in_array($definition->name, self::RESERVED_WEBONYX_NAMES, true)) {
+            throw InvalidDirectiveException::reservedName($definition->name, $directiveClass);
+        }
 
         if (! $definition->builtIn && $this->isReservedBuiltInName($definition->name)) {
             throw InvalidDirectiveException::reservedName($definition->name, $directiveClass);

--- a/src/Directives/DirectiveValidator.php
+++ b/src/Directives/DirectiveValidator.php
@@ -14,29 +14,14 @@ use function in_array;
 use function is_a;
 
 /**
- * Validates directives at two points:
- *
- *   - {@see self::validate()} at discovery time, delegating to {@see AttributeTargetValidator} (the
- *     `#[Attribute(...)]` PHP targets cover every declared GraphQL location) and
- *     {@see InterfaceLocationValidator} (each family interface has a matching location, and vice
- *     versa).
- *   - {@see self::assertDirectivesUsableAt()} at apply time: a directive placed on a class is
- *     allowed at that class's location. PHP's `#[Attribute]` targets can't tell a `#[Type]` class
- *     from an `#[Input]` class (both are `TARGET_CLASS`), so `#[OneOf]` could be placed on the wrong
- *     kind of class; this reports it instead of letting the collectors drop it silently.
- *
- * Producing the arguments, repeatability, and webonyx directive is {@see DirectiveResolver}'s job;
- * name uniqueness is checked in {@see DirectiveRegistry}.
+ * Validates a directive at discovery time ({@see self::validate()}, delegating target and
+ * interface/location checks) and its placement at apply time ({@see self::assertDirectivesUsableAt()}).
  *
  * @internal
  */
 final class DirectiveValidator
 {
-    /**
-     * @param class-string<TypeSystemDirective> $directiveClass
-     *
-     * @throws InvalidDirectiveException
-     */
+    /** @param class-string<TypeSystemDirective> $directiveClass */
     public static function validate(string $directiveClass, DirectiveDefinition $definition): void
     {
         $reflection = new ReflectionClass($directiveClass);
@@ -49,11 +34,7 @@ final class DirectiveValidator
         InterfaceLocationValidator::validate($directiveClass, $definition, $reflection);
     }
 
-    /**
-     * @param ReflectionClass<object> $refClass
-     *
-     * @throws InvalidDirectiveException when a directive on $refClass isn't allowed at $location.
-     */
+    /** @param ReflectionClass<object> $refClass */
     public static function assertDirectivesUsableAt(ReflectionClass $refClass, DirectiveLocation $location): void
     {
         foreach ($refClass->getAttributes() as $attribute) {

--- a/src/Directives/DirectiveValidator.php
+++ b/src/Directives/DirectiveValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Directives;
 
+use Attribute;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
 
@@ -11,15 +12,40 @@ use function in_array;
 use function is_a;
 
 /**
- * Validates that directives are applied where they're allowed. PHP's `#[Attribute]` targets can't
- * tell a `#[Type]` class from an `#[Input]` class (both are `TARGET_CLASS`), so a class-level
- * directive like `#[OneOf]` could be placed on the wrong kind of class. This reports that instead
- * of letting the interface-based collectors drop the misplaced directive silently.
+ * Validates directives at two points:
+ *
+ *   - {@see self::validate()} at discovery time: the `#[Attribute(...)]` PHP target covers every
+ *     declared GraphQL location, and each family interface has a matching location declared (and
+ *     vice versa).
+ *   - {@see self::assertDirectivesUsableAt()} at apply time: a directive placed on a class is
+ *     allowed at that class's location. PHP's `#[Attribute]` targets can't tell a `#[Type]` class
+ *     from an `#[Input]` class (both are `TARGET_CLASS`), so `#[OneOf]` could be placed on the wrong
+ *     kind of class; this reports it instead of letting the collectors drop it silently.
+ *
+ * Producing the arguments, repeatability, and webonyx directive is {@see DirectiveResolver}'s job;
+ * name uniqueness is checked in {@see DirectiveRegistry}.
  *
  * @internal
  */
 final class DirectiveValidator
 {
+    /**
+     * @param class-string<TypeSystemDirective> $directiveClass
+     *
+     * @throws InvalidDirectiveException
+     */
+    public static function validate(string $directiveClass, DirectiveDefinition $definition): void
+    {
+        $reflection = new ReflectionClass($directiveClass);
+
+        if ($reflection->getAttributes(Attribute::class) === []) {
+            throw InvalidDirectiveException::notAttribute($directiveClass);
+        }
+
+        self::checkPhpTargets($directiveClass, $definition, DirectiveReflection::attributeFlags($reflection));
+        self::checkInterfaceAndLocationAgreement($directiveClass, $definition, $reflection);
+    }
+
     /**
      * @param ReflectionClass<object> $refClass
      *
@@ -40,5 +66,63 @@ final class DirectiveValidator
 
             throw InvalidDirectiveException::notUsableAtLocation($directiveClass, $location, $locations);
         }
+    }
+
+    private static function checkPhpTargets(string $directiveClass, DirectiveDefinition $definition, int $phpFlags): void
+    {
+        foreach ($definition->locations as $location) {
+            foreach (self::requiredPhpTargetsFor($location) as $requiredTarget => $label) {
+                if (($phpFlags & $requiredTarget) === $requiredTarget) {
+                    continue;
+                }
+
+                throw InvalidDirectiveException::phpTargetMissingForLocation($directiveClass, $location, $label);
+            }
+        }
+    }
+
+    /** @param ReflectionClass<TypeSystemDirective> $reflection */
+    private static function checkInterfaceAndLocationAgreement(string $directiveClass, DirectiveDefinition $definition, ReflectionClass $reflection): void
+    {
+        $locations = $definition->locations;
+        $interfacePairs = [
+            FieldDirective::class => DirectiveLocation::FIELD_DEFINITION,
+            InputFieldDirective::class => DirectiveLocation::INPUT_FIELD_DEFINITION,
+            ObjectTypeDirective::class => DirectiveLocation::OBJECT,
+            InputObjectTypeDirective::class => DirectiveLocation::INPUT_OBJECT,
+        ];
+
+        foreach ($interfacePairs as $interface => $expectedLocation) {
+            $implements = $reflection->implementsInterface($interface);
+            $declaresLocation = in_array($expectedLocation, $locations, true);
+
+            if ($implements && ! $declaresLocation) {
+                throw InvalidDirectiveException::interfaceWithoutMatchingLocation($directiveClass, $interface, $locations);
+            }
+
+            if (! $implements && $declaresLocation) {
+                throw InvalidDirectiveException::locationWithoutMatchingInterface($directiveClass, $expectedLocation, $interface);
+            }
+        }
+    }
+
+    /** @return array<int, string> map of Attribute::TARGET_* flag → human-readable label */
+    private static function requiredPhpTargetsFor(DirectiveLocation $location): array
+    {
+        return match ($location) {
+            DirectiveLocation::FIELD_DEFINITION => [
+                Attribute::TARGET_METHOD => 'TARGET_METHOD',
+                Attribute::TARGET_PROPERTY => 'TARGET_PROPERTY',
+            ],
+            DirectiveLocation::INPUT_FIELD_DEFINITION => [
+                Attribute::TARGET_METHOD => 'TARGET_METHOD',
+                Attribute::TARGET_PROPERTY => 'TARGET_PROPERTY',
+                Attribute::TARGET_PARAMETER => 'TARGET_PARAMETER',
+            ],
+            DirectiveLocation::OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
+            DirectiveLocation::INPUT_OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
+            // Other locations don't have apply hooks yet, so there's nothing to enforce.
+            default => [],
+        };
     }
 }

--- a/src/Directives/DirectiveValidator.php
+++ b/src/Directives/DirectiveValidator.php
@@ -7,6 +7,8 @@ namespace TheCodingMachine\GraphQLite\Directives;
 use Attribute;
 use ReflectionClass;
 use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
+use TheCodingMachine\GraphQLite\Directives\Validation\AttributeTargetValidator;
+use TheCodingMachine\GraphQLite\Directives\Validation\InterfaceLocationValidator;
 
 use function in_array;
 use function is_a;
@@ -14,9 +16,10 @@ use function is_a;
 /**
  * Validates directives at two points:
  *
- *   - {@see self::validate()} at discovery time: the `#[Attribute(...)]` PHP target covers every
- *     declared GraphQL location, and each family interface has a matching location declared (and
- *     vice versa).
+ *   - {@see self::validate()} at discovery time, delegating to {@see AttributeTargetValidator} (the
+ *     `#[Attribute(...)]` PHP targets cover every declared GraphQL location) and
+ *     {@see InterfaceLocationValidator} (each family interface has a matching location, and vice
+ *     versa).
  *   - {@see self::assertDirectivesUsableAt()} at apply time: a directive placed on a class is
  *     allowed at that class's location. PHP's `#[Attribute]` targets can't tell a `#[Type]` class
  *     from an `#[Input]` class (both are `TARGET_CLASS`), so `#[OneOf]` could be placed on the wrong
@@ -42,8 +45,8 @@ final class DirectiveValidator
             throw InvalidDirectiveException::notAttribute($directiveClass);
         }
 
-        self::checkPhpTargets($directiveClass, $definition, DirectiveReflection::attributeFlags($reflection));
-        self::checkInterfaceAndLocationAgreement($directiveClass, $definition, $reflection);
+        AttributeTargetValidator::validate($directiveClass, $definition, DirectiveReflection::attributeFlags($reflection));
+        InterfaceLocationValidator::validate($directiveClass, $definition, $reflection);
     }
 
     /**
@@ -66,63 +69,5 @@ final class DirectiveValidator
 
             throw InvalidDirectiveException::notUsableAtLocation($directiveClass, $location, $locations);
         }
-    }
-
-    private static function checkPhpTargets(string $directiveClass, DirectiveDefinition $definition, int $phpFlags): void
-    {
-        foreach ($definition->locations as $location) {
-            foreach (self::requiredPhpTargetsFor($location) as $requiredTarget => $label) {
-                if (($phpFlags & $requiredTarget) === $requiredTarget) {
-                    continue;
-                }
-
-                throw InvalidDirectiveException::phpTargetMissingForLocation($directiveClass, $location, $label);
-            }
-        }
-    }
-
-    /** @param ReflectionClass<TypeSystemDirective> $reflection */
-    private static function checkInterfaceAndLocationAgreement(string $directiveClass, DirectiveDefinition $definition, ReflectionClass $reflection): void
-    {
-        $locations = $definition->locations;
-        $interfacePairs = [
-            FieldDirective::class => DirectiveLocation::FIELD_DEFINITION,
-            InputFieldDirective::class => DirectiveLocation::INPUT_FIELD_DEFINITION,
-            ObjectTypeDirective::class => DirectiveLocation::OBJECT,
-            InputObjectTypeDirective::class => DirectiveLocation::INPUT_OBJECT,
-        ];
-
-        foreach ($interfacePairs as $interface => $expectedLocation) {
-            $implements = $reflection->implementsInterface($interface);
-            $declaresLocation = in_array($expectedLocation, $locations, true);
-
-            if ($implements && ! $declaresLocation) {
-                throw InvalidDirectiveException::interfaceWithoutMatchingLocation($directiveClass, $interface, $locations);
-            }
-
-            if (! $implements && $declaresLocation) {
-                throw InvalidDirectiveException::locationWithoutMatchingInterface($directiveClass, $expectedLocation, $interface);
-            }
-        }
-    }
-
-    /** @return array<int, string> map of Attribute::TARGET_* flag → human-readable label */
-    private static function requiredPhpTargetsFor(DirectiveLocation $location): array
-    {
-        return match ($location) {
-            DirectiveLocation::FIELD_DEFINITION => [
-                Attribute::TARGET_METHOD => 'TARGET_METHOD',
-                Attribute::TARGET_PROPERTY => 'TARGET_PROPERTY',
-            ],
-            DirectiveLocation::INPUT_FIELD_DEFINITION => [
-                Attribute::TARGET_METHOD => 'TARGET_METHOD',
-                Attribute::TARGET_PROPERTY => 'TARGET_PROPERTY',
-                Attribute::TARGET_PARAMETER => 'TARGET_PARAMETER',
-            ],
-            DirectiveLocation::OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
-            DirectiveLocation::INPUT_OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
-            // Other locations don't have apply hooks yet, so there's nothing to enforce.
-            default => [],
-        };
     }
 }

--- a/src/Directives/Discovery/DirectiveClassFinder.php
+++ b/src/Directives/Discovery/DirectiveClassFinder.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives\Discovery;
+
+use ReflectionClass;
+use TheCodingMachine\GraphQLite\Directives\TypeSystemDirective;
+use TheCodingMachine\GraphQLite\Discovery\Cache\ClassFinderComputedCache;
+use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
+
+use function array_reduce;
+
+/**
+ * Finds the classes in the configured namespaces that implement {@see TypeSystemDirective}.
+ *
+ * Same pattern as {@see \TheCodingMachine\GraphQLite\Mappers\ClassFinderTypeMapper}: map each class
+ * from {@see ClassFinder} to a {@see GlobDirectivesCache} entry (or null), then collect the FQCNs.
+ * {@see ClassFinderComputedCache} handles cache invalidation in dev mode.
+ *
+ * @internal
+ */
+final class DirectiveClassFinder
+{
+    /** @var list<class-string<TypeSystemDirective>>|null */
+    private array|null $cache = null;
+
+    public function __construct(
+        private readonly ClassFinder $classFinder,
+        private readonly ClassFinderComputedCache $classFinderComputedCache,
+    ) {
+    }
+
+    /** @return list<class-string<TypeSystemDirective>> */
+    public function findDirectives(): array
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        /** @var list<class-string<TypeSystemDirective>> $result */
+        $result = $this->classFinderComputedCache->compute(
+            $this->classFinder,
+            'customDirectives',
+            static function (ReflectionClass $refClass): GlobDirectivesCache|null {
+                if ($refClass->isAbstract() || $refClass->isInterface() || $refClass->isEnum()) {
+                    return null;
+                }
+
+                if (! $refClass->implementsInterface(TypeSystemDirective::class)) {
+                    return null;
+                }
+
+                /** @var class-string<TypeSystemDirective> $directiveClass */
+                $directiveClass = $refClass->getName();
+                return new GlobDirectivesCache($directiveClass);
+            },
+            static fn (array $entries): array => array_reduce(
+                $entries,
+                static function (array $carry, GlobDirectivesCache|null $entry): array {
+                    if ($entry === null) {
+                        return $carry;
+                    }
+                    $carry[] = $entry->directiveClass;
+                    return $carry;
+                },
+                [],
+            ),
+        );
+
+        $this->cache = $result;
+        return $result;
+    }
+}

--- a/src/Directives/Discovery/DirectiveClassFinder.php
+++ b/src/Directives/Discovery/DirectiveClassFinder.php
@@ -12,11 +12,8 @@ use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
 use function array_reduce;
 
 /**
- * Finds the classes in the configured namespaces that implement {@see TypeSystemDirective}.
- *
- * Same pattern as {@see \TheCodingMachine\GraphQLite\Mappers\ClassFinderTypeMapper}: map each class
- * from {@see ClassFinder} to a {@see GlobDirectivesCache} entry (or null), then collect the FQCNs.
- * {@see ClassFinderComputedCache} handles cache invalidation in dev mode.
+ * Finds classes in the configured namespaces that implement {@see TypeSystemDirective}, cached the
+ * same way as {@see \TheCodingMachine\GraphQLite\Mappers\ClassFinderTypeMapper}.
  *
  * @internal
  */

--- a/src/Directives/Discovery/GlobDirectivesCache.php
+++ b/src/Directives/Discovery/GlobDirectivesCache.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives\Discovery;
+
+use TheCodingMachine\GraphQLite\Directives\TypeSystemDirective;
+
+/**
+ * Cache entry for one file scanned by {@see DirectiveClassFinder}, holding the FQCN of the directive
+ * class it found. Files with no directive class get no entry.
+ *
+ * @internal
+ */
+final class GlobDirectivesCache
+{
+    /** @param class-string<TypeSystemDirective> $directiveClass */
+    public function __construct(public readonly string $directiveClass)
+    {
+    }
+}

--- a/src/Directives/Discovery/GlobDirectivesCache.php
+++ b/src/Directives/Discovery/GlobDirectivesCache.php
@@ -7,8 +7,7 @@ namespace TheCodingMachine\GraphQLite\Directives\Discovery;
 use TheCodingMachine\GraphQLite\Directives\TypeSystemDirective;
 
 /**
- * Cache entry for one file scanned by {@see DirectiveClassFinder}, holding the FQCN of the directive
- * class it found. Files with no directive class get no entry.
+ * Cache entry for a directive class {@see DirectiveClassFinder} found.
  *
  * @internal
  */

--- a/src/Directives/Exceptions/InvalidDirectiveException.php
+++ b/src/Directives/Exceptions/InvalidDirectiveException.php
@@ -103,17 +103,9 @@ final class InvalidDirectiveException extends GraphQLRuntimeException
     public static function reservedName(string $name, string $directiveClass): self
     {
         return new self(sprintf(
-            'Directive "%s" declares the name "@%s" which is reserved for a webonyx built-in directive (@skip, @include, @deprecated). Pick a different name.',
+            'Directive "%s" declares the name "@%s", which is reserved for a built-in directive. Pick a different name, or set builtIn: true on its definition to intentionally override the built-in.',
             $directiveClass,
             $name,
-        ));
-    }
-
-    public static function noDefinitionMethod(string $directiveClass): self
-    {
-        return new self(sprintf(
-            'Directive "%s" implements DirectiveInterface but does not declare a static `definition(): DirectiveDefinition` method.',
-            $directiveClass,
         ));
     }
 }

--- a/src/Directives/Validation/AttributeTargetValidator.php
+++ b/src/Directives/Validation/AttributeTargetValidator.php
@@ -10,14 +10,12 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
 
 /**
- * Checks that a directive's `#[Attribute(...)]` PHP targets cover every GraphQL location it declares
- * (e.g. a FIELD_DEFINITION directive must allow both TARGET_METHOD and TARGET_PROPERTY).
+ * Checks a directive's `#[Attribute(...)]` targets cover every GraphQL location it declares.
  *
  * @internal
  */
 final class AttributeTargetValidator
 {
-    /** @throws InvalidDirectiveException */
     public static function validate(string $directiveClass, DirectiveDefinition $definition, int $phpFlags): void
     {
         foreach ($definition->locations as $location) {
@@ -31,7 +29,7 @@ final class AttributeTargetValidator
         }
     }
 
-    /** @return array<int, string> map of Attribute::TARGET_* flag → human-readable label */
+    /** @return array<int, string> required TARGET_* flag => label */
     private static function requiredPhpTargetsFor(DirectiveLocation $location): array
     {
         return match ($location) {
@@ -46,7 +44,7 @@ final class AttributeTargetValidator
             ],
             DirectiveLocation::OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
             DirectiveLocation::INPUT_OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
-            // Other locations don't have apply hooks yet, so there's nothing to enforce.
+            // No apply hooks for the other locations yet.
             default => [],
         };
     }

--- a/src/Directives/Validation/AttributeTargetValidator.php
+++ b/src/Directives/Validation/AttributeTargetValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives\Validation;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
+
+/**
+ * Checks that a directive's `#[Attribute(...)]` PHP targets cover every GraphQL location it declares
+ * (e.g. a FIELD_DEFINITION directive must allow both TARGET_METHOD and TARGET_PROPERTY).
+ *
+ * @internal
+ */
+final class AttributeTargetValidator
+{
+    /** @throws InvalidDirectiveException */
+    public static function validate(string $directiveClass, DirectiveDefinition $definition, int $phpFlags): void
+    {
+        foreach ($definition->locations as $location) {
+            foreach (self::requiredPhpTargetsFor($location) as $requiredTarget => $label) {
+                if (($phpFlags & $requiredTarget) === $requiredTarget) {
+                    continue;
+                }
+
+                throw InvalidDirectiveException::phpTargetMissingForLocation($directiveClass, $location, $label);
+            }
+        }
+    }
+
+    /** @return array<int, string> map of Attribute::TARGET_* flag → human-readable label */
+    private static function requiredPhpTargetsFor(DirectiveLocation $location): array
+    {
+        return match ($location) {
+            DirectiveLocation::FIELD_DEFINITION => [
+                Attribute::TARGET_METHOD => 'TARGET_METHOD',
+                Attribute::TARGET_PROPERTY => 'TARGET_PROPERTY',
+            ],
+            DirectiveLocation::INPUT_FIELD_DEFINITION => [
+                Attribute::TARGET_METHOD => 'TARGET_METHOD',
+                Attribute::TARGET_PROPERTY => 'TARGET_PROPERTY',
+                Attribute::TARGET_PARAMETER => 'TARGET_PARAMETER',
+            ],
+            DirectiveLocation::OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
+            DirectiveLocation::INPUT_OBJECT => [Attribute::TARGET_CLASS => 'TARGET_CLASS'],
+            // Other locations don't have apply hooks yet, so there's nothing to enforce.
+            default => [],
+        };
+    }
+}

--- a/src/Directives/Validation/InterfaceLocationValidator.php
+++ b/src/Directives/Validation/InterfaceLocationValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives\Validation;
+
+use ReflectionClass;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+use TheCodingMachine\GraphQLite\Directives\InputFieldDirective;
+use TheCodingMachine\GraphQLite\Directives\InputObjectTypeDirective;
+use TheCodingMachine\GraphQLite\Directives\ObjectTypeDirective;
+use TheCodingMachine\GraphQLite\Directives\TypeSystemDirective;
+
+use function in_array;
+
+/**
+ * Checks that a directive's family interfaces and its declared GraphQL locations agree: implementing
+ * FieldDirective requires the FIELD_DEFINITION location, and vice versa (same for the input-field,
+ * object and input-object families).
+ *
+ * @internal
+ */
+final class InterfaceLocationValidator
+{
+    /**
+     * @param ReflectionClass<TypeSystemDirective> $reflection
+     *
+     * @throws InvalidDirectiveException
+     */
+    public static function validate(string $directiveClass, DirectiveDefinition $definition, ReflectionClass $reflection): void
+    {
+        $locations = $definition->locations;
+        $interfacePairs = [
+            FieldDirective::class => DirectiveLocation::FIELD_DEFINITION,
+            InputFieldDirective::class => DirectiveLocation::INPUT_FIELD_DEFINITION,
+            ObjectTypeDirective::class => DirectiveLocation::OBJECT,
+            InputObjectTypeDirective::class => DirectiveLocation::INPUT_OBJECT,
+        ];
+
+        foreach ($interfacePairs as $interface => $expectedLocation) {
+            $implements = $reflection->implementsInterface($interface);
+            $declaresLocation = in_array($expectedLocation, $locations, true);
+
+            if ($implements && ! $declaresLocation) {
+                throw InvalidDirectiveException::interfaceWithoutMatchingLocation($directiveClass, $interface, $locations);
+            }
+
+            if (! $implements && $declaresLocation) {
+                throw InvalidDirectiveException::locationWithoutMatchingInterface($directiveClass, $expectedLocation, $interface);
+            }
+        }
+    }
+}

--- a/src/Directives/Validation/InterfaceLocationValidator.php
+++ b/src/Directives/Validation/InterfaceLocationValidator.php
@@ -17,19 +17,14 @@ use TheCodingMachine\GraphQLite\Directives\TypeSystemDirective;
 use function in_array;
 
 /**
- * Checks that a directive's family interfaces and its declared GraphQL locations agree: implementing
- * FieldDirective requires the FIELD_DEFINITION location, and vice versa (same for the input-field,
- * object and input-object families).
+ * Checks a directive's family interfaces and declared locations agree (FieldDirective and
+ * FIELD_DEFINITION imply each other, likewise for the input-field, object and input-object families).
  *
  * @internal
  */
 final class InterfaceLocationValidator
 {
-    /**
-     * @param ReflectionClass<TypeSystemDirective> $reflection
-     *
-     * @throws InvalidDirectiveException
-     */
+    /** @param ReflectionClass<TypeSystemDirective> $reflection */
     public static function validate(string $directiveClass, DirectiveDefinition $definition, ReflectionClass $reflection): void
     {
         $locations = $definition->locations;

--- a/src/SchemaFactory.php
+++ b/src/SchemaFactory.php
@@ -20,6 +20,7 @@ use TheCodingMachine\GraphQLite\Cache\FilesSnapshot;
 use TheCodingMachine\GraphQLite\Cache\SnapshotClassBoundCache;
 use TheCodingMachine\GraphQLite\Directives\DirectiveAstBuilder;
 use TheCodingMachine\GraphQLite\Directives\DirectiveRegistry;
+use TheCodingMachine\GraphQLite\Directives\Discovery\DirectiveClassFinder;
 use TheCodingMachine\GraphQLite\Discovery\Cache\HardClassFinderComputedCache;
 use TheCodingMachine\GraphQLite\Discovery\Cache\SnapshotClassFinderComputedCache;
 use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
@@ -408,7 +409,10 @@ class SchemaFactory
         $expressionLanguage = $this->expressionLanguage ?: new ExpressionLanguage($symfonyCache);
         $expressionLanguage->registerProvider(new SecurityExpressionLanguageProvider());
 
-        $directiveRegistry = new DirectiveRegistry($annotationReader);
+        $directiveRegistry = new DirectiveRegistry(
+            $annotationReader,
+            new DirectiveClassFinder($classFinder, $classFinderComputedCache),
+        );
         $directiveRegistry->discover();
 
         $directiveAstBuilder = new DirectiveAstBuilder($directiveRegistry);

--- a/tests/Directives/BuiltInDirectivesTest.php
+++ b/tests/Directives/BuiltInDirectivesTest.php
@@ -32,7 +32,7 @@ final class BuiltInDirectivesTest extends TestCase
         $registry = self::buildRegistry([]);
         $registry->discover();
 
-        // @oneOf is a webonyx built-in, so the registry shouldn't add it to the custom list.
+        // @oneOf is a webonyx built-in, not part of the custom list.
         $names = array_map(static fn (WebonyxDirective $d) => $d->name, $registry->webonyxDirectives());
 
         $this->assertSame([], $names);
@@ -50,8 +50,7 @@ final class BuiltInDirectivesTest extends TestCase
 
     public function testDiscoveryFindingTheBundledBuiltInClassIsIdempotent(): void
     {
-        // If discovery finds our own built-in class (same FQCN as BUILT_IN_ATTRIBUTES), registering
-        // it twice shouldn't throw.
+        // Discovery finding our own built-in shouldn't double-register.
         $registry = self::buildRegistry([OneOf::class]);
         $registry->discover();
 
@@ -60,7 +59,7 @@ final class BuiltInDirectivesTest extends TestCase
 
     public function testUserOverrideOfBuiltInWinsOverBundled(): void
     {
-        // User binds their own class to @oneOf (builtIn: true); ours should defer to it.
+        // User override wins over the bundled OneOf.
         $registry = self::buildRegistry([CustomOneOfOverride::class]);
         $registry->discover();
 

--- a/tests/Directives/BuiltInDirectivesTest.php
+++ b/tests/Directives/BuiltInDirectivesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives;
+
+use GraphQL\Type\Definition\Directive as WebonyxDirective;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use TheCodingMachine\GraphQLite\AnnotationReader;
+use TheCodingMachine\GraphQLite\Directives\BuiltIn\OneOf;
+use TheCodingMachine\GraphQLite\Directives\Discovery\DirectiveClassFinder;
+use TheCodingMachine\GraphQLite\Discovery\Cache\HardClassFinderComputedCache;
+use TheCodingMachine\GraphQLite\Discovery\StaticClassFinder;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\CustomOneOfOverride;
+
+use function array_map;
+
+final class BuiltInDirectivesTest extends TestCase
+{
+    public function testRegistryAlwaysRegistersBuiltInAttributesEvenWithEmptyClassFinder(): void
+    {
+        $registry = self::buildRegistry([]);
+        $registry->discover();
+
+        $this->assertNotNull($registry->definitionFor(OneOf::class));
+    }
+
+    public function testBuiltInDirectivesAreNotEmittedAsCustomDirectives(): void
+    {
+        $registry = self::buildRegistry([]);
+        $registry->discover();
+
+        // @oneOf is a webonyx built-in, so the registry shouldn't add it to the custom list.
+        $names = array_map(static fn (WebonyxDirective $d) => $d->name, $registry->webonyxDirectives());
+
+        $this->assertSame([], $names);
+        $this->assertFalse($registry->hasAny());
+    }
+
+    public function testOneOfDefinitionMarksItselfAsBuiltIn(): void
+    {
+        $definition = OneOf::definition();
+
+        $this->assertSame('oneOf', $definition->name);
+        $this->assertTrue($definition->builtIn);
+        $this->assertSame([DirectiveLocation::INPUT_OBJECT], $definition->locations);
+    }
+
+    public function testDiscoveryFindingTheBundledBuiltInClassIsIdempotent(): void
+    {
+        // If discovery finds our own built-in class (same FQCN as BUILT_IN_ATTRIBUTES), registering
+        // it twice shouldn't throw.
+        $registry = self::buildRegistry([OneOf::class]);
+        $registry->discover();
+
+        $this->assertNotNull($registry->definitionFor(OneOf::class));
+    }
+
+    public function testUserOverrideOfBuiltInWinsOverBundled(): void
+    {
+        // User binds their own class to @oneOf (builtIn: true); ours should defer to it.
+        $registry = self::buildRegistry([CustomOneOfOverride::class]);
+        $registry->discover();
+
+        $this->assertNotNull($registry->definitionFor(CustomOneOfOverride::class));
+        $this->assertNull($registry->definitionFor(OneOf::class));
+    }
+
+    /** @param list<class-string<TypeSystemDirective>> $classes */
+    private static function buildRegistry(array $classes): DirectiveRegistry
+    {
+        $finder = new DirectiveClassFinder(
+            new StaticClassFinder($classes),
+            new HardClassFinderComputedCache(new Psr16Cache(new ArrayAdapter())),
+        );
+
+        return new DirectiveRegistry(new AnnotationReader(), $finder);
+    }
+}

--- a/tests/Directives/DirectiveDefinitionTest.php
+++ b/tests/Directives/DirectiveDefinitionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives;
+
+use PHPUnit\Framework\TestCase;
+
+final class DirectiveDefinitionTest extends TestCase
+{
+    public function testStoresProvidedFields(): void
+    {
+        $definition = new DirectiveDefinition(
+            name: 'audit',
+            locations: [DirectiveLocation::FIELD_DEFINITION, DirectiveLocation::INPUT_FIELD_DEFINITION],
+            description: 'Audit log marker',
+        );
+
+        $this->assertSame('audit', $definition->name);
+        $this->assertSame([DirectiveLocation::FIELD_DEFINITION, DirectiveLocation::INPUT_FIELD_DEFINITION], $definition->locations);
+        $this->assertSame('Audit log marker', $definition->description);
+    }
+
+    public function testDefaultsDescriptionToNull(): void
+    {
+        $definition = new DirectiveDefinition(
+            name: 'noop',
+            locations: [DirectiveLocation::OBJECT],
+        );
+
+        $this->assertNull($definition->description);
+    }
+}

--- a/tests/Directives/DirectiveLocationTest.php
+++ b/tests/Directives/DirectiveLocationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives;
+
+use PHPUnit\Framework\TestCase;
+
+final class DirectiveLocationTest extends TestCase
+{
+    public function testEnumExposesAllNineteenSpecLocations(): void
+    {
+        $this->assertCount(19, DirectiveLocation::cases());
+    }
+
+    public function testBackingValuesMatchSpecStrings(): void
+    {
+        $this->assertSame('FIELD_DEFINITION', DirectiveLocation::FIELD_DEFINITION->value);
+        $this->assertSame('OBJECT', DirectiveLocation::OBJECT->value);
+        $this->assertSame('INPUT_OBJECT', DirectiveLocation::INPUT_OBJECT->value);
+        $this->assertSame('INPUT_FIELD_DEFINITION', DirectiveLocation::INPUT_FIELD_DEFINITION->value);
+    }
+
+    public function testIsExecutableClassifiesQueryDocumentLocations(): void
+    {
+        $this->assertTrue(DirectiveLocation::QUERY->isExecutable());
+        $this->assertTrue(DirectiveLocation::FIELD->isExecutable());
+        $this->assertTrue(DirectiveLocation::FRAGMENT_DEFINITION->isExecutable());
+        $this->assertTrue(DirectiveLocation::INLINE_FRAGMENT->isExecutable());
+        $this->assertTrue(DirectiveLocation::VARIABLE_DEFINITION->isExecutable());
+    }
+
+    public function testIsTypeSystemClassifiesSchemaLocations(): void
+    {
+        $this->assertTrue(DirectiveLocation::FIELD_DEFINITION->isTypeSystem());
+        $this->assertTrue(DirectiveLocation::OBJECT->isTypeSystem());
+        $this->assertTrue(DirectiveLocation::INPUT_OBJECT->isTypeSystem());
+        $this->assertTrue(DirectiveLocation::INPUT_FIELD_DEFINITION->isTypeSystem());
+        $this->assertTrue(DirectiveLocation::ENUM->isTypeSystem());
+        $this->assertTrue(DirectiveLocation::SCHEMA->isTypeSystem());
+    }
+
+    public function testIsExecutableAndIsTypeSystemArePartitions(): void
+    {
+        foreach (DirectiveLocation::cases() as $location) {
+            $this->assertNotSame($location->isExecutable(), $location->isTypeSystem(), 'Location ' . $location->value . ' should be executable or type-system, not both.');
+        }
+    }
+}

--- a/tests/Directives/DirectiveRegistryTest.php
+++ b/tests/Directives/DirectiveRegistryTest.php
@@ -37,8 +37,7 @@ final class DirectiveRegistryTest extends TestCase
 
     public function testBuiltInsAreNotAddedToTheSchemaDirectiveList(): void
     {
-        // webonyx already declares @oneOf and @deprecated, so the registry contributes nothing to
-        // SchemaConfig::$directives.
+        // webonyx already declares these, so the registry adds nothing to the schema.
         $registry = $this->registry();
 
         $this->assertSame([], $registry->webonyxDirectives());
@@ -112,7 +111,7 @@ final class DirectiveRegistryTest extends TestCase
 
     public function testRejectsCustomDirectiveUsingWebonyxReservedName(): void
     {
-        // @skip is a webonyx built-in GraphQLite doesn't bind, so it can't be claimed at all.
+        // @skip is a webonyx built-in we don't bind.
         $registry = self::buildRegistry([WebonyxReservedNameDirective::class]);
 
         $this->expectException(InvalidDirectiveException::class);
@@ -132,8 +131,7 @@ final class DirectiveRegistryTest extends TestCase
 
     public function testWebonyxDirectivesIsolatedFromBuiltins(): void
     {
-        // The built directives shouldn't include webonyx's built-ins; those get merged in at the
-        // Schema layer, not here.
+        // Built-ins merge in at the Schema layer, not here.
         $registry = self::buildRegistry([InternalFieldDirective::class]);
         $registry->discover();
 

--- a/tests/Directives/DirectiveRegistryTest.php
+++ b/tests/Directives/DirectiveRegistryTest.php
@@ -4,24 +4,28 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\GraphQLite\Directives;
 
+use GraphQL\Type\Definition\Directive as WebonyxDirective;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 use TheCodingMachine\GraphQLite\AnnotationReader;
 use TheCodingMachine\GraphQLite\Directives\BuiltIn\Deprecated;
 use TheCodingMachine\GraphQLite\Directives\BuiltIn\OneOf;
+use TheCodingMachine\GraphQLite\Directives\Discovery\DirectiveClassFinder;
 use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
+use TheCodingMachine\GraphQLite\Discovery\Cache\HardClassFinderComputedCache;
+use TheCodingMachine\GraphQLite\Discovery\StaticClassFinder;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\InternalFieldDirective;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid\ReservedNameDirective;
 use TheCodingMachine\GraphQLite\Fixtures\Directives\MisusedOneOfOnType;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\NoteFieldDirective;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\RevisionInputObjectDirective;
+
+use function array_map;
 
 final class DirectiveRegistryTest extends TestCase
 {
-    private function registry(): DirectiveRegistry
-    {
-        $registry = new DirectiveRegistry(new AnnotationReader());
-        $registry->discover();
-
-        return $registry;
-    }
-
     public function testRegistersTheBuiltInDirectives(): void
     {
         $registry = $this->registry();
@@ -50,7 +54,7 @@ final class DirectiveRegistryTest extends TestCase
 
     public function testDiscoverIsIdempotent(): void
     {
-        $registry = new DirectiveRegistry(new AnnotationReader());
+        $registry = self::buildRegistry();
         $registry->discover();
         $registry->discover();
 
@@ -63,5 +67,87 @@ final class DirectiveRegistryTest extends TestCase
         $this->expectExceptionMessageMatches('/cannot be used on OBJECT/');
 
         $this->registry()->objectTypeDirectives(new ReflectionClass(MisusedOneOfOnType::class));
+    }
+
+    public function testDiscoversAndRegistersValidDirectives(): void
+    {
+        $registry = self::buildRegistry([
+            InternalFieldDirective::class,
+            NoteFieldDirective::class,
+            RevisionInputObjectDirective::class,
+        ]);
+        $registry->discover();
+
+        $this->assertTrue($registry->hasAny());
+
+        $webonyx = $registry->webonyxDirectives();
+        $this->assertCount(3, $webonyx);
+
+        $byName = [];
+        foreach ($webonyx as $directive) {
+            $byName[$directive->name] = $directive;
+        }
+
+        $this->assertArrayHasKey('internal', $byName);
+        $this->assertArrayHasKey('note', $byName);
+        $this->assertArrayHasKey('revision', $byName);
+
+        $note = $byName['note'];
+        $this->assertTrue($note->isRepeatable);
+        $this->assertSame('Attaches a freeform note to a field.', $note->description);
+        $this->assertCount(1, $note->args);
+        $this->assertSame('text', $note->args[0]->name);
+    }
+
+    public function testRejectsCustomDirectiveUsingReservedName(): void
+    {
+        $registry = self::buildRegistry([ReservedNameDirective::class]);
+
+        $this->expectException(InvalidDirectiveException::class);
+        $this->expectExceptionMessageMatches('/reserved/');
+
+        $registry->discover();
+    }
+
+    public function testEmptyRegistryReportsNoDirectives(): void
+    {
+        $registry = self::buildRegistry([]);
+        $registry->discover();
+
+        $this->assertFalse($registry->hasAny());
+        $this->assertSame([], $registry->webonyxDirectives());
+    }
+
+    public function testWebonyxDirectivesIsolatedFromBuiltins(): void
+    {
+        // The built directives shouldn't include webonyx's built-ins; those get merged in at the
+        // Schema layer, not here.
+        $registry = self::buildRegistry([InternalFieldDirective::class]);
+        $registry->discover();
+
+        $names = array_map(static fn (WebonyxDirective $d) => $d->name, $registry->webonyxDirectives());
+        $this->assertNotContains('skip', $names);
+        $this->assertNotContains('include', $names);
+        $this->assertNotContains('deprecated', $names);
+        $this->assertNotContains('oneOf', $names);
+    }
+
+    private function registry(): DirectiveRegistry
+    {
+        $registry = self::buildRegistry();
+        $registry->discover();
+
+        return $registry;
+    }
+
+    /** @param list<class-string<TypeSystemDirective>> $classes */
+    private static function buildRegistry(array $classes = []): DirectiveRegistry
+    {
+        $finder = new DirectiveClassFinder(
+            new StaticClassFinder($classes),
+            new HardClassFinderComputedCache(new Psr16Cache(new ArrayAdapter())),
+        );
+
+        return new DirectiveRegistry(new AnnotationReader(), $finder);
     }
 }

--- a/tests/Directives/DirectiveRegistryTest.php
+++ b/tests/Directives/DirectiveRegistryTest.php
@@ -18,6 +18,7 @@ use TheCodingMachine\GraphQLite\Discovery\Cache\HardClassFinderComputedCache;
 use TheCodingMachine\GraphQLite\Discovery\StaticClassFinder;
 use TheCodingMachine\GraphQLite\Fixtures\Directives\InternalFieldDirective;
 use TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid\ReservedNameDirective;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid\WebonyxReservedNameDirective;
 use TheCodingMachine\GraphQLite\Fixtures\Directives\MisusedOneOfOnType;
 use TheCodingMachine\GraphQLite\Fixtures\Directives\NoteFieldDirective;
 use TheCodingMachine\GraphQLite\Fixtures\Directives\RevisionInputObjectDirective;
@@ -102,6 +103,17 @@ final class DirectiveRegistryTest extends TestCase
     public function testRejectsCustomDirectiveUsingReservedName(): void
     {
         $registry = self::buildRegistry([ReservedNameDirective::class]);
+
+        $this->expectException(InvalidDirectiveException::class);
+        $this->expectExceptionMessageMatches('/reserved/');
+
+        $registry->discover();
+    }
+
+    public function testRejectsCustomDirectiveUsingWebonyxReservedName(): void
+    {
+        // @skip is a webonyx built-in GraphQLite doesn't bind, so it can't be claimed at all.
+        $registry = self::buildRegistry([WebonyxReservedNameDirective::class]);
 
         $this->expectException(InvalidDirectiveException::class);
         $this->expectExceptionMessageMatches('/reserved/');

--- a/tests/Directives/DirectiveResolverTest.php
+++ b/tests/Directives/DirectiveResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives;
+
+use GraphQL\Type\Definition\Directive as WebonyxDirective;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\StringType;
+use PHPUnit\Framework\TestCase;
+use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\InternalFieldDirective;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid\UnsupportedArgumentTypeDirective;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\NoteFieldDirective;
+
+final class DirectiveResolverTest extends TestCase
+{
+    public function testResolvesNoArgsToEmptyList(): void
+    {
+        $resolved = DirectiveResolver::resolve(InternalFieldDirective::class, InternalFieldDirective::definition());
+
+        $this->assertSame([], $resolved->arguments);
+    }
+
+    public function testResolvesScalarArgumentWithCorrectTypeAndNullability(): void
+    {
+        $resolved = DirectiveResolver::resolve(NoteFieldDirective::class, NoteFieldDirective::definition());
+
+        $this->assertCount(1, $resolved->arguments);
+        $this->assertSame('text', $resolved->arguments[0]->name);
+        $this->assertInstanceOf(NonNull::class, $resolved->arguments[0]->type);
+        $this->assertInstanceOf(StringType::class, $resolved->arguments[0]->type->getWrappedType());
+        $this->assertFalse($resolved->arguments[0]->hasDefaultValue);
+    }
+
+    public function testInfersRepeatableFromAttributeFlags(): void
+    {
+        $note = DirectiveResolver::resolve(NoteFieldDirective::class, NoteFieldDirective::definition())->webonyxDirective;
+        $internal = DirectiveResolver::resolve(InternalFieldDirective::class, InternalFieldDirective::definition())->webonyxDirective;
+
+        $this->assertInstanceOf(WebonyxDirective::class, $note);
+        $this->assertTrue($note->isRepeatable);
+
+        $this->assertInstanceOf(WebonyxDirective::class, $internal);
+        $this->assertFalse($internal->isRepeatable);
+    }
+
+    public function testRejectsUnsupportedArgumentType(): void
+    {
+        $this->expectException(InvalidDirectiveException::class);
+        $this->expectExceptionMessageMatches('/scalar types/');
+
+        DirectiveResolver::resolve(UnsupportedArgumentTypeDirective::class, UnsupportedArgumentTypeDirective::definition());
+    }
+}

--- a/tests/Directives/DirectiveValidatorTest.php
+++ b/tests/Directives/DirectiveValidatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Directives;
+
+use PHPUnit\Framework\TestCase;
+use TheCodingMachine\GraphQLite\Directives\Exceptions\InvalidDirectiveException;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid\InterfaceWithoutLocationDirective;
+use TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid\MissingPhpTargetDirective;
+
+final class DirectiveValidatorTest extends TestCase
+{
+    public function testRejectsDirectiveMissingRequiredPhpTarget(): void
+    {
+        $this->expectException(InvalidDirectiveException::class);
+        $this->expectExceptionMessageMatches('/TARGET_METHOD/');
+
+        DirectiveValidator::validate(MissingPhpTargetDirective::class, MissingPhpTargetDirective::definition());
+    }
+
+    public function testRejectsInterfaceWithoutMatchingLocation(): void
+    {
+        $this->expectException(InvalidDirectiveException::class);
+        $this->expectExceptionMessageMatches('/FieldDirective/');
+
+        DirectiveValidator::validate(InterfaceWithoutLocationDirective::class, InterfaceWithoutLocationDirective::definition());
+    }
+}

--- a/tests/Fixtures/Directives/CustomOneOfOverride.php
+++ b/tests/Fixtures/Directives/CustomOneOfOverride.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\BehavioralInputObjectTypeDirective;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\InputObjectTypeDescriptor;
+use TheCodingMachine\GraphQLite\Middlewares\InputObjectTypeHandlerInterface;
+use TheCodingMachine\GraphQLite\Types\MutableInputObjectType;
+
+/**
+ * Stands in for a user-supplied replacement of the bundled `OneOf`. Same `@oneOf` name, marked
+ * `builtIn: true`, so the registry uses it instead of ours.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class CustomOneOfOverride implements BehavioralInputObjectTypeDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'oneOf',
+            locations: [DirectiveLocation::INPUT_OBJECT],
+            builtIn: true,
+        );
+    }
+
+    public function applyToInputObjectType(InputObjectTypeDescriptor $descriptor, InputObjectTypeHandlerInterface $next): MutableInputObjectType
+    {
+        $type = $next->handle($descriptor);
+        $type->isOneOf = true;
+        return $type;
+    }
+}

--- a/tests/Fixtures/Directives/CustomOneOfOverride.php
+++ b/tests/Fixtures/Directives/CustomOneOfOverride.php
@@ -12,10 +12,7 @@ use TheCodingMachine\GraphQLite\InputObjectTypeDescriptor;
 use TheCodingMachine\GraphQLite\Middlewares\InputObjectTypeHandlerInterface;
 use TheCodingMachine\GraphQLite\Types\MutableInputObjectType;
 
-/**
- * Stands in for a user-supplied replacement of the bundled `OneOf`. Same `@oneOf` name, marked
- * `builtIn: true`, so the registry uses it instead of ours.
- */
+/** User replacement for the bundled `OneOf` (`@oneOf`, `builtIn: true`). */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class CustomOneOfOverride implements BehavioralInputObjectTypeDirective
 {

--- a/tests/Fixtures/Directives/InternalFieldDirective.php
+++ b/tests/Fixtures/Directives/InternalFieldDirective.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+
+/**
+ * A no-argument marker field directive. Unit specimen for the "no args, not repeatable" resolver
+ * path; deliberately not behavioral (nothing invokes it, we only resolve it).
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
+final class InternalFieldDirective implements FieldDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'internal',
+            locations: [DirectiveLocation::FIELD_DEFINITION],
+        );
+    }
+}

--- a/tests/Fixtures/Directives/InternalFieldDirective.php
+++ b/tests/Fixtures/Directives/InternalFieldDirective.php
@@ -9,10 +9,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\FieldDirective;
 
-/**
- * A no-argument marker field directive. Unit specimen for the "no args, not repeatable" resolver
- * path; deliberately not behavioral (nothing invokes it, we only resolve it).
- */
+/** No-arg, non-repeatable marker; specimen for the no-args resolver path. */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
 final class InternalFieldDirective implements FieldDirective
 {

--- a/tests/Fixtures/Directives/Invalid/InterfaceWithoutLocationDirective.php
+++ b/tests/Fixtures/Directives/Invalid/InterfaceWithoutLocationDirective.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+
+/**
+ * Implements FieldDirective but declares no FIELD_DEFINITION location, so the validator's
+ * interface/location check rejects it. Empty locations keeps the PHP-target check from firing first.
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
+final class InterfaceWithoutLocationDirective implements FieldDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'noLocation',
+            locations: [],
+        );
+    }
+}

--- a/tests/Fixtures/Directives/Invalid/InterfaceWithoutLocationDirective.php
+++ b/tests/Fixtures/Directives/Invalid/InterfaceWithoutLocationDirective.php
@@ -8,10 +8,7 @@ use Attribute;
 use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\FieldDirective;
 
-/**
- * Implements FieldDirective but declares no FIELD_DEFINITION location, so the validator's
- * interface/location check rejects it. Empty locations keeps the PHP-target check from firing first.
- */
+/** FieldDirective with no FIELD_DEFINITION location; rejected by the interface/location check. */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
 final class InterfaceWithoutLocationDirective implements FieldDirective
 {

--- a/tests/Fixtures/Directives/Invalid/MissingPhpTargetDirective.php
+++ b/tests/Fixtures/Directives/Invalid/MissingPhpTargetDirective.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+
+/**
+ * Declares FIELD_DEFINITION but the PHP target is TARGET_CLASS only, so the validator rejects it:
+ * the PHP target has to cover the GraphQL locations.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class MissingPhpTargetDirective implements FieldDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'badTarget',
+            locations: [DirectiveLocation::FIELD_DEFINITION],
+        );
+    }
+}

--- a/tests/Fixtures/Directives/Invalid/MissingPhpTargetDirective.php
+++ b/tests/Fixtures/Directives/Invalid/MissingPhpTargetDirective.php
@@ -9,10 +9,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\FieldDirective;
 
-/**
- * Declares FIELD_DEFINITION but the PHP target is TARGET_CLASS only, so the validator rejects it:
- * the PHP target has to cover the GraphQL locations.
- */
+/** FIELD_DEFINITION with a TARGET_CLASS-only attribute; rejected by the target check. */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class MissingPhpTargetDirective implements FieldDirective
 {

--- a/tests/Fixtures/Directives/Invalid/ReservedNameDirective.php
+++ b/tests/Fixtures/Directives/Invalid/ReservedNameDirective.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\InputObjectTypeDirective;
+
+/**
+ * Reuses webonyx's built-in `@oneOf` name, so the registry's reserved-name check rejects it.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class ReservedNameDirective implements InputObjectTypeDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'oneOf',
+            locations: [DirectiveLocation::INPUT_OBJECT],
+        );
+    }
+}

--- a/tests/Fixtures/Directives/Invalid/ReservedNameDirective.php
+++ b/tests/Fixtures/Directives/Invalid/ReservedNameDirective.php
@@ -9,9 +9,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\InputObjectTypeDirective;
 
-/**
- * Reuses webonyx's built-in `@oneOf` name, so the registry's reserved-name check rejects it.
- */
+/** Reuses `@oneOf`; rejected by the reserved-name check. */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class ReservedNameDirective implements InputObjectTypeDirective
 {

--- a/tests/Fixtures/Directives/Invalid/UnsupportedArgumentTypeDirective.php
+++ b/tests/Fixtures/Directives/Invalid/UnsupportedArgumentTypeDirective.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid;
+
+use Attribute;
+use stdClass;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+
+/**
+ * Constructor parameter is a non-scalar object, which the validator rejects (args must map to a
+ * scalar).
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
+final class UnsupportedArgumentTypeDirective implements FieldDirective
+{
+    public function __construct(public readonly stdClass $thing)
+    {
+    }
+
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'unsupportedArg',
+            locations: [DirectiveLocation::FIELD_DEFINITION],
+        );
+    }
+}

--- a/tests/Fixtures/Directives/Invalid/UnsupportedArgumentTypeDirective.php
+++ b/tests/Fixtures/Directives/Invalid/UnsupportedArgumentTypeDirective.php
@@ -10,10 +10,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\FieldDirective;
 
-/**
- * Constructor parameter is a non-scalar object, which the validator rejects (args must map to a
- * scalar).
- */
+/** Non-scalar constructor arg; rejected by the resolver. */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
 final class UnsupportedArgumentTypeDirective implements FieldDirective
 {

--- a/tests/Fixtures/Directives/Invalid/WebonyxReservedNameDirective.php
+++ b/tests/Fixtures/Directives/Invalid/WebonyxReservedNameDirective.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives\Invalid;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+
+/**
+ * A well-formed field directive that claims webonyx's `@skip` name, so the registry's reserved-name
+ * check rejects it even though it passes validation.
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
+final class WebonyxReservedNameDirective implements FieldDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'skip',
+            locations: [DirectiveLocation::FIELD_DEFINITION],
+        );
+    }
+}

--- a/tests/Fixtures/Directives/Invalid/WebonyxReservedNameDirective.php
+++ b/tests/Fixtures/Directives/Invalid/WebonyxReservedNameDirective.php
@@ -9,10 +9,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\FieldDirective;
 
-/**
- * A well-formed field directive that claims webonyx's `@skip` name, so the registry's reserved-name
- * check rejects it even though it passes validation.
- */
+/** Well-formed but claims webonyx's `@skip` name; rejected by the reserved-name check. */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
 final class WebonyxReservedNameDirective implements FieldDirective
 {

--- a/tests/Fixtures/Directives/NoteFieldDirective.php
+++ b/tests/Fixtures/Directives/NoteFieldDirective.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+
+/**
+ * A repeatable field directive carrying a single required scalar argument. Unit specimen for the
+ * resolver's argument encoding and repeatable inference.
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+final class NoteFieldDirective implements FieldDirective
+{
+    public function __construct(public readonly string $text)
+    {
+    }
+
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'note',
+            locations: [DirectiveLocation::FIELD_DEFINITION],
+            description: 'Attaches a freeform note to a field.',
+        );
+    }
+}

--- a/tests/Fixtures/Directives/NoteFieldDirective.php
+++ b/tests/Fixtures/Directives/NoteFieldDirective.php
@@ -9,10 +9,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\FieldDirective;
 
-/**
- * A repeatable field directive carrying a single required scalar argument. Unit specimen for the
- * resolver's argument encoding and repeatable inference.
- */
+/** Repeatable field directive with one required scalar arg; resolver specimen. */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class NoteFieldDirective implements FieldDirective
 {

--- a/tests/Fixtures/Directives/RevisionInputObjectDirective.php
+++ b/tests/Fixtures/Directives/RevisionInputObjectDirective.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\InputObjectTypeDirective;
+
+/**
+ * A custom input-object directive with a constructor argument. Metadata only (no apply method),
+ * used to exercise the `INPUT_OBJECT` path: definition, argument encoding, and SDL output.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class RevisionInputObjectDirective implements InputObjectTypeDirective
+{
+    public function __construct(public readonly int $number)
+    {
+    }
+
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'revision',
+            locations: [DirectiveLocation::INPUT_OBJECT],
+        );
+    }
+}

--- a/tests/Fixtures/Directives/RevisionInputObjectDirective.php
+++ b/tests/Fixtures/Directives/RevisionInputObjectDirective.php
@@ -9,10 +9,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\InputObjectTypeDirective;
 
-/**
- * A custom input-object directive with a constructor argument. Metadata only (no apply method),
- * used to exercise the `INPUT_OBJECT` path: definition, argument encoding, and SDL output.
- */
+/** Input-object directive with one arg; specimen for the `INPUT_OBJECT` path. */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class RevisionInputObjectDirective implements InputObjectTypeDirective
 {

--- a/tests/Fixtures/DirectivesIntegration/Controllers/WidgetController.php
+++ b/tests/Fixtures/DirectivesIntegration/Controllers/WidgetController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Controllers;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives\UppercaseDirective;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Inputs\OneOfLookup;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Inputs\WidgetLookup;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Models\Widget;
+
+final class WidgetController
+{
+    #[Query]
+    #[UppercaseDirective]
+    public function tagline(): string
+    {
+        return 'hello world';
+    }
+
+    #[Query]
+    public function findWidget(WidgetLookup $lookup): Widget
+    {
+        return new Widget($lookup->sku ?? 'id-' . ($lookup->id ?? 0));
+    }
+
+    #[Query]
+    public function findOneOf(OneOfLookup $lookup): Widget
+    {
+        return new Widget($lookup->sku ?? 'id-' . ($lookup->id ?? 0));
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Directives/AuditDirective.php
+++ b/tests/Fixtures/DirectivesIntegration/Directives/AuditDirective.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\FieldDirective;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+final class AuditDirective implements FieldDirective
+{
+    public function __construct(public readonly string $reason)
+    {
+    }
+
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'audit',
+            locations: [DirectiveLocation::FIELD_DEFINITION],
+            description: 'Marks a field for audit-log tracking.',
+        );
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Directives/SanitizedDirective.php
+++ b/tests/Fixtures/DirectivesIntegration/Directives/SanitizedDirective.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\InputFieldDirective;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+final class SanitizedDirective implements InputFieldDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'sanitized',
+            locations: [DirectiveLocation::INPUT_FIELD_DEFINITION],
+        );
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Directives/TaggedDirective.php
+++ b/tests/Fixtures/DirectivesIntegration/Directives/TaggedDirective.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\ObjectTypeDirective;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class TaggedDirective implements ObjectTypeDirective
+{
+    public function __construct(public readonly string $name)
+    {
+    }
+
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'tagged',
+            locations: [DirectiveLocation::OBJECT],
+        );
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Directives/UppercaseDirective.php
+++ b/tests/Fixtures/DirectivesIntegration/Directives/UppercaseDirective.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives;
+
+use Attribute;
+use GraphQL\Type\Definition\FieldDefinition;
+use TheCodingMachine\GraphQLite\Directives\BehavioralFieldDirective;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Middlewares\FieldHandlerInterface;
+use TheCodingMachine\GraphQLite\QueryFieldDescriptor;
+
+use function is_string;
+use function strtoupper;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
+final class UppercaseDirective implements BehavioralFieldDirective
+{
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'uppercase',
+            locations: [DirectiveLocation::FIELD_DEFINITION],
+        );
+    }
+
+    public function applyToField(QueryFieldDescriptor $descriptor, FieldHandlerInterface $next): FieldDefinition|null
+    {
+        $resolver = $descriptor->getResolver();
+        $descriptor = $descriptor->withResolver(static function (...$args) use ($resolver): mixed {
+            $value = $resolver(...$args);
+            return is_string($value) ? strtoupper($value) : $value;
+        });
+
+        return $next->handle($descriptor);
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Directives/VersionedDirective.php
+++ b/tests/Fixtures/DirectivesIntegration/Directives/VersionedDirective.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives;
+
+use Attribute;
+use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
+use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
+use TheCodingMachine\GraphQLite\Directives\InputObjectTypeDirective;
+
+/**
+ * Marks an input object with a schema version. A custom input-object directive used in the
+ * integration test to check the custom path runs alongside the bundled `#[OneOf]`.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class VersionedDirective implements InputObjectTypeDirective
+{
+    public function __construct(public readonly int $version)
+    {
+    }
+
+    public static function definition(): DirectiveDefinition
+    {
+        return new DirectiveDefinition(
+            name: 'versioned',
+            locations: [DirectiveLocation::INPUT_OBJECT],
+            description: 'Marks an input with a schema version for backwards-compat tracking.',
+        );
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Directives/VersionedDirective.php
+++ b/tests/Fixtures/DirectivesIntegration/Directives/VersionedDirective.php
@@ -9,10 +9,7 @@ use TheCodingMachine\GraphQLite\Directives\DirectiveDefinition;
 use TheCodingMachine\GraphQLite\Directives\DirectiveLocation;
 use TheCodingMachine\GraphQLite\Directives\InputObjectTypeDirective;
 
-/**
- * Marks an input object with a schema version. A custom input-object directive used in the
- * integration test to check the custom path runs alongside the bundled `#[OneOf]`.
- */
+/** Input-object directive tagging a schema version; runs alongside the bundled `#[OneOf]`. */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class VersionedDirective implements InputObjectTypeDirective
 {

--- a/tests/Fixtures/DirectivesIntegration/Inputs/OneOfLookup.php
+++ b/tests/Fixtures/DirectivesIntegration/Inputs/OneOfLookup.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Inputs;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Input;
+use TheCodingMachine\GraphQLite\Directives\BuiltIn\OneOf;
+
+/**
+ * Uses the built-in `@oneOf` directive, which sets webonyx's `isOneOf` flag so callers pass either
+ * `sku` or `id`, not both.
+ */
+#[Input]
+#[OneOf]
+final class OneOfLookup
+{
+    public function __construct(
+        #[Field]
+        public string|null $sku = null,
+        #[Field]
+        public int|null $id = null,
+    ) {
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Inputs/OneOfLookup.php
+++ b/tests/Fixtures/DirectivesIntegration/Inputs/OneOfLookup.php
@@ -8,10 +8,7 @@ use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\Input;
 use TheCodingMachine\GraphQLite\Directives\BuiltIn\OneOf;
 
-/**
- * Uses the built-in `@oneOf` directive, which sets webonyx's `isOneOf` flag so callers pass either
- * `sku` or `id`, not both.
- */
+/** Uses `@oneOf` so callers pass either `sku` or `id`, not both. */
 #[Input]
 #[OneOf]
 final class OneOfLookup

--- a/tests/Fixtures/DirectivesIntegration/Inputs/WidgetLookup.php
+++ b/tests/Fixtures/DirectivesIntegration/Inputs/WidgetLookup.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Inputs;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Input;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives\SanitizedDirective;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives\VersionedDirective;
+
+#[Input]
+#[VersionedDirective(version: 2)]
+final class WidgetLookup
+{
+    public function __construct(
+        #[Field]
+        #[SanitizedDirective]
+        public string|null $sku = null,
+        #[Field]
+        public int|null $id = null,
+    ) {
+    }
+}

--- a/tests/Fixtures/DirectivesIntegration/Models/Widget.php
+++ b/tests/Fixtures/DirectivesIntegration/Models/Widget.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Models;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives\AuditDirective;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives\TaggedDirective;
+use TheCodingMachine\GraphQLite\Fixtures\DirectivesIntegration\Directives\UppercaseDirective;
+
+#[Type]
+#[TaggedDirective(name: 'primary')]
+final class Widget
+{
+    public function __construct(public string $label)
+    {
+    }
+
+    #[Field]
+    #[UppercaseDirective]
+    #[AuditDirective(reason: 'pii')]
+    #[AuditDirective(reason: 'compliance')]
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+}

--- a/tests/Integration/DirectivesEndToEndTest.php
+++ b/tests/Integration/DirectivesEndToEndTest.php
@@ -24,13 +24,9 @@ use function count;
 use function is_array;
 
 /**
- * End-to-end test for custom directives. Builds a schema from the
- * `tests/Fixtures/DirectivesIntegration` namespaces and checks that directive definitions show up
- * in SDL and introspection, and that behavioral directives wrap their resolver at runtime.
- *
- * We don't assert directive applications in SDL (e.g. `tagline: String! @uppercase`): webonyx's
- * SchemaPrinter doesn't render those, and we follow its behavior. The applications are still on each
- * element's `astNode->directives` for anyone who wants to print them with their own printer.
+ * End-to-end custom directives: builds a schema from the `DirectivesIntegration` fixtures and checks
+ * definitions (SDL/introspection), runtime behavior, and applications on each element's AST node.
+ * webonyx's SchemaPrinter doesn't render applications, so those are checked via `astNode->directives`.
  */
 final class DirectivesEndToEndTest extends TestCase
 {
@@ -49,8 +45,6 @@ final class DirectivesEndToEndTest extends TestCase
         $schema = $this->buildSchema();
         $sdl = SchemaPrinter::doPrint($schema);
 
-        // Definitions: the webonyx printer emits these once the directives are registered on the
-        // schema (see SchemaFactory's wiring of DirectiveRegistry::webonyxDirectives()).
         $this->assertStringContainsString('directive @uppercase on FIELD_DEFINITION', $sdl);
         $this->assertStringContainsString('Marks a field for audit-log tracking.', $sdl);
         $this->assertStringContainsString('directive @audit(reason: String!) repeatable on FIELD_DEFINITION', $sdl);
@@ -59,11 +53,7 @@ final class DirectivesEndToEndTest extends TestCase
         $this->assertStringContainsString('Marks an input with a schema version for backwards-compat tracking.', $sdl);
         $this->assertStringContainsString('directive @versioned(version: Int!) on INPUT_OBJECT', $sdl);
 
-        // No assertions on directive applications here; webonyx's SchemaPrinter doesn't render them.
-        // See the class docblock.
-
-        // @oneOf is webonyx's built-in: it prints the application from the isOneOf flag, and we
-        // don't re-declare it in the custom list.
+        // @oneOf is webonyx's: printed from the isOneOf flag, not re-declared in the custom list.
         $this->assertStringNotContainsString('directive @oneOf ', $sdl);
         $this->assertStringContainsString('input OneOfLookupInput @oneOf', $sdl);
     }
@@ -83,12 +73,11 @@ final class DirectivesEndToEndTest extends TestCase
             $names[] = $directive['name'];
         }
 
-        // Built-ins remain present alongside custom directives.
+        // Built-ins present alongside custom directives.
         $this->assertContains('skip', $names);
         $this->assertContains('include', $names);
         $this->assertContains('deprecated', $names);
 
-        // Custom directives present.
         $this->assertContains('uppercase', $names);
         $this->assertContains('audit', $names);
         $this->assertContains('tagged', $names);
@@ -115,7 +104,7 @@ final class DirectivesEndToEndTest extends TestCase
         )->toArray();
 
         $this->assertArrayNotHasKey('errors', $result);
-        // getLabel() carries @uppercase, so "abc" comes back uppercased.
+        // getLabel() carries @uppercase.
         $this->assertSame('ABC', $result['data']['findWidget']['label']);
     }
 
@@ -145,8 +134,7 @@ final class DirectivesEndToEndTest extends TestCase
             $names[] = $directive->name->value;
         }
 
-        // getLabel() carries @uppercase once and the repeatable @audit twice; every application
-        // survives onto the field's AST node.
+        // @uppercase once, repeatable @audit twice.
         $this->assertContains('uppercase', $names);
         $this->assertSame(2, count(array_filter($names, static fn (string $name) => $name === 'audit')));
     }
@@ -155,8 +143,7 @@ final class DirectivesEndToEndTest extends TestCase
     {
         $schema = $this->buildSchema();
 
-        // Object, input-object and input-field placements land on each element's AST node with their
-        // arguments, even though the SDL printer doesn't render applications.
+        // Applications land on each element's AST node, though the printer omits them.
         $widget = $schema->getType('Widget');
         assert($widget instanceof ObjectType);
         $this->assertSame(['tagged' => ['name' => 'primary']], self::astDirectives($widget->astNode?->directives ?? []));
@@ -174,7 +161,7 @@ final class DirectivesEndToEndTest extends TestCase
     {
         $schema = $this->buildSchema();
 
-        // Exactly one field resolves (and @uppercase still applies to the returned label).
+        // One field resolves; @uppercase still applies to the label.
         $ok = GraphQL::executeQuery($schema, '{ findOneOf(lookup: { sku: "widget-1" }) { label } }')->toArray();
         $this->assertArrayNotHasKey('errors', $ok);
         $this->assertSame('WIDGET-1', $ok['data']['findOneOf']['label']);
@@ -192,7 +179,7 @@ final class DirectivesEndToEndTest extends TestCase
     /**
      * @param iterable<DirectiveNode> $directives
      *
-     * @return array<string, array<string, string>> directive name => [argument name => literal value]
+     * @return array<string, array<string, string>> name => [arg => value]
      */
     private static function astDirectives(iterable $directives): array
     {

--- a/tests/Integration/DirectivesEndToEndTest.php
+++ b/tests/Integration/DirectivesEndToEndTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace TheCodingMachine\GraphQLite\Integration;
 
 use GraphQL\GraphQL;
+use GraphQL\Language\AST\DirectiveNode;
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Introspection;
 use GraphQL\Utils\SchemaPrinter;
@@ -147,5 +149,62 @@ final class DirectivesEndToEndTest extends TestCase
         // survives onto the field's AST node.
         $this->assertContains('uppercase', $names);
         $this->assertSame(2, count(array_filter($names, static fn (string $name) => $name === 'audit')));
+    }
+
+    public function testMetadataDirectivesAttachToTheirElementsAst(): void
+    {
+        $schema = $this->buildSchema();
+
+        // Object, input-object and input-field placements land on each element's AST node with their
+        // arguments, even though the SDL printer doesn't render applications.
+        $widget = $schema->getType('Widget');
+        assert($widget instanceof ObjectType);
+        $this->assertSame(['tagged' => ['name' => 'primary']], self::astDirectives($widget->astNode?->directives ?? []));
+
+        $lookup = $schema->getType('WidgetLookupInput');
+        assert($lookup instanceof InputObjectType);
+        $this->assertSame(['versioned' => ['version' => '2']], self::astDirectives($lookup->astNode?->directives ?? []));
+
+        $sku = $lookup->getField('sku')->astNode;
+        $this->assertNotNull($sku);
+        $this->assertSame(['sanitized' => []], self::astDirectives($sku->directives));
+    }
+
+    public function testOneOfInputEnforcesExactlyOneField(): void
+    {
+        $schema = $this->buildSchema();
+
+        // Exactly one field resolves (and @uppercase still applies to the returned label).
+        $ok = GraphQL::executeQuery($schema, '{ findOneOf(lookup: { sku: "widget-1" }) { label } }')->toArray();
+        $this->assertArrayNotHasKey('errors', $ok);
+        $this->assertSame('WIDGET-1', $ok['data']['findOneOf']['label']);
+
+        // Two fields violates @oneOf.
+        $both = GraphQL::executeQuery($schema, '{ findOneOf(lookup: { sku: "a", id: 1 }) { label } }')->toArray();
+        $this->assertArrayHasKey('errors', $both);
+        $this->assertStringContainsString('exactly one field', $both['errors'][0]['message']);
+
+        // Zero fields also violates @oneOf.
+        $none = GraphQL::executeQuery($schema, '{ findOneOf(lookup: {}) { label } }')->toArray();
+        $this->assertArrayHasKey('errors', $none);
+    }
+
+    /**
+     * @param iterable<DirectiveNode> $directives
+     *
+     * @return array<string, array<string, string>> directive name => [argument name => literal value]
+     */
+    private static function astDirectives(iterable $directives): array
+    {
+        $result = [];
+        foreach ($directives as $directive) {
+            $args = [];
+            foreach ($directive->arguments as $argument) {
+                $args[$argument->name->value] = $argument->value->value;
+            }
+            $result[$directive->name->value] = $args;
+        }
+
+        return $result;
     }
 }

--- a/tests/Integration/DirectivesEndToEndTest.php
+++ b/tests/Integration/DirectivesEndToEndTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Integration;
+
+use GraphQL\GraphQL;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Introspection;
+use GraphQL\Utils\SchemaPrinter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
+use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
+use TheCodingMachine\GraphQLite\Schema;
+use TheCodingMachine\GraphQLite\SchemaFactory;
+
+use function array_filter;
+use function assert;
+use function count;
+use function is_array;
+
+/**
+ * End-to-end test for custom directives. Builds a schema from the
+ * `tests/Fixtures/DirectivesIntegration` namespaces and checks that directive definitions show up
+ * in SDL and introspection, and that behavioral directives wrap their resolver at runtime.
+ *
+ * We don't assert directive applications in SDL (e.g. `tagline: String! @uppercase`): webonyx's
+ * SchemaPrinter doesn't render those, and we follow its behavior. The applications are still on each
+ * element's `astNode->directives` for anyone who wants to print them with their own printer.
+ */
+final class DirectivesEndToEndTest extends TestCase
+{
+    private function buildSchema(): Schema
+    {
+        $cache = new Psr16Cache(new ArrayAdapter());
+        $factory = new SchemaFactory($cache, new BasicAutoWiringContainer(new EmptyContainer()));
+        $factory->prodMode();
+        $factory->addNamespace('TheCodingMachine\\GraphQLite\\Fixtures\\DirectivesIntegration');
+
+        return $factory->createSchema();
+    }
+
+    public function testSchemaPrintsDirectiveDefinitions(): void
+    {
+        $schema = $this->buildSchema();
+        $sdl = SchemaPrinter::doPrint($schema);
+
+        // Definitions: the webonyx printer emits these once the directives are registered on the
+        // schema (see SchemaFactory's wiring of DirectiveRegistry::webonyxDirectives()).
+        $this->assertStringContainsString('directive @uppercase on FIELD_DEFINITION', $sdl);
+        $this->assertStringContainsString('Marks a field for audit-log tracking.', $sdl);
+        $this->assertStringContainsString('directive @audit(reason: String!) repeatable on FIELD_DEFINITION', $sdl);
+        $this->assertStringContainsString('directive @tagged(name: String!) on OBJECT', $sdl);
+        $this->assertStringContainsString('directive @sanitized on INPUT_FIELD_DEFINITION', $sdl);
+        $this->assertStringContainsString('Marks an input with a schema version for backwards-compat tracking.', $sdl);
+        $this->assertStringContainsString('directive @versioned(version: Int!) on INPUT_OBJECT', $sdl);
+
+        // No assertions on directive applications here; webonyx's SchemaPrinter doesn't render them.
+        // See the class docblock.
+
+        // @oneOf is webonyx's built-in: it prints the application from the isOneOf flag, and we
+        // don't re-declare it in the custom list.
+        $this->assertStringNotContainsString('directive @oneOf ', $sdl);
+        $this->assertStringContainsString('input OneOfLookupInput @oneOf', $sdl);
+    }
+
+    public function testIntrospectionExposesEveryDirective(): void
+    {
+        $schema = $this->buildSchema();
+
+        $result = GraphQL::executeQuery($schema, Introspection::getIntrospectionQuery())->toArray();
+        $this->assertArrayNotHasKey('errors', $result);
+
+        $directives = $result['data']['__schema']['directives'];
+        assert(is_array($directives));
+
+        $names = [];
+        foreach ($directives as $directive) {
+            $names[] = $directive['name'];
+        }
+
+        // Built-ins remain present alongside custom directives.
+        $this->assertContains('skip', $names);
+        $this->assertContains('include', $names);
+        $this->assertContains('deprecated', $names);
+
+        // Custom directives present.
+        $this->assertContains('uppercase', $names);
+        $this->assertContains('audit', $names);
+        $this->assertContains('tagged', $names);
+        $this->assertContains('versioned', $names);
+        $this->assertContains('sanitized', $names);
+    }
+
+    public function testFieldDirectiveWrapsResolver(): void
+    {
+        $schema = $this->buildSchema();
+
+        $result = GraphQL::executeQuery($schema, '{ tagline }')->toArray();
+        $this->assertArrayNotHasKey('errors', $result);
+        $this->assertSame('HELLO WORLD', $result['data']['tagline']);
+    }
+
+    public function testInputObjectFieldsResolveWithDirectiveAttached(): void
+    {
+        $schema = $this->buildSchema();
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            '{ findWidget(lookup: { sku: "abc" }) { label } }',
+        )->toArray();
+
+        $this->assertArrayNotHasKey('errors', $result);
+        // getLabel() carries @uppercase, so "abc" comes back uppercased.
+        $this->assertSame('ABC', $result['data']['findWidget']['label']);
+    }
+
+    public function testFieldDirectiveUppercasesMixedCaseValue(): void
+    {
+        $schema = $this->buildSchema();
+
+        $result = GraphQL::executeQuery(
+            $schema,
+            '{ findWidget(lookup: { sku: "MixedCase" }) { label } }',
+        )->toArray();
+
+        $this->assertArrayNotHasKey('errors', $result);
+        $this->assertSame('MIXEDCASE', $result['data']['findWidget']['label']);
+    }
+
+    public function testRepeatableDirectiveAttachesOncePerUsageToFieldAst(): void
+    {
+        $widget = $this->buildSchema()->getType('Widget');
+        assert($widget instanceof ObjectType);
+
+        $astNode = $widget->getField('label')->astNode;
+        $this->assertNotNull($astNode);
+
+        $names = [];
+        foreach ($astNode->directives as $directive) {
+            $names[] = $directive->name->value;
+        }
+
+        // getLabel() carries @uppercase once and the repeatable @audit twice; every application
+        // survives onto the field's AST node.
+        $this->assertContains('uppercase', $names);
+        $this->assertSame(2, count(array_filter($names, static fn (string $name) => $name === 'audit')));
+    }
+}


### PR DESCRIPTION
# Description

As discussed in #807, the library can support custom defined directives as well. This PR addresses that concern by adding:
  - Discovery — DirectiveClassFinder scans the registered namespaces for classes implementing TypeSystemDirective (cached like ClassFinderTypeMapper). No new configuration: a directive class in a namespace you already addNamespace() is picked up automatically.                                               
  - Registration & validation — DirectiveRegistry now discovers user directives alongside the built-ins (`@oneOf`, `@deprecated`), validating each at discovery time and enforcing unique names.                                                                                                                       
  - Validation split into focused units: AttributeTargetValidator (the #[Attribute(...)] targets cover the declared GraphQL locations) and InterfaceLocationValidator (family interface ⇄ location agreement).                                                                                                     
  - Wiring — SchemaFactory injects the class finder into the registry; behavioral directives wrap their resolver at runtime, metadata directives land on each element's astNode->directives.  


## Directive definition
Defining a directive

```php
#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
final class UppercaseDirective implements BehavioralFieldDirective
{
    public static function definition(): DirectiveDefinition
    {
        return new DirectiveDefinition(name: 'uppercase', locations: [DirectiveLocation::FIELD_DEFINITION]);
    }

    public function applyToField(QueryFieldDescriptor $descriptor, FieldHandlerInterface $next): FieldDefinition|null
    { /* wrap the resolver */ }
```

## Name reservation
- `@oneOf` / `@deprecated` (names we bind): reserved for custom use unless the directive declares builtIn: true to intentionally override the bundled binding.
- `@skip` / `@include` / `@specifiedBy` (webonyx directives we don't bind): hard-reserved — sourced from Directive::*_NAME constants — so a custom directive can't collide with them at schema build.