### PR TITLE
fix: Undefined array input type

### DIFF
--- a/src/Mappers/Parameters/TypeHandler.php
+++ b/src/Mappers/Parameters/TypeHandler.php
@@ -38,6 +38,7 @@ use TheCodingMachine\GraphQLite\Annotations\UseInputType;
 use TheCodingMachine\GraphQLite\InvalidDocBlockRuntimeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeExceptionInterface;
+use TheCodingMachine\GraphQLite\Mappers\Root\NullableTypeMapperAdapter;
 use TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface;
 use TheCodingMachine\GraphQLite\Mappers\Root\UndefinedTypeMapper;
 use TheCodingMachine\GraphQLite\Parameters\DefaultValueParameter;
@@ -408,6 +409,12 @@ class TypeHandler implements ParameterHandlerInterface
             $type = new Nullable($type);
         }
         $innerType = $type instanceof Nullable ? $type->getActualType() : $type;
+
+        if ($innerType instanceof Compound && UndefinedTypeMapper::containsUndefined($innerType)) {
+            $innerType = NullableTypeMapperAdapter::getNonNullableType(
+                UndefinedTypeMapper::replaceUndefinedWith($innerType),
+            ) ?? $innerType;
+        }
 
         if (
             $innerType instanceof Array_

--- a/src/Mappers/Root/NullableTypeMapperAdapter.php
+++ b/src/Mappers/Root/NullableTypeMapperAdapter.php
@@ -43,7 +43,7 @@ class NullableTypeMapperAdapter implements RootTypeMapperInterface
         $isNullable = $this->isNullable($type);
 
         if ($isNullable) {
-            $nonNullableType = $this->getNonNullable($type);
+            $nonNullableType = self::getNonNullableType($type);
             if ($nonNullableType === null) {
                 throw CannotMapTypeException::createForNull();
             }
@@ -69,7 +69,7 @@ class NullableTypeMapperAdapter implements RootTypeMapperInterface
         $isNullable = $this->isNullable($type);
 
         if ($isNullable) {
-            $nonNullableType = $this->getNonNullable($type);
+            $nonNullableType = self::getNonNullableType($type);
             if ($nonNullableType === null) {
                 throw CannotMapTypeException::createForNull();
             }
@@ -119,16 +119,21 @@ class NullableTypeMapperAdapter implements RootTypeMapperInterface
         return false;
     }
 
-    private function getNonNullable(Type $type): Type|null
+    /**
+     * Reduces a type to its non-nullable form: strips `Nullable`/`Null_` wrappers and, for a Compound,
+     * drops every null member. Returns the single remaining type, a Compound of the survivors when more
+     * than one remains, or null when the type was purely null.
+     */
+    public static function getNonNullableType(Type $type): Type|null
     {
         if ($type instanceof Null_) {
             return null;
         }
         if ($type instanceof Nullable) {
-            return $this->getNonNullable($type->getActualType());
+            return self::getNonNullableType($type->getActualType());
         }
         if ($type instanceof Compound) {
-            $types = array_map([$this, 'getNonNullable'], iterator_to_array($type));
+            $types = array_map([self::class, 'getNonNullableType'], iterator_to_array($type));
             // Remove null values
             $types = array_values(array_filter($types));
             if (count($types) > 1) {

--- a/tests/Fixtures/Integration/Controllers/ArticleController.php
+++ b/tests/Fixtures/Integration/Controllers/ArticleController.php
@@ -34,6 +34,7 @@ class ArticleController
     {
         $article = new Article('test');
         $article->magazine = 'The New Yorker';
+        $article->tags = ['tech', 'news'];
 
         $article->summary = $input->summary;
 

--- a/tests/Fixtures/Integration/Controllers/ArticleController.php
+++ b/tests/Fixtures/Integration/Controllers/ArticleController.php
@@ -41,6 +41,10 @@ class ArticleController
             $article->magazine = $input->magazine;
         }
 
+        if ($input->tags !== Undefined::VALUE) {
+            $article->tags = $input->tags;
+        }
+
         return $article;
     }
 }

--- a/tests/Fixtures/Integration/Models/Article.php
+++ b/tests/Fixtures/Integration/Models/Article.php
@@ -19,6 +19,10 @@ class Article extends Post
     #[Field]
     public ?string $magazine = null;
 
+    /** @var list<string>|null */
+    #[Field]
+    public ?array $tags = null;
+
     #[Field(for: 'Article')]
     public function localizedTitle(string|null|Undefined $locale): string
     {

--- a/tests/Fixtures/Integration/Models/UpdateArticleInput.php
+++ b/tests/Fixtures/Integration/Models/UpdateArticleInput.php
@@ -10,12 +10,15 @@ use TheCodingMachine\GraphQLite\Undefined;
 #[Input]
 class UpdateArticleInput
 {
+    /** @param list<string>|null $tags */
     public function __construct(
         #[Field]
         #[Security("magazine != 'NYTimes'")]
         public readonly string|null|Undefined $magazine = Undefined::VALUE,
         #[Field]
         public readonly string $summary = 'default',
+        #[Field]
+        public readonly array|null|Undefined $tags = Undefined::VALUE,
     )
     {
     }

--- a/tests/Fixtures/Integration/Models/UpdateArticleInput.php
+++ b/tests/Fixtures/Integration/Models/UpdateArticleInput.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TheCodingMachine\GraphQLite\Fixtures\Integration\Models;
 
 use TheCodingMachine\GraphQLite\Annotations\Field;
@@ -10,15 +12,15 @@ use TheCodingMachine\GraphQLite\Undefined;
 #[Input]
 class UpdateArticleInput
 {
-    /** @param list<string>|null $tags */
+    /** @param list<string>|Undefined|null $tags */
     public function __construct(
         #[Field]
         #[Security("magazine != 'NYTimes'")]
-        public readonly string|null|Undefined $magazine = Undefined::VALUE,
+        public readonly string|Undefined|null $magazine = Undefined::VALUE,
         #[Field]
         public readonly string $summary = 'default',
         #[Field]
-        public readonly array|null|Undefined $tags = Undefined::VALUE,
+        public readonly array|Undefined|null $tags = Undefined::VALUE,
     )
     {
     }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -2015,6 +2015,34 @@ class EndToEndTest extends IntegrationTestCase
         $this->assertSame('test', $data['updateArticle']['localizedTitle']);
     }
 
+    public function testEndToEndInputUndefinedListValue(): void
+    {
+        $schema = $this->mainContainer->get(Schema::class);
+        assert($schema instanceof Schema);
+
+        // A provided list round-trips.
+        $result = GraphQL::executeQuery($schema, '
+        mutation {
+            updateArticle(input: { tags: ["news", "tech"] }) {
+                tags
+            }
+        }
+        ');
+        $data = $this->getSuccessResult($result);
+        $this->assertSame(['news', 'tech'], $data['updateArticle']['tags']);
+
+        // An omitted list is Undefined, so the controller leaves it untouched.
+        $result = GraphQL::executeQuery($schema, '
+        mutation {
+            updateArticle(input: { magazine: "The Verge" }) {
+                tags
+            }
+        }
+        ');
+        $data = $this->getSuccessResult($result);
+        $this->assertNull($data['updateArticle']['tags']);
+    }
+
     public function testEndToEndSchemaIsPrintable(): void
     {
         $this->expectNotToPerformAssertions();

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -2031,10 +2031,21 @@ class EndToEndTest extends IntegrationTestCase
         $data = $this->getSuccessResult($result);
         $this->assertSame(['news', 'tech'], $data['updateArticle']['tags']);
 
-        // An omitted list is Undefined, so the controller leaves it untouched.
+        // An omitted list is Undefined, so the controller leaves the default untouched.
         $result = GraphQL::executeQuery($schema, '
         mutation {
             updateArticle(input: { magazine: "The Verge" }) {
+                tags
+            }
+        }
+        ');
+        $data = $this->getSuccessResult($result);
+        $this->assertSame(['tech', 'news'], $data['updateArticle']['tags']);
+
+        // An explicit null nullifies the default, proving null is distinct from Undefined.
+        $result = GraphQL::executeQuery($schema, '
+        mutation {
+            updateArticle(input: { tags: null }) {
                 tags
             }
         }

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -2031,27 +2031,21 @@ class EndToEndTest extends IntegrationTestCase
         $data = $this->getSuccessResult($result);
         $this->assertSame(['news', 'tech'], $data['updateArticle']['tags']);
 
-        // An omitted list is Undefined, so the controller leaves the default untouched.
+        // Same seeded default (['tech', 'news']), two inputs in one operation: omitting tags leaves it
+        // untouched, while an explicit null nullifies it.
         $result = GraphQL::executeQuery($schema, '
         mutation {
-            updateArticle(input: { magazine: "The Verge" }) {
+            untouched: updateArticle(input: { magazine: "The Verge" }) {
+                tags
+            }
+            nullified: updateArticle(input: { tags: null }) {
                 tags
             }
         }
         ');
         $data = $this->getSuccessResult($result);
-        $this->assertSame(['tech', 'news'], $data['updateArticle']['tags']);
-
-        // An explicit null nullifies the default, proving null is distinct from Undefined.
-        $result = GraphQL::executeQuery($schema, '
-        mutation {
-            updateArticle(input: { tags: null }) {
-                tags
-            }
-        }
-        ');
-        $data = $this->getSuccessResult($result);
-        $this->assertNull($data['updateArticle']['tags']);
+        $this->assertSame(['tech', 'news'], $data['untouched']['tags']);
+        $this->assertNull($data['nullified']['tags']);
     }
 
     public function testEndToEndSchemaIsPrintable(): void

--- a/tests/Mappers/Parameters/TypeMapperTest.php
+++ b/tests/Mappers/Parameters/TypeMapperTest.php
@@ -16,10 +16,11 @@ use TheCodingMachine\GraphQLite\Fixtures\UnionOutputType;
 use TheCodingMachine\GraphQLite\Mappers\CannotMapTypeException;
 use TheCodingMachine\GraphQLite\Parameters\DefaultValueParameter;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeParameter;
-use TheCodingMachine\GraphQLite\Reflection\DocBlock\CachedDocBlockFactory;
+use TheCodingMachine\GraphQLite\Undefined;
 
 use function assert;
 use function count;
+use function reset;
 
 class TypeMapperTest extends AbstractQueryProvider
 {
@@ -92,6 +93,36 @@ class TypeMapperTest extends AbstractQueryProvider
         $this->assertEquals('TestObject2', $unionTypes[1]->name);
     }
 
+    public function testMapUndefinedListParameterDoesNotCreateForbiddenUnion(): void
+    {
+        $docBlockFactory = $this->getDocBlockFactory();
+
+        $typeMapper = new TypeHandler(
+            $this->getArgumentResolver(),
+            $this->getRootTypeMapper(),
+            $this->getTypeResolver(),
+            $docBlockFactory,
+        );
+
+        $refMethod = new ReflectionMethod($this, 'withUndefinedList');
+        $refParameter = $refMethod->getParameters()[0];
+        $docBlockObj = $docBlockFactory->create($refMethod);
+        $paramTags = $docBlockObj->getTagsByName('param');
+        $paramTagType = reset($paramTags)->getType();
+        $annotations = $this->getAnnotationReader()->getParameterAnnotationsPerParameter([$refParameter])['foo'];
+
+        $parameter = $typeMapper->mapParameter($refParameter, $docBlockObj, $paramTagType, $annotations);
+
+        $this->assertInstanceOf(InputTypeParameter::class, $parameter);
+        assert($parameter instanceof InputTypeParameter);
+        // The reflection `array` and the phpdoc `list<string>` must resolve to a single `[String!]`,
+        // not an illegal `array | list<string>` input union once `Undefined` is in the type.
+        $this->assertSame('[String!]', $parameter->getType()->toString());
+        // The `Undefined` default is the "optional field" marker: GraphQL prints no default for it.
+        $this->assertFalse($parameter->hasDefaultValue());
+        $this->assertNull($parameter->getDefaultValue());
+    }
+
     public function testHideParameter(): void
     {
         $docBlockFactory = $this->getDocBlockFactory();
@@ -160,6 +191,11 @@ class TypeMapperTest extends AbstractQueryProvider
     }
 
     private function dummy(): int|string
+    {
+    }
+
+    /** @param list<string>|null $foo */
+    private function withUndefinedList(array|Undefined|null $foo = Undefined::VALUE): void
     {
     }
 


### PR DESCRIPTION
# Description 

  Optional-via-`Undefined` works for scalars but explodes on lists:
                                                                                                                                                                                                                                                                                                                            
  ```php                                                                                                                                                                                                                                                                                                                    
  /** @param list<string>|Undefined|null $ids */
  public readonly array|Undefined|null $ids = Undefined::VALUE,
  // CannotMapTypeException: type-hinted to "array|list<string>" ... forbidden
```
  
Fix: drop Undefined and take the non-null core before the container check, reusing existing helpers (UndefinedTypeMapper + a now-public static getNonNullableType).

Covers array/list. Native iterable isn't handled (PHP expands it to array|Traversable) and since it's rare for an input, I left it alone