### PR TITLE
feat!: make #[EnumValue] control per-case enum schema exposure

### DIFF
--- a/src/Mappers/Root/EnumTypeMapper.php
+++ b/src/Mappers/Root/EnumTypeMapper.php
@@ -21,6 +21,7 @@ use TheCodingMachine\GraphQLite\Discovery\Cache\ClassFinderComputedCache;
 use TheCodingMachine\GraphQLite\Discovery\ClassFinder;
 use TheCodingMachine\GraphQLite\Reflection\DocBlock\DocBlockFactory;
 use TheCodingMachine\GraphQLite\Types\EnumType;
+use TheCodingMachine\GraphQLite\Types\ExposedEnumCase;
 use TheCodingMachine\GraphQLite\Utils\DescriptionResolver;
 use UnitEnum;
 
@@ -138,64 +139,73 @@ class EnumTypeMapper implements RootTypeMapperInterface
                 : null,
         );
 
-        /** @var array<string, string|null> $enumCaseDescriptions */
-        $enumCaseDescriptions = [];
-        /** @var array<string, string> $enumCaseDeprecationReasons */
-        $enumCaseDeprecationReasons = [];
-        $hasEnumValueAttribute = false;
+        // Single pass: build an ExposedEnumCase for every case, resolving its metadata, and bucket
+        // it by whether it carries #[EnumValue]. The moment any case is annotated the enum is in
+        // opt-in mode and only the annotated bucket is exposed; otherwise every case is exposed.
+        /** @var list<ExposedEnumCase> $annotatedCases */
+        $annotatedCases = [];
+        /** @var list<ExposedEnumCase> $unannotatedCases */
+        $unannotatedCases = [];
 
         foreach ($reflectionEnum->getCases() as $reflectionEnumCase) {
+            $attribute = $this->annotationReader->getEnumValueAnnotation($reflectionEnumCase);
             $docBlock = $this->docBlockFactory->create($reflectionEnumCase);
-            $enumValueAttribute = $this->annotationReader->getEnumValueAnnotation($reflectionEnumCase);
 
-            if ($enumValueAttribute !== null) {
-                $hasEnumValueAttribute = true;
-            }
-
-            $enumCaseDescriptions[$reflectionEnumCase->getName()] = $this->descriptionResolver->resolve(
-                $enumValueAttribute?->description,
+            $description = $this->descriptionResolver->resolve(
+                $attribute?->description,
                 $docBlock->getSummary() ?: null,
             );
 
-            $explicitDeprecation = $enumValueAttribute?->deprecationReason;
+            $deprecationReason = null;
+            $explicitDeprecation = $attribute?->deprecationReason;
             if ($explicitDeprecation !== null) {
                 // Explicit `deprecationReason` always wins; an empty string deliberately clears
                 // any @deprecated tag on the case docblock the same way an empty description
                 // blocks the docblock fallback.
                 if ($explicitDeprecation !== '') {
-                    $enumCaseDeprecationReasons[$reflectionEnumCase->getName()] = $explicitDeprecation;
+                    $deprecationReason = $explicitDeprecation;
                 }
-                continue;
+            } else {
+                $deprecation = $docBlock->getTagsByName('deprecated')[0] ?? null;
+                if ($deprecation) {
+                    $deprecationReason = (string) $deprecation;
+                }
             }
 
-            $deprecation = $docBlock->getTagsByName('deprecated')[0] ?? null;
+            $exposedCase = new ExposedEnumCase($reflectionEnumCase->getValue(), $description, $deprecationReason);
 
-            // phpcs:ignore
-            if ($deprecation) {
-                $enumCaseDeprecationReasons[$reflectionEnumCase->getName()] = (string) $deprecation;
+            if ($attribute !== null) {
+                $annotatedCases[] = $exposedCase;
+            } else {
+                $unannotatedCases[] = $exposedCase;
             }
         }
 
-        if (! $hasEnumValueAttribute) {
+        $exposedCases = $annotatedCases !== [] ? $annotatedCases : $unannotatedCases;
+
+        if ($annotatedCases === []) {
             $this->warnEnumHasNoEnumValueAttribute($enumClass);
         }
 
-        $type = new EnumType($enumClass, $typeName, $enumDescription, $enumCaseDescriptions, $enumCaseDeprecationReasons, $useValues);
+        $type = new EnumType($exposedCases, $typeName, $enumDescription, $useValues);
 
         return $this->cacheByName[$type->name] = $this->cacheByClass[$enumClass] = $type;
     }
 
     /**
      * Emits a deprecation notice when a GraphQL-mapped enum declares zero {@see EnumValue}
-     * attributes across its cases — the signal that the developer has not yet engaged with
-     * the opt-in model that a future major release will require.
+     * attributes across its cases — the signal that the developer has not yet engaged with the
+     * per-case opt-in model.
      *
-     * Today every case is automatically exposed in the schema regardless of `#[EnumValue]` —
-     * this call site keeps that behaviour intact. The notice announces the planned migration:
-     * a future major release will require `#[EnumValue]` on each case that should participate
-     * in the schema, and unannotated cases will be hidden (mirroring `#[Field]`'s opt-in
-     * model on classes). Partial annotation is deliberately allowed and intentionally silent
-     * so that leaving some cases unannotated can be used to hide them once the default flips.
+     * `#[EnumValue]` is now the per-case exposure toggle. As soon as an enum carries the attribute
+     * on at least one case it enters opt-in mode: only the annotated cases are exposed and every
+     * unannotated case is hidden from the schema (mirroring `#[Field]`'s opt-in model on classes).
+     * A fully-unannotated enum stays in legacy mode — every case is still exposed — and this notice
+     * fires to flag that the enum has not opted in, so a future major release that makes the
+     * attribute mandatory would otherwise hide all of its cases.
+     *
+     * Partial annotation is deliberately silent: leaving a case unannotated is now the supported
+     * mechanism for keeping it out of the public schema, so it must not itself produce an advisory.
      *
      * @param class-string<UnitEnum> $enumClass
      */
@@ -204,8 +214,8 @@ class EnumTypeMapper implements RootTypeMapperInterface
         trigger_error(
             sprintf(
                 'Enum "%s" is mapped to a GraphQL enum type but declares no #[EnumValue] attributes on any case. '
-                . 'Today every case is automatically exposed; a future major release will require #[EnumValue] on each case that should participate in the schema, and unannotated cases will be hidden (mirroring #[Field]\'s opt-in model on classes). '
-                . 'Add #[EnumValue] to every case you want to keep exposed. Omit it only from cases you want hidden from the public schema after the future default flip.',
+                . 'Every case is exposed in legacy mode; adding #[EnumValue] to any case switches the enum to opt-in mode, where only annotated cases are exposed and unannotated ones are hidden (mirroring #[Field]\'s opt-in model on classes). '
+                . 'Add #[EnumValue] to every case you want exposed. Omit it only from cases you want hidden from the public schema.',
                 $enumClass,
             ),
             E_USER_DEPRECATED,

--- a/src/Types/EnumType.php
+++ b/src/Types/EnumType.php
@@ -14,30 +14,30 @@ use function is_string;
 
 /**
  * An extension of the EnumType to support native enums.
+ *
+ * @internal The constructor shape (an explicit list of exposed cases with resolved metadata) is a
+ *     framework-internal contract with EnumTypeMapper, not a public API.
  */
 class EnumType extends BaseEnumType
 {
     /**
-     * @param class-string<UnitEnum> $enumName
-     * @param array<string, string|null> $caseDescriptions
-     * @param array<string, string> $caseDeprecationReasons
+     * @param list<ExposedEnumCase> $cases The enum cases that participate in the schema, each
+     *     paired with its resolved metadata.
      */
     public function __construct(
-        string $enumName,
+        array $cases,
         string $typeName,
         string|null $description,
-        array $caseDescriptions,
-        array $caseDeprecationReasons,
         private readonly bool $useValues = false,
     ) {
         $typeValues = [];
-        foreach ($enumName::cases() as $case) {
-            $key = $this->serialize($case);
+        foreach ($cases as $exposed) {
+            $key = $this->serialize($exposed->case);
             $typeValues[$key] = [
                 'name' => $key,
-                'value' => $case,
-                'description' => $caseDescriptions[$case->name] ?? null,
-                'deprecationReason' => $caseDeprecationReasons[$case->name] ?? null,
+                'value' => $exposed->case,
+                'description' => $exposed->description,
+                'deprecationReason' => $exposed->deprecationReason,
             ];
         }
 

--- a/src/Types/ExposedEnumCase.php
+++ b/src/Types/ExposedEnumCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Types;
+
+use UnitEnum;
+
+/**
+ * A single enum case exposed in the GraphQL schema, paired with its resolved metadata.
+ *
+ * @internal Built by EnumTypeMapper and consumed by EnumType; not part of the public API.
+ */
+final class ExposedEnumCase
+{
+    public function __construct(
+        public readonly UnitEnum $case,
+        public readonly string|null $description,
+        public readonly string|null $deprecationReason,
+    ) {
+    }
+}

--- a/tests/Fixtures/EnumExposure/EnumExposureController.php
+++ b/tests/Fixtures/EnumExposure/EnumExposureController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\EnumExposure;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+
+class EnumExposureController
+{
+    #[Query]
+    public function publishStatus(): PublishStatus
+    {
+        return PublishStatus::Published;
+    }
+}

--- a/tests/Fixtures/EnumExposure/PublishStatus.php
+++ b/tests/Fixtures/EnumExposure/PublishStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\EnumExposure;
+
+use TheCodingMachine\GraphQLite\Annotations\EnumValue;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * Partially-annotated enum: it carries #[EnumValue] on some cases, which puts it in opt-in mode.
+ * Only the annotated cases must reach the schema; the unannotated internal cases stay hidden.
+ */
+#[Type]
+enum PublishStatus: string
+{
+    #[EnumValue(description: 'Visible to everyone.')]
+    case Published = 'published';
+
+    #[EnumValue]
+    case Scheduled = 'scheduled';
+
+    // Internal-only working state — deliberately left unannotated so it never enters the schema.
+    case Draft = 'draft';
+
+    // Internal-only terminal state — likewise hidden.
+    case Archived = 'archived';
+}

--- a/tests/Fixtures/EnumExposureLegacy/Weekday.php
+++ b/tests/Fixtures/EnumExposureLegacy/Weekday.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\EnumExposureLegacy;
+
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * Fully-unannotated enum: it declares zero #[EnumValue] attributes, so it stays in legacy mode
+ * where every case is exposed and case descriptions still fall back to the docblock summary.
+ */
+#[Type]
+enum Weekday: string
+{
+    /**
+     * The first working day of the week.
+     */
+    case Monday = 'monday';
+    case Tuesday = 'tuesday';
+    case Wednesday = 'wednesday';
+}

--- a/tests/Fixtures/EnumExposureLegacy/WeekdayController.php
+++ b/tests/Fixtures/EnumExposureLegacy/WeekdayController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Fixtures\EnumExposureLegacy;
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+
+class WeekdayController
+{
+    #[Query]
+    public function weekday(): Weekday
+    {
+        return Weekday::Monday;
+    }
+}

--- a/tests/Integration/DescriptionTest.php
+++ b/tests/Integration/DescriptionTest.php
@@ -108,11 +108,11 @@ class DescriptionTest extends TestCase
 
     public function testEnumWithZeroEnumValueAttributesTriggersDeprecation(): void
     {
-        // The Era fixture deliberately declares zero #[EnumValue] attributes — the signal that
-        // the developer has not yet engaged with the opt-in migration. That is the scenario the
+        // The Era fixture deliberately declares zero #[EnumValue] attributes, so it stays in
+        // legacy mode (every case exposed) and the advisory fires. That is the scenario the
         // advisory targets; partial annotation on other enums (like Genre in the Description
-        // namespace) is deliberately silent because it already acknowledges the new model.
-        $this->expectUserDeprecationMessageMatches('/declares no #\[EnumValue\] attributes.*future major/s');
+        // namespace) is deliberately silent because it has already opted in.
+        $this->expectUserDeprecationMessageMatches('/declares no #\[EnumValue\] attributes.*legacy mode/s');
 
         $schema = $this->buildSchema(Era::class);
         // Force enum resolution — types are lazy-mapped until referenced.
@@ -149,18 +149,19 @@ class DescriptionTest extends TestCase
         $this->assertSame([], $captured, 'Partial #[EnumValue] annotation must not trigger the advisory notice.');
     }
 
-    public function testEnumCaseWithoutAttributeFallsBackToDocblock(): void
+    public function testUnannotatedCaseIsHiddenInOptInMode(): void
     {
         $schema = $this->buildSchema(Book::class);
 
         $genreType = $schema->getType('Genre');
-        $nonFictionValue = $genreType->getValue('NonFiction');
-        // The NonFiction case has no #[EnumValue] attribute, so its description comes from the docblock.
-        $this->assertNotNull($nonFictionValue->description);
-        $this->assertStringContainsString(
-            'This docblock description should appear on the NonFiction enum value',
-            $nonFictionValue->description,
-        );
+
+        // Genre carries #[EnumValue] on Fiction and Poetry, which puts it in opt-in mode. The
+        // NonFiction case has no #[EnumValue] attribute, so it is now hidden from the schema
+        // entirely rather than falling back to its docblock description.
+        $this->assertNull($genreType->getValue('NonFiction'));
+
+        $exposedNames = array_map(static fn ($value) => $value->name, $genreType->getValues());
+        $this->assertSame(['Fiction', 'Poetry'], $exposedNames);
     }
 
     public function testEnumValueAttributeProvidesDeprecationReason(): void
@@ -172,20 +173,20 @@ class DescriptionTest extends TestCase
         $this->assertSame('Use Fiction::Verse instead.', $poetryValue->deprecationReason);
     }
 
-    public function testDisablingDocblockFallbackSuppressesEnumCaseDescription(): void
+    public function testDisablingDocblockFallbackKeepsExplicitDescriptionOnExposedCase(): void
     {
         $schema = $this->buildSchema(Book::class, docblockDescriptions: false);
 
         $genreType = $schema->getType('Genre');
 
-        // Fiction has an explicit #[EnumValue] description — still present.
+        // Fiction has an explicit #[EnumValue] description — still present with the toggle off.
         $this->assertSame(
             'Fiction works including novels and short stories.',
             $genreType->getValue('Fiction')->description,
         );
 
-        // NonFiction relied on its docblock summary — with the toggle off, it must disappear.
-        $this->assertNull($genreType->getValue('NonFiction')->description);
+        // NonFiction is unannotated, so opt-in mode hides it regardless of the docblock toggle.
+        $this->assertNull($genreType->getValue('NonFiction'));
     }
 
     public function testExtendTypeSuppliesDescriptionWhenBaseTypeHasNone(): void

--- a/tests/Integration/EnumExposureTest.php
+++ b/tests/Integration/EnumExposureTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\GraphQLite\Integration;
+
+use GraphQL\Type\Definition\EnumType;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use TheCodingMachine\GraphQLite\Containers\BasicAutoWiringContainer;
+use TheCodingMachine\GraphQLite\Containers\EmptyContainer;
+use TheCodingMachine\GraphQLite\Fixtures\EnumExposure\PublishStatus;
+use TheCodingMachine\GraphQLite\Fixtures\EnumExposureLegacy\Weekday;
+use TheCodingMachine\GraphQLite\Schema;
+use TheCodingMachine\GraphQLite\SchemaFactory;
+use TheCodingMachine\GraphQLite\Security\VoidAuthenticationService;
+use TheCodingMachine\GraphQLite\Security\VoidAuthorizationService;
+
+use function array_map;
+
+/**
+ * End-to-end verification of the #[EnumValue] per-case exposure toggle.
+ *
+ * The attribute is the opt-in signal for a case reaching the schema:
+ *   - An enum with a MIX of annotated and unannotated cases is in opt-in mode; only the annotated
+ *     cases are exposed and every unannotated case is hidden from the SDL.
+ *   - A fully-unannotated enum stays in legacy mode; every case is exposed and docblock summaries
+ *     continue to populate case descriptions.
+ */
+class EnumExposureTest extends TestCase
+{
+    /** @param class-string $fixtureClass Any class from the fixture namespace to build over. */
+    private function buildSchema(string $fixtureClass, bool $docblockDescriptions = true): Schema
+    {
+        $factory = new SchemaFactory(
+            new Psr16Cache(new ArrayAdapter()),
+            new BasicAutoWiringContainer(new EmptyContainer()),
+        );
+        $factory->setAuthenticationService(new VoidAuthenticationService());
+        $factory->setAuthorizationService(new VoidAuthorizationService());
+        $factory->addNamespace((new ReflectionClass($fixtureClass))->getNamespaceName());
+        $factory->setDocblockDescriptionsEnabled($docblockDescriptions);
+
+        return $factory->createSchema();
+    }
+
+    public function testMixedEnumExposesOnlyAnnotatedCases(): void
+    {
+        $schema = $this->buildSchema(PublishStatus::class);
+
+        $enum = $schema->getType('PublishStatus');
+        $this->assertInstanceOf(EnumType::class, $enum);
+
+        $exposedNames = array_map(static fn ($value) => $value->name, $enum->getValues());
+        $this->assertSame(['Published', 'Scheduled'], $exposedNames);
+
+        // Annotated cases reach the schema, unannotated internal cases are hidden.
+        $this->assertNotNull($enum->getValue('Published'));
+        $this->assertNotNull($enum->getValue('Scheduled'));
+        $this->assertNull($enum->getValue('Draft'));
+        $this->assertNull($enum->getValue('Archived'));
+
+        // Metadata wiring stays intact for exposed cases.
+        $this->assertSame('Visible to everyone.', $enum->getValue('Published')->description);
+    }
+
+    public function testFullyUnannotatedEnumExposesEveryCase(): void
+    {
+        // A fully-unannotated enum stays in legacy mode; resolving it emits the opt-in advisory.
+        $this->expectUserDeprecationMessageMatches('/declares no #\[EnumValue\] attributes/');
+
+        $schema = $this->buildSchema(Weekday::class);
+
+        $enum = $schema->getType('Weekday');
+        $this->assertInstanceOf(EnumType::class, $enum);
+
+        $exposedNames = array_map(static fn ($value) => $value->name, $enum->getValues());
+        $this->assertSame(['Monday', 'Tuesday', 'Wednesday'], $exposedNames);
+
+        // Docblock fallback still populates case descriptions in legacy mode.
+        $this->assertSame('The first working day of the week.', $enum->getValue('Monday')->description);
+    }
+
+    public function testLegacyEnumStillSuppressesDocblockCaseDescriptionWhenDisabled(): void
+    {
+        // Docblock fallback off: every case is still exposed, but the docblock-derived description
+        // is dropped.
+        $this->expectUserDeprecationMessageMatches('/declares no #\[EnumValue\] attributes/');
+
+        $schema = $this->buildSchema(Weekday::class, docblockDescriptions: false);
+
+        $enum = $schema->getType('Weekday');
+        $this->assertInstanceOf(EnumType::class, $enum);
+
+        $this->assertCount(3, $enum->getValues());
+        $this->assertNull($enum->getValue('Monday')->description);
+    }
+}

--- a/website/docs/CHANGELOG.md
+++ b/website/docs/CHANGELOG.md
@@ -4,6 +4,31 @@ title: Changelog
 sidebar_label: Changelog
 ---
 
+## 8.4.0
+
+### Breaking Changes
+
+- `#[EnumValue]` now controls enum case exposure. Once any case of a `#[Type]`-mapped enum carries
+  `#[EnumValue]`, the enum is in opt-in mode: only annotated cases are exposed and unannotated cases
+  are hidden from the schema (mirroring `#[Field]`'s opt-in model on classes). A fully-unannotated
+  mapped enum still exposes every case and emits a deprecation notice. **Migration**: any enum that
+  intentionally left some cases unannotated (for example, for docblock-only descriptions) must now
+  add `#[EnumValue]` to every case it wants exposed.
+
+### New Features
+
+- `#[EnumValue]` is now the per-case schema-exposure toggle, so internal enum cases can be kept out
+  of the public schema by omitting the attribute.
+  ([#826](https://github.com/thecodingmachine/graphqlite/pull/826))
+- [#822 Accept PHP callables as `#[Security]` rules](https://github.com/thecodingmachine/graphqlite/pull/822)
+  @oojacoboo, alongside the existing expression form, with access to the field context and custom
+  refusal messages.
+
+### Bug Fixes
+
+- [#819 Fix undefined array input type](https://github.com/thecodingmachine/graphqlite/pull/819)
+  @michael-georgiadis
+
 ## >8.0.0
 
 **For all future changelog details, refer to the [Releases](https://github.com/thecodingmachine/graphqlite/releases).

--- a/website/docs/attributes-reference.md
+++ b/website/docs/attributes-reference.md
@@ -59,9 +59,15 @@ name           | *yes*      | string | The GraphQL input type name extended by t
 ## #[EnumValue]
 
 The `#[EnumValue]` attribute attaches GraphQL schema metadata (description, deprecation reason)
-to an individual case of a PHP 8.1+ native enum that is exposed as a GraphQL enum type.
+to an individual case of a PHP 8.1+ native enum, and controls whether that case is exposed as a
+GraphQL enum value.
 
 **Applies on**: cases of an enum annotated (directly or indirectly) with `#[Type]`.
+
+**Schema exposure**: the moment any case of a `#[Type]`-mapped enum carries `#[EnumValue]`, the
+enum is in opt-in mode and only annotated cases are exposed; unannotated cases are hidden. An
+enum with no `#[EnumValue]` on any case stays in legacy mode (every case exposed) and triggers a
+deprecation notice. See [enum value descriptions](descriptions.md#enum-value-descriptions).
 
 Attribute         | Compulsory | Type   | Definition
 ------------------|------------|--------|-----------
@@ -77,6 +83,8 @@ enum Genre: string
 
     #[EnumValue(deprecationReason: 'Use Fiction::Verse instead.')]
     case Poetry = 'poetry';
+
+    case NonFiction = 'non-fiction'; // no #[EnumValue], so it is hidden from the schema
 }
 ```
 

--- a/website/docs/descriptions.md
+++ b/website/docs/descriptions.md
@@ -91,8 +91,9 @@ public function internalOnly(): Foo { /* ... */ }
 
 ## Enum value descriptions
 
-Native PHP 8.1 enums mapped to GraphQL enum types get per-case metadata via the `#[EnumValue]`
-attribute applied to individual cases:
+Native PHP 8.1 enums mapped to GraphQL enum types use the `#[EnumValue]` attribute on individual
+cases both to attach per-case metadata (description, deprecation reason) and to control which
+cases appear in the schema:
 
 ```php
 use TheCodingMachine\GraphQLite\Annotations\EnumValue;
@@ -110,7 +111,7 @@ enum Genre: string
     /**
      * Works grounded in verifiable facts.
      */
-    case NonFiction = 'non-fiction'; // no attribute — description comes from the docblock
+    case NonFiction = 'non-fiction'; // no #[EnumValue], so it is hidden from the schema
 }
 ```
 
@@ -129,16 +130,20 @@ is an enum value.
   Omitting it falls back to the `@deprecated` tag on the case docblock. An explicit empty string
   `''` deliberately clears any inherited `@deprecated` tag.
 
-### Future migration
+### Schema exposure
 
-A future major release will require `#[EnumValue]` on each case that should participate in
-the schema; unannotated cases will be hidden (mirroring `#[Field]`'s opt-in model). Today
-every case is still auto-exposed, so nothing breaks. Add `#[EnumValue]` to every case you
-want to keep exposed — omitting it from a case is the mechanism for hiding internal values
-once the default flips.
+`#[EnumValue]` also controls which cases appear in the schema, following the same opt-in model
+as `#[Field]` on classes:
 
-GraphQLite emits a deprecation notice when a `#[Type]`-mapped enum has **zero**
-`#[EnumValue]` attributes at all (partial annotation is intentional and stays silent).
+- **Opt-in mode**: as soon as **any** case of a `#[Type]`-mapped enum carries `#[EnumValue]`,
+  only the annotated cases are exposed; every case without the attribute is hidden. In the
+  `Genre` example above, `NonFiction` has no `#[EnumValue]`, so it does not appear in the schema.
+- **Legacy mode**: a mapped enum with **zero** `#[EnumValue]` attributes keeps every case
+  exposed, and GraphQLite emits a deprecation notice recommending you annotate the cases you
+  want exposed. (Partial annotation triggers no notice; it is the supported way to hide a case.)
+
+Add `#[EnumValue]` to every case you want in the public schema; omit it only from cases you want
+hidden, such as internal values that should never reach API consumers.
 
 ## Description uniqueness on `#[ExtendType]`
 


### PR DESCRIPTION
Builds on #793 (which added `#[EnumValue]` for per-case metadata). This makes `#[EnumValue]` the schema-exposure toggle for `#[Type]`-mapped enums, mirroring `#[Field]`'s opt-in model on classes.

## Behavior

Once any case of a mapped enum carries `#[EnumValue]`, the enum enters opt-in mode: only annotated cases are exposed, and unannotated cases are hidden from the schema. A fully-unannotated mapped enum stays in legacy mode (every case exposed) and keeps emitting the existing deprecation advisory.

## Implementation

- Adds `Types\ExposedEnumCase` and reshapes `EnumType`'s internal constructor to take the resolved exposed cases the mapper decided, replacing the parallel per-name metadata arrays.
- `EnumTypeMapper` buckets cases in a single pass, preserving deprecation precedence (explicit `#[EnumValue(deprecationReason:)]` wins, an empty string clears, otherwise the `@deprecated` docblock is honored).

## Breaking change

Partially-annotated `#[Type]` enums now hide their unannotated cases from the schema. Annotate every case you want exposed.

Docs updated (`attributes-reference`, `descriptions`); tests added (`EnumExposureTest` + fixtures, covering opt-in, legacy, and mixed enums).